### PR TITLE
style: Improve code style by putting private after public

### DIFF
--- a/src/spider/core/Data.hpp
+++ b/src/spider/core/Data.hpp
@@ -7,17 +7,8 @@
 #include <string>
 #include <utility>
 
+namespace spider::core {
 class Data {
-private:
-    boost::uuids::uuid m_id;
-    std::optional<std::string> m_key;
-    std::string m_value;
-
-    void init_id() {
-        boost::uuids::random_generator gen;
-        m_id = gen();
-    }
-
 public:
     explicit Data(std::string value) : m_value(std::move(value)) { init_id(); }
 
@@ -30,6 +21,17 @@ public:
     [[nodiscard]] auto get_key() const -> std::optional<std::string> { return m_key; }
 
     [[nodiscard]] auto get_value() const -> std::string { return m_value; }
+
+private:
+    boost::uuids::uuid m_id;
+    std::optional<std::string> m_key;
+    std::string m_value;
+
+    void init_id() {
+        boost::uuids::random_generator gen;
+        m_id = gen();
+    }
 };
+}  // namespace spider::core
 
 #endif  // SPIDER_CORE_DATA_HPP

--- a/src/spider/core/Task.hpp
+++ b/src/spider/core/Task.hpp
@@ -85,16 +85,6 @@ enum class TaskCreatorType : std::uint8_t {
 };
 
 class Task {
-private:
-    boost::uuids::uuid m_id;
-    std::string m_function_name;
-    TaskState m_state = TaskState::Pending;
-    TaskCreatorType m_creator_type;
-    boost::uuids::uuid m_creator_id;
-    float m_timeout = 0;
-    std::vector<TaskInput> m_inputs;
-    std::vector<TaskOutput> m_outputs;
-
 public:
     Task(std::string function_name, TaskCreatorType creator_type, boost::uuids::uuid creator_id)
             : m_function_name(std::move(function_name)),
@@ -127,6 +117,16 @@ public:
     [[nodiscard]] auto get_input(uint64_t index) const -> TaskInput { return m_inputs[index]; }
 
     [[nodiscard]] auto get_output(uint64_t index) const -> TaskOutput { return m_outputs[index]; }
+
+private:
+    boost::uuids::uuid m_id;
+    std::string m_function_name;
+    TaskState m_state = TaskState::Pending;
+    TaskCreatorType m_creator_type;
+    boost::uuids::uuid m_creator_id;
+    float m_timeout = 0;
+    std::vector<TaskInput> m_inputs;
+    std::vector<TaskOutput> m_outputs;
 };
 
 }  // namespace spider::core

--- a/src/spider/core/Task.hpp
+++ b/src/spider/core/Task.hpp
@@ -12,14 +12,7 @@
 #include <vector>
 
 namespace spider::core {
-
 class TaskInput {
-private:
-    std::optional<std::tuple<boost::uuids::uuid, std::uint8_t>> m_task_output;
-    std::optional<std::string> m_value;
-    std::optional<boost::uuids::uuid> m_data_id;
-    std::string m_type;
-
 public:
     TaskInput(boost::uuids::uuid output_task_id, std::uint8_t position, std::string type)
             : m_task_output({output_task_id, position}),
@@ -43,14 +36,15 @@ public:
     }
 
     [[nodiscard]] auto get_type() const -> std::string { return m_type; }
-};
 
-class TaskOutput {
 private:
+    std::optional<std::tuple<boost::uuids::uuid, std::uint8_t>> m_task_output;
     std::optional<std::string> m_value;
     std::optional<boost::uuids::uuid> m_data_id;
     std::string m_type;
+};
 
+class TaskOutput {
 public:
     TaskOutput(std::string value, std::string type)
             : m_value(std::move(value)),
@@ -67,6 +61,11 @@ public:
     }
 
     [[nodiscard]] auto get_type() const -> std::string { return m_type; }
+
+private:
+    std::optional<std::string> m_value;
+    std::optional<boost::uuids::uuid> m_data_id;
+    std::string m_type;
 };
 
 class TaskInstance {};

--- a/src/spider/core/TaskGraph.hpp
+++ b/src/spider/core/TaskGraph.hpp
@@ -11,12 +11,7 @@
 #include "Task.hpp"
 
 namespace spider::core {
-
 class TaskGraph {
-private:
-    absl::flat_hash_map<boost::uuids::uuid, Task> m_tasks;
-    std::vector<std::pair<boost::uuids::uuid, boost::uuids::uuid>> m_dependencies;
-
 public:
     auto add_child_task(Task const& task, std::vector<boost::uuids::uuid> const& parents) -> bool {
         boost::uuids::uuid const task_id = task.get_id();
@@ -73,6 +68,10 @@ public:
     ) const -> std::vector<std::pair<boost::uuids::uuid, boost::uuids::uuid>> const& {
         return m_dependencies;
     }
+
+private:
+    absl::flat_hash_map<boost::uuids::uuid, Task> m_tasks;
+    std::vector<std::pair<boost::uuids::uuid, boost::uuids::uuid>> m_dependencies;
 };
 }  // namespace spider::core
 


### PR DESCRIPTION
# Description
Improve code style by putting private after public in class definition.


# Validation performed
- [x] task:lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Reorganized member variable declarations in the `Data`, `TaskInput`, `TaskOutput`, and `TaskGraph` classes for improved structure.
	- Changed visibility of certain member variables in the `TaskInput` and `Task` classes from private to public.
	- Adjusted the order of member variables in the `TaskOutput` and `TaskGraph` classes without altering functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->