### PR TITLE
build: Unlock task version

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,10 +10,8 @@ RUN ./tools/scripts/lib_install/linux/install-dev.sh
 RUN ./tools/scripts/lib_install/linux/install-lib.sh
 
 # NOTE:
-# - `task` doesn't have an apt/yum package so we use its install script.
-# - We lock task's version since v3.40.0 and higher change the behaviour of how undefined variables
-#   are treated in `ref` statements, causing yscope-dev-utils' `validate-checksum` task to fail.
-RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin v3.39.2
+# `task` doesn't have an apt/yum package so we use its install script.
+RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
 
 # Remove cached files
 RUN apt-get clean \

--- a/.github/workflows/code-linting-checks.yaml
+++ b/.github/workflows/code-linting-checks.yaml
@@ -31,11 +31,8 @@ jobs:
         with:
           python-version: "3.10"
 
-      # We lock task's version since v3.40.0 and higher change the behaviour of how undefined
-      # variables are treated in `ref` statements, causing yscope-dev-utils' `validate-checksum`
-      # task to fail.
       - name: "Install task"
-        run: "npm install -g @go-task/cli@3.39.2"
+        run: "npm install -g @go-task/cli"
 
       - if: "matrix.os == 'macos-latest'"
         name: "Install coreutils (for md5sum)"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Follow the steps below to develop and contribute to the project.
 
 ## Requirements
 * Python 3.10 or higher
-* [Task] >= 3.38.0, < 3.40.0
+* [Task] 3.38.0 or higher
 
 ## Set up
 Initialize and update submodules:


### PR DESCRIPTION
# Description
In #22, task version is locked to 3.39.2 temporarily as a workaround. Now the upstream yscope-dev-utils have updated and solved the problem, we can remove the task version lock.


# Validation performed
- [x] Github workflow succeeded.
