### PR TITLE
chore: Select YAML files for linting using an include rather than exclude list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Initialize and update submodules:
 git submodule update --init --recursive
 ```
 
+## Adding files
+Certain file types need to be added to our linting rules manually:
+
+* **YAML**. If adding a YAML file (regardless of its extension), add it as an argument to the
+  `yamllint` command in [lint-tasks.yaml](lint-tasks.yaml).
+
 ## Linting
 Before submitting a pull request, ensure you’ve run the linting commands below and either fixed any
 violations or suppressed the warning.

--- a/lint-tasks.yaml
+++ b/lint-tasks.yaml
@@ -36,7 +36,14 @@ tasks:
     cmds:
       - |-
         . "{{.G_LINT_VENV_DIR}}/bin/activate"
-        yamllint --strict .
+        yamllint \
+          --config-file "tools/yscope-dev-utils/lint-configs/.yamllint.yml" \
+          --strict \
+          .gersemirc \
+          .github/ \
+          .yamllint.yaml \
+          lint-tasks.yaml \
+          taskfile.yaml
 
   cmake:
     internal: true


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

There are usually more YAML files to exclude (e.g., those in the generated files for a CMake build) than include in a repo, so it's better to select the YAML files to lint using an include list.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->

* Workflow succeeded.
* Added a lint violation in a YAML file.
* Validated `task lint:check` detected it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Enhanced the YAML linting command for improved functionality and specificity.
	- Added a new section in the README.md to guide contributors on incorporating files into the project's linting rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->