### PR TITLE
feat: Add gitattribute for correct line ending on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.cpp text
+*.hpp text
+
+# Declare files that will always have LF line endings on checkout
+*.sh text eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary


### PR DESCRIPTION
# Description
Git on windows by default checkout in CRLF format and check in with LF. However, the scripts to build containers should be ended with LF so that they can be directly copied into Linux/macOS container.

# Validation performed
- Dev container can be built on Windows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Git configuration for handling line endings and file types to ensure consistency across different operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->