### PR TITLE
chore: Add boilerplate CMake project and Taskfile tasks to lint CMake files.

### DIFF
--- a/.gersemirc
+++ b/.gersemirc
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/BlankSpruce/gersemi/master/gersemi/configuration.schema.json
+
+line_length: 100
+list_expansion: "favour-expansion"

--- a/.gersemirc
+++ b/.gersemirc
@@ -1,3 +1,4 @@
+# yamllint disable-line rule:line-length
 # yaml-language-server: $schema=https://raw.githubusercontent.com/BlankSpruce/gersemi/master/gersemi/configuration.schema.json
 
 line_length: 100

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,4 +31,8 @@ endif()
 
 add_executable(spider)
 target_compile_features(spider PRIVATE cxx_std_20)
-target_sources(spider PRIVATE src/spider/spider.cpp)
+
+set(SPIDER_SOURCES src/spider/spider.cpp)
+target_sources(spider PRIVATE ${SPIDER_SOURCES})
+
+target_include_directories(spider PRIVATE src/)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,34 @@
+# CMake 3.22.1 is the default on Ubuntu 22.04
+cmake_minimum_required(VERSION 3.22.1)
+
+project(
+    spider
+    LANGUAGES
+        C
+        CXX
+    VERSION 0.1.0
+)
+
+# Enable exporting compile commands
+set(CMAKE_EXPORT_COMPILE_COMMANDS
+    ON
+    CACHE BOOL
+    "Enable/Disable output of compile commands during generation."
+    FORCE
+)
+
+# Set the default build type to Release if not specified
+if(NOT CMAKE_BUILD_TYPE)
+    set(SPIDER_DEFAULT_BUILD_TYPE "Release")
+    message(STATUS "No build type specified. Setting to '${SPIDER_DEFAULT_BUILD_TYPE}'.")
+    set(CMAKE_BUILD_TYPE
+        "${SPIDER_DEFAULT_BUILD_TYPE}"
+        CACHE STRING
+        "Choose the type of build."
+        FORCE
+    )
+endif()
+
+add_executable(spider)
+target_compile_features(spider PRIVATE cxx_std_20)
+target_sources(spider PRIVATE src/spider/spider.cpp)

--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ The commands above run all linting checks, but for performance you may want to r
 if you only changed C++ files, you don't need to run the YAML linting checks) using one of the tasks
 in the table below.
 
-| Task                    | Description                                              |
-|-------------------------|----------------------------------------------------------|
-| `lint:yml-check`        | Runs the YAML linters.                                   |
-| `lint:yml-fix`          | Runs the YAML linters and fixes some violations.         |
+| Task               | Description                                      |
+|--------------------|--------------------------------------------------|
+| `lint:cmake-check` | Runs the CMake linters.                          |
+| `lint:cmake-fix`   | Runs the CMake linters and fixes any violations. |
+| `lint:yml-check`   | Runs the YAML linters.                           |
+| `lint:yml-fix`     | Runs the YAML linters and fixes some violations. |
 
 [Task]: https://taskfile.dev

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,1 +1,2 @@
+gersemi>=0.16.2
 yamllint>=1.35.1

--- a/lint-tasks.yaml
+++ b/lint-tasks.yaml
@@ -49,3 +49,26 @@ tasks:
         vars:
           DATA_DIR: "{{.OUTPUT_DIR}}"
           OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
+
+  cmake-check:
+    deps: ["venv"]
+    cmds:
+      - task: "cmake"
+        vars:
+          FLAGS: "--check"
+
+  cmake-fix:
+    deps: ["venv"]
+    cmds:
+      - task: "cmake"
+        vars:
+          FLAGS: "--in-place"
+
+  cmake:
+    internal: true
+    requires:
+      vars: ["FLAGS"]
+    cmd: |-
+      . "{{.G_LINT_VENV_DIR}}/bin/activate"
+      find . -name CMakeLists.txt -print0 \
+        | xargs -0 gersemi {{.FLAGS}} --line-length 100 --list-expansion favour-expansion

--- a/lint-tasks.yaml
+++ b/lint-tasks.yaml
@@ -44,7 +44,11 @@ tasks:
       vars: ["FLAGS"]
     cmd: |-
       . "{{.G_LINT_VENV_DIR}}/bin/activate"
-      find . -name CMakeLists.txt -print0 | xargs -0 gersemi {{.FLAGS}}
+      find . \
+        -path ./build -prune \
+        -o -name CMakeLists.txt \
+        -print0 | \
+          xargs -0 --no-run-if-empty gersemi {{.FLAGS}}
 
   venv:
     internal: true

--- a/lint-tasks.yaml
+++ b/lint-tasks.yaml
@@ -6,11 +6,27 @@ vars:
 tasks:
   check:
     cmds:
+      - task: "cmake-check"
       - task: "yml-check"
 
   fix:
     cmds:
+      - task: "cmake-fix"
       - task: "yml-fix"
+
+  cmake-check:
+    deps: ["venv"]
+    cmds:
+      - task: "cmake"
+        vars:
+          FLAGS: "--check"
+
+  cmake-fix:
+    deps: ["venv"]
+    cmds:
+      - task: "cmake"
+        vars:
+          FLAGS: "--in-place"
 
   yml:
     aliases:
@@ -21,6 +37,14 @@ tasks:
       - |-
         . "{{.G_LINT_VENV_DIR}}/bin/activate"
         yamllint --strict .
+
+  cmake:
+    internal: true
+    requires:
+      vars: ["FLAGS"]
+    cmd: |-
+      . "{{.G_LINT_VENV_DIR}}/bin/activate"
+      find . -name CMakeLists.txt -print0 | xargs -0 gersemi {{.FLAGS}}
 
   venv:
     internal: true
@@ -49,25 +73,3 @@ tasks:
         vars:
           DATA_DIR: "{{.OUTPUT_DIR}}"
           OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
-
-  cmake-check:
-    deps: ["venv"]
-    cmds:
-      - task: "cmake"
-        vars:
-          FLAGS: "--check"
-
-  cmake-fix:
-    deps: ["venv"]
-    cmds:
-      - task: "cmake"
-        vars:
-          FLAGS: "--in-place"
-
-  cmake:
-    internal: true
-    requires:
-      vars: ["FLAGS"]
-    cmd: |-
-      . "{{.G_LINT_VENV_DIR}}/bin/activate"
-      find . -name CMakeLists.txt -print0 | xargs -0 gersemi {{.FLAGS}}

--- a/lint-tasks.yaml
+++ b/lint-tasks.yaml
@@ -70,5 +70,4 @@ tasks:
       vars: ["FLAGS"]
     cmd: |-
       . "{{.G_LINT_VENV_DIR}}/bin/activate"
-      find . -name CMakeLists.txt -print0 \
-        | xargs -0 gersemi {{.FLAGS}} --line-length 100 --list-expansion favour-expansion
+      find . -name CMakeLists.txt -print0 | xargs -0 gersemi {{.FLAGS}}

--- a/lint-tasks.yaml
+++ b/lint-tasks.yaml
@@ -56,6 +56,7 @@ tasks:
       - "{{.TASKFILE}}"
       - "lint-requirements.txt"
     generates: ["{{.CHECKSUM_FILE}}"]
+    run: "once"
     deps:
       - ":init"
       - task: ":utils:validate-checksum"

--- a/src/spider/spider.cpp
+++ b/src/spider/spider.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+    std::cout << "Hello, world!" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

* Adds the `lint:cmake-check` and `lint:cmake-fix` tasks for formatting `CMakeLists.txt` files.
* Adds a boilerplate CMake project that we can use to validate the new tasks.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->

* Added extra indentation in CMakeLists.txt
* `task lint:cmake-check` detected it.
* `task lint:check` detected it.
* `task lint:cmake-fix` fixed it.
* Added an extra newline in CMakeLists.txt
* `task lint:fix` fixed it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new configuration file for YAML linting with customizable settings.
	- Added a build configuration for the project "spider" with CMake, including a default executable.
	- New CMake linting tasks added to streamline development processes.

- **Documentation**
	- Updated README to include new CMake linting tasks.

- **Dependencies**
	- Added a new dependency on `gersemi` for enhanced linting capabilities.

- **Code**
	- Introduced a simple C++ program that outputs "Hello, world!" to the console.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->