### PR TITLE
fix: Lock task to v3.39.2 to work around behaviour change in v3.40.0.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,8 +10,10 @@ RUN ./tools/scripts/lib_install/linux/install-dev.sh
 RUN ./tools/scripts/lib_install/linux/install-lib.sh
 
 # NOTE:
-# `task` doesn't have an apt/yum package so we use its install script.
-RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
+# - `task` doesn't have an apt/yum package so we use its install script.
+# - We lock task's version since v3.40.0 and higher change the behaviour of how undefined variables
+#   are treated in `ref` statements, causing yscope-dev-utils' `validate-checksum` task to fail.
+RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin v3.39.2
 
 # Remove cached files
 RUN apt-get clean \

--- a/.github/workflows/code-linting-checks.yaml
+++ b/.github/workflows/code-linting-checks.yaml
@@ -31,8 +31,11 @@ jobs:
         with:
           python-version: "3.10"
 
+      # We lock task's version since v3.40.0 and higher change the behaviour of how undefined
+      # variables are treated in `ref` statements, causing yscope-dev-utils' `validate-checksum`
+      # task to fail.
       - name: "Install task"
-        run: "npm install -g @go-task/cli"
+        run: "npm install -g @go-task/cli@3.39.2"
 
       - if: "matrix.os == 'macos-latest'"
         name: "Install coreutils (for md5sum)"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Follow the steps below to develop and contribute to the project.
 
 ## Requirements
 * Python 3.10 or higher
-* [Task] 3.38.0 or higher
+* [Task] >= 3.38.0, < 3.40.0
 
 ## Set up
 Initialize and update submodules:


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

The GH linting workflow was failing since it was using the latest version (v3.40.0) of task which changes the behaviour of how undefined variables are treated in `ref` statements, causing yscope-dev-utils' `validate-checksum` task to fail. 

This PR locks task's version to v3.39.2 to work around the issue. Once yscope-dev-utils' tasks are updated, we can remove this constraint.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->

GH workflow succeeded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the "Requirements" section in `README.md` to specify a version range for the `Task` dependency, allowing for more flexible usage while excluding versions 3.40.0 and above.
  
- **Chores**
	- Locked the installation of the `task` utility and `@go-task/cli` to version `3.39.2` in the Dockerfile and workflow configuration, respectively, to ensure consistent behaviour and prevent issues with undefined variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->