### PR TITLE
fix(linting): Select CMake files for linting using an include rather than exclude list; Finish incomplete changes from previous PRs.

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,5 +1,0 @@
-extends: "tools/yscope-dev-utils/lint-configs/.yamllint.yml"
-
-ignore: |
-  build/
-  tools/yscope-dev-utils/

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ task lint:cpp-configs
 ## Adding files
 Certain file types need to be added to our linting rules manually:
 
+* **CMake**. If adding a CMake file, add it (or its parent directory) as an argument to the
+  `gersemi` command in [lint-tasks.yaml](lint-tasks.yaml).
+  * If adding a directory, the file must be named `CMakeLists.txt` or use the `.cmake` extension.
 * **YAML**. If adding a YAML file (regardless of its extension), add it as an argument to the
   `yamllint` command in [lint-tasks.yaml](lint-tasks.yaml).
 

--- a/lint-tasks.yaml
+++ b/lint-tasks.yaml
@@ -104,7 +104,6 @@ tasks:
           --strict \
           .gersemirc \
           .github/ \
-          .yamllint.yaml \
           lint-tasks.yaml \
           taskfile.yaml
 

--- a/lint-tasks.yaml
+++ b/lint-tasks.yaml
@@ -82,7 +82,7 @@ tasks:
       - "{{.G_SPIDER_CMAKE_CACHE}}"
       - "{{.G_SPIDER_COMPILE_COMMANDS_DB}}"
       - "{{.TASKFILE}}"
-      - "Taskfile.yml"
+      - "taskfile.yaml"
       - "tools/yscope-dev-utils/lint-configs/.clang-tidy"
     deps: [":config-cmake-project", "cpp-configs", "venv"]
     cmds:

--- a/lint-tasks.yaml
+++ b/lint-tasks.yaml
@@ -137,11 +137,7 @@ tasks:
       vars: ["FLAGS"]
     cmd: |-
       . "{{.G_LINT_VENV_DIR}}/bin/activate"
-      find . \
-        -path ./build -prune \
-        -o -name CMakeLists.txt \
-        -print0 | \
-          xargs -0 --no-run-if-empty gersemi {{.FLAGS}}
+      gersemi {{.FLAGS}} CMakeLists.txt src/
 
   venv:
     internal: true


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

#10 demonstrates that there are usually more CMake files to exclude (e.g., those in submodules) than include in a repo, so it's better to select the CMake files to lint using an include list.

This PR also finishes some incomplete changes from previous PRs:
* Remove the now unused `.yamllint` file that should've been deleted in #8.
* Fix the broken reference to `Taskfile.yml` that should've been changed to `taskfile.yaml` in #6.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
* Workflow succeeded.
* Added a lint violation in CMakeLists.txt and validated `task lint:check` detected it.
* Created a temporary CMakeLists.txt with a lint violation in `src/` and validated `task lint:check` detected it.
* Changed `taskfile.yaml` and validated `task lint:check` detected the change and recreated the lint venv.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the README.md with instructions for handling CMake files in relation to linting.
  
- **Chores**
	- Removed the `.yamllint.yaml` configuration file, eliminating custom linting rules.
	- Refined task definitions in `lint-tasks.yaml`, including updates to the `cmake` and `yml` tasks for consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->