### PR TITLE
ci: Add GH workflow to validate PR titles follow Conventional Commits.

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -18,5 +18,6 @@ jobs:
   conventional-commits:
     runs-on: "ubuntu-latest"
     steps:
-      - name: "semantic-pull-request"
-        uses: "amannn/action-semantic-pull-request@v5.5.3"
+      - uses: "amannn/action-semantic-pull-request@v5.5.3"
+        env:
+          GITHUB_TOKEN: "${{secrets.GITHUB_TOKEN}}"

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -1,0 +1,22 @@
+name: "pr-title"
+
+on:
+  pull_request_target:
+    types: ["edited", "opened", "reopened"]
+    branches: ["main"]
+
+permissions:
+  pull-requests: "read"
+
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+
+  # Cancel in-progress jobs for efficiency
+  cancel-in-progress: true
+
+jobs:
+  conventional-commits:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "semantic-pull-request"
+        uses: "amannn/action-semantic-pull-request@v5.5.3"

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -18,6 +18,6 @@ jobs:
   conventional-commits:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "amannn/action-semantic-pull-request@v5.5.3"
+      - uses: "amannn/action-semantic-pull-request@v5"
         env:
           GITHUB_TOKEN: "${{secrets.GITHUB_TOKEN}}"


### PR DESCRIPTION
# Description

[Convention Commits](https://www.conventionalcommits.org) is a specification for writing commit messages (or in our case, PR titles) that makes it easy to see at a glance what change the commit makes which in turn makes it easier to generate release notes.

This PR adds a workflow to check PR titles match the spec.

# Validation performed

* Merged this PR into my fork.
* Created a PR to kirkrodrigues/main, triggering the workflow.
* Validated that changing the PR title triggered the workflow.
* Validated that the workflow detected invalid PR titles (e.g., starting with a capital letter, using an unknown type, etc.).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new GitHub Actions workflow for managing pull request titles, enhancing commit message standards.

- **Chores**
	- Configured concurrency settings for improved job efficiency within the workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->