### PR TITLE
chore: Add Taskfile tasks to lint C++ files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,9 @@
 .task
 build
 
+# Generated lint configs
+.clang-format
+.clang-tidy
+
 # IDE-related directories and files
 .idea

--- a/README.md
+++ b/README.md
@@ -36,11 +36,17 @@ The commands above run all linting checks, but for performance you may want to r
 if you only changed C++ files, you don't need to run the YAML linting checks) using one of the tasks
 in the table below.
 
-| Task               | Description                                      |
-|--------------------|--------------------------------------------------|
-| `lint:cmake-check` | Runs the CMake linters.                          |
-| `lint:cmake-fix`   | Runs the CMake linters and fixes any violations. |
-| `lint:yml-check`   | Runs the YAML linters.                           |
-| `lint:yml-fix`     | Runs the YAML linters and fixes some violations. |
+| Task                    | Description                                              |
+|-------------------------|----------------------------------------------------------|
+| `lint:cmake-check`      | Runs the CMake linters.                                  |
+| `lint:cmake-fix`        | Runs the CMake linters and fixes any violations.         |
+| `lint:cpp-check`        | Runs the C++ linters (formatters and static analyzers).  |
+| `lint:cpp-fix`          | Runs the C++ linters and fixes some violations.          |
+| `lint:cpp-format-check` | Runs the C++ formatters.                                 |
+| `lint:cpp-format-fix`   | Runs the C++ formatters and fixes some violations.       |
+| `lint:cpp-static-check` | Runs the C++ static analyzers.                           |
+| `lint:cpp-static-fix`   | Runs the C++ static analyzers and fixes some violations. |
+| `lint:yml-check`        | Runs the YAML linters.                                   |
+| `lint:yml-fix`          | Runs the YAML linters and fixes some violations.         |
 
 [Task]: https://taskfile.dev

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Initialize and update submodules:
 git submodule update --init --recursive
 ```
 
+Set up the config files for our C++ linting tools:
+```shell
+task lint:cpp-configs
+```
+
 ## Adding files
 Certain file types need to be added to our linting rules manually:
 

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,2 +1,5 @@
+# Lock to v18.x until we can upgrade our code to meet v19's formatting standards.
+clang-format~=18.1
+clang-tidy>=19.1.0
 gersemi>=0.16.2
 yamllint>=1.35.1

--- a/lint-tasks.yaml
+++ b/lint-tasks.yaml
@@ -2,16 +2,19 @@ version: "3"
 
 vars:
   G_LINT_VENV_DIR: "{{.G_BUILD_DIR}}/lint-venv"
+  G_LINT_VENV_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/lint#venv.md5"
 
 tasks:
   check:
     cmds:
       - task: "cmake-check"
+      - task: "cpp-check"
       - task: "yml-check"
 
   fix:
     cmds:
       - task: "cmake-fix"
+      - task: "cpp-fix"
       - task: "yml-fix"
 
   cmake-check:
@@ -27,6 +30,66 @@ tasks:
       - task: "cmake"
         vars:
           FLAGS: "--in-place"
+
+  cpp-configs: "tools/yscope-dev-utils/lint-configs/symlink-cpp-lint-configs.sh"
+
+  cpp-check:
+    cmds:
+      - task: "cpp-format-check"
+      - task: "cpp-static-check"
+
+  cpp-fix:
+    cmds:
+      - task: "cpp-format-fix"
+      - task: "cpp-static-fix"
+
+  cpp-format-check:
+    sources: &cpp_format_src_files
+      - "{{.G_LINT_VENV_CHECKSUM_FILE}}"
+      - "{{.G_SRC_SPIDER_DIR}}/.clang-format"
+      - "{{.G_SRC_SPIDER_DIR}}/**/*.cpp"
+      - "{{.G_SRC_SPIDER_DIR}}/**/*.h"
+      - "{{.G_SRC_SPIDER_DIR}}/**/*.hpp"
+      - "{{.TASKFILE}}"
+      - "tools/yscope-dev-utils/lint-configs/.clang-format"
+    deps: ["cpp-configs", "venv"]
+    cmds:
+      - task: "clang-format"
+        vars:
+          FLAGS: "--dry-run"
+          SRC_DIR: "{{.G_SRC_SPIDER_DIR}}"
+
+  cpp-format-fix:
+    sources: *cpp_format_src_files
+    deps: ["cpp-configs", "venv"]
+    cmds:
+      - task: "clang-format"
+        vars:
+          FLAGS: "-i"
+          SRC_DIR: "{{.G_SRC_SPIDER_DIR}}"
+
+  cpp-static-check:
+    # Alias task to `cpp-static-fix` since we don't currently support automatic fixes.
+    # NOTE: clang-tidy does have the ability to fix some errors, but the fixes can be inaccurate.
+    # When we eventually determine which errors can be safely fixed, we'll allow clang-tidy to
+    # fix them.
+    aliases: ["cpp-static-fix"]
+    sources:
+      - "{{.G_LINT_VENV_CHECKSUM_FILE}}"
+      - "{{.G_SRC_SPIDER_DIR}}/**/*.cpp"
+      - "{{.G_SRC_SPIDER_DIR}}/**/*.h"
+      - "{{.G_SRC_SPIDER_DIR}}/**/*.hpp"
+      - "{{.G_SPIDER_CMAKE_CACHE}}"
+      - "{{.G_SPIDER_COMPILE_COMMANDS_DB}}"
+      - "{{.TASKFILE}}"
+      - "Taskfile.yml"
+      - "tools/yscope-dev-utils/lint-configs/.clang-tidy"
+    deps: [":config-cmake-project", "cpp-configs", "venv"]
+    cmds:
+      - task: "clang-tidy"
+        vars:
+          FLAGS: "--config-file=.clang-tidy -p {{.G_SPIDER_COMPILE_COMMANDS_DB}}"
+          SRC_DIR: "{{.G_SRC_SPIDER_DIR}}"
 
   yml:
     aliases:
@@ -45,6 +108,30 @@ tasks:
           lint-tasks.yaml \
           taskfile.yaml
 
+  clang-format:
+    internal: true
+    requires:
+      vars: ["FLAGS", "SRC_DIR"]
+    cmd: |-
+      . "{{.G_LINT_VENV_DIR}}/bin/activate"
+      find "{{.SRC_DIR}}" \
+        -type f \
+        \( -iname "*.cpp" -o -iname "*.h" -o -iname "*.hpp" \) \
+        -print0 | \
+          xargs -0 --no-run-if-empty clang-format {{.FLAGS}} -Werror
+
+  clang-tidy:
+    internal: true
+    requires:
+      vars: ["FLAGS", "SRC_DIR"]
+    cmd: |-
+      . "{{.G_LINT_VENV_DIR}}/bin/activate"
+      find "{{.SRC_DIR}}" \
+        -type f \
+        \( -iname "*.cpp" -o -iname "*.h" -o -iname "*.hpp" \) \
+        -print0 | \
+          xargs -0 --no-run-if-empty clang-tidy {{.FLAGS}}
+
   cmake:
     internal: true
     requires:
@@ -60,7 +147,7 @@ tasks:
   venv:
     internal: true
     vars:
-      CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK | replace \":\" \"#\"}}.md5"
+      CHECKSUM_FILE: "{{.G_LINT_VENV_CHECKSUM_FILE}}"
       OUTPUT_DIR: "{{.G_LINT_VENV_DIR}}"
     sources:
       - "{{.ROOT_DIR}}/taskfile.yaml"

--- a/src/spider/.clang-format
+++ b/src/spider/.clang-format
@@ -1,0 +1,20 @@
+BasedOnStyle: "InheritParentConfig"
+
+IncludeCategories:
+  # NOTE: A header is grouped by first matching regex
+  # Project headers
+  - Regex: "^<spider"
+    Priority: 4
+  # Library headers. Update when adding new libraries.
+  # NOTE: clang-format retains leading white-space on a line in violation of the YAML spec.
+  # Ex:
+  # - Regex: "<(fmt|spdlog)"
+  #   Priority: 3
+  - Regex: "^<(clp)"
+    Priority: 3
+  # C system headers
+  - Regex: "^<.+\\.h>"
+    Priority: 1
+  # C++ standard libraries
+  - Regex: "^<.+>"
+    Priority: 2

--- a/src/spider/spider.cpp
+++ b/src/spider/spider.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 
-int main() {
-    std::cout << "Hello, world!" << std::endl;
+auto main() -> int {
+    std::cout << "Hello, world!" << '\n';
     return 0;
 }

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -6,11 +6,25 @@ includes:
 
 vars:
   G_BUILD_DIR: "{{.ROOT_DIR}}/build"
+  G_BUILD_SPIDER_DIR: "{{.G_BUILD_DIR}}/spider"
+  G_SPIDER_CMAKE_CACHE: "{{.G_BUILD_SPIDER_DIR}}/CMakeCache.txt"
+  G_SPIDER_COMPILE_COMMANDS_DB: "{{.G_BUILD_SPIDER_DIR}}/compile_commands.json"
+  G_SRC_SPIDER_DIR: "{{.ROOT_DIR}}/src/spider"
 
 tasks:
   clean:
     cmds:
       - "rm -rf '{{.G_BUILD_DIR}}'"
+
+  config-cmake-project:
+    internal: true
+    sources:
+      - "{{.TASKFILE}}"
+      - "CMakeLists.txt"
+    generates:
+      - "{{.G_SPIDER_CMAKE_CACHE}}"
+      - "{{.G_SPIDER_COMPILE_COMMANDS_DB}}"
+    cmd: "cmake -S '{{.ROOT_DIR}}' -B '{{.G_BUILD_SPIDER_DIR}}'"
 
   init:
     internal: true


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

* Follows this [process](https://github.com/y-scope/yscope-dev-utils/blob/main/docs/lint-tools-cpp.md) to add our YScope-wide C++ linting configs to this repo.
* Adds the following tasks for linting C++ files (see the README updates for descriptions):
  * `lint:cpp-configs`
  * `lint:cpp-check`
  * `lint:cpp-fix`
  * `lint:cpp-format-check`
  * `lint:cpp-format-fix`
  * `lint:cpp-static-check`
  * `lint:cpp-static-fix`
* Fixes the violations in the existing C++ code.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->

* `task lint:cpp-configs` generated symlinks to the C++ linting configs.
  * Running it again succeeded idempotently.
* Temporarily undid the fixes to the C++ code from this PR:
  * `task lint:check` failed due to the violations.
  * `task lint:cpp-check` failed due to the violations.
  * `task lint:cpp-static-check` failed due to the violations.
  * `task lint:fix` failed due to the violations.
  * `task lint:cpp-fix` failed due to the violations.
  * `task lint:cpp-static-fix` failed due to the violations.
* Added extra whitespace in spider.cpp and then:
  * `task lint:check` failed due to the violation.
  * `task lint:cpp-check` failed due to the violation.
  * `task lint:cpp-format-check` failed due to the violation.
  * `task lint:fix` removed the extra whitespace.
  * `task lint:cpp-fix` removed the extra whitespace.
  * `task lint:cpp-format-fix` removed the extra whitespace.
* Ran `task lint:cpp-check` twice to ensure no checks were re-run, edited spider.cpp, and then `task lint:cpp-check` detected the changes and re-ran `cpp-format-check` and `cpp-static-check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced C++ linting tasks in the README, enhancing linting capabilities with new commands for checking and fixing code.
	- Added a new configuration file for clang-format to manage header file formatting.
	- Implemented new variables and a task for CMake project configuration in the taskfile.

- **Documentation**
	- Updated README.md with instructions for C++ linting tools and tasks.

- **Chores**
	- Expanded `.gitignore` to include lint configuration files.
	- Updated dependency versions in lint-requirements.txt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->