### PR TITLE
ci: Add tasks to run unit tests and GitHub workflow to run non-storage unit tests.

### DIFF
--- a/.github/workflows/code-linting-checks.yaml
+++ b/.github/workflows/code-linting-checks.yaml
@@ -18,10 +18,7 @@ concurrency:
 
 jobs:
   lint:
-    strategy:
-      matrix:
-        os: ["ubuntu-latest"]
-    runs-on: "${{matrix.os}}"
+    runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v4"
         with:
@@ -34,10 +31,6 @@ jobs:
       - name: "Install task"
         run: "npm install -g @go-task/cli"
 
-      - if: "matrix.os == 'macos-latest'"
-        name: "Install coreutils (for md5sum)"
-        run: "brew install coreutils"
-
       - name: "Log tool versions"
         run: |-
           md5sum --version
@@ -47,7 +40,6 @@ jobs:
 
       - name: "Install project dependencies "
         timeout-minutes: 10
-        continue-on-error: false
         run: "task deps:lib_install"
 
       - run: "task lint:check"

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -1,0 +1,53 @@
+name: "code-linting-checks"
+
+on:
+  pull_request:
+  push:
+  schedule:
+    # Run daily at 00:15 UTC (the 15 is to avoid periods of high load)
+    - cron: "15 0 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+
+  # Cancel in-progress jobs for efficiency
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    strategy:
+      matrix:
+        os: ["ubuntu-latest"]
+    runs-on: "${{matrix.os}}"
+    steps:
+      - uses: "actions/checkout@v4"
+        with:
+          submodules: "recursive"
+
+      - uses: "actions/setup-python@v5"
+        with:
+          python-version: "3.10"
+
+      - name: "Install task"
+        run: "npm install -g @go-task/cli"
+
+      - if: "matrix.os == 'macos-latest'"
+        name: "Install coreutils (for md5sum)"
+        run: "brew install coreutils"
+
+      - name: "Log tool versions"
+        run: |-
+          md5sum --version
+          python --version
+          tar --version
+          task --version
+
+      - name: "Install project dependencies "
+        timeout-minutes: 10
+        continue-on-error: false
+        run: "task deps:lib_install"
+
+      - run: "task test:unit-test"

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
+  non-storage-unit-tests:
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v4"

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,4 +1,4 @@
-name: "code-linting-checks"
+name: "unit-tests"
 
 on:
   pull_request:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -18,10 +18,7 @@ concurrency:
 
 jobs:
   lint:
-    strategy:
-      matrix:
-        os: ["ubuntu-latest"]
-    runs-on: "${{matrix.os}}"
+    runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v4"
         with:
@@ -34,10 +31,6 @@ jobs:
       - name: "Install task"
         run: "npm install -g @go-task/cli"
 
-      - if: "matrix.os == 'macos-latest'"
-        name: "Install coreutils (for md5sum)"
-        run: "brew install coreutils"
-
       - name: "Log tool versions"
         run: |-
           md5sum --version
@@ -47,7 +40,6 @@ jobs:
 
       - name: "Install project dependencies "
         timeout-minutes: 10
-        continue-on-error: false
         run: "task deps:lib_install"
 
-      - run: "task test:unit-test"
+      - run: "task test:non-storage-unit-tests"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Follow the steps below to develop and contribute to the project.
 
 ## Requirements
 * Python 3.10 or higher
-* [Task] 3.38.0 or higher
+* [Task] 3.40.0 or higher
 
 ## Set up
 Initialize and update submodules:

--- a/build-tasks.yaml
+++ b/build-tasks.yaml
@@ -15,6 +15,6 @@ tasks:
 
   clean:
     internal: true
-    deps: ["::config-cmake-project"]
+    deps: [":config-cmake-project"]
     cmds:
       - "cmake --build {{.G_BUILD_SPIDER_DIR}} --target clean --parallel {{numCPU}}"

--- a/build-tasks.yaml
+++ b/build-tasks.yaml
@@ -8,8 +8,11 @@ tasks:
         ref: "default (list \"all\") .TARGETS"
     deps: [":config-cmake-project"]
     cmds:
-      - "cmake --build {{.G_BUILD_SPIDER_DIR}} --parallel {{numCPU}}
-      --target {{trimPrefix \"[\" .TARGETS | trimSuffix \"]\"}}"
+      - >-
+        cmake
+        --build "{{.G_BUILD_SPIDER_DIR}}"
+        --parallel {{numCPU}}
+        --target {{range .TARGETS}}{{.}} {{end}}
 
   clean:
     internal: true

--- a/build-tasks.yaml
+++ b/build-tasks.yaml
@@ -1,0 +1,24 @@
+version: "3"
+
+tasks:
+  target:
+    internal: true
+    vars:
+      TARGET: "{{default \"all\" .TARGET}}"
+    requires:
+      vars:
+        - name: "TARGET"
+          enum:
+            - "all"
+            - "spider_client"
+            - "spider_worker"
+            - "spider_task_executor"
+            - "unitTest"
+            - "worker_test"
+    cmds:
+      - "cmake --build {{.G_BUILD_SPIDER_DIR}} --target {{.TARGET}} --parallel"
+
+  clean:
+    internal: true
+    cmds:
+      - "cmake --build {{.G_BUILD_SPIDER_DIR}} --target clean --parallel"

--- a/build-tasks.yaml
+++ b/build-tasks.yaml
@@ -10,11 +10,11 @@ tasks:
         - name: "TARGETS"
     deps: [":config-cmake-project"]
     cmds:
-      - "cmake --build {{.G_BUILD_SPIDER_DIR}} --parallel
+      - "cmake --build {{.G_BUILD_SPIDER_DIR}} --parallel {{numCPU}}
       --target {{trimPrefix \"[\" .TARGETS | trimSuffix \"]\"}}"
 
   clean:
     internal: true
     deps: ["::config-cmake-project"]
     cmds:
-      - "cmake --build {{.G_BUILD_SPIDER_DIR}} --target clean --parallel"
+      - "cmake --build {{.G_BUILD_SPIDER_DIR}} --target clean --parallel {{numCPU}}"

--- a/build-tasks.yaml
+++ b/build-tasks.yaml
@@ -4,10 +4,8 @@ tasks:
   target:
     internal: true
     vars:
-      TARGETS: "{{.TARGETS}}"
-    requires:
-      vars:
-        - name: "TARGETS"
+      TARGETS:
+        ref: "default (list \"all\") .TARGETS"
     deps: [":config-cmake-project"]
     cmds:
       - "cmake --build {{.G_BUILD_SPIDER_DIR}} --parallel {{numCPU}}

--- a/build-tasks.yaml
+++ b/build-tasks.yaml
@@ -4,20 +4,14 @@ tasks:
   target:
     internal: true
     vars:
-      TARGET: "{{default \"all\" .TARGET}}"
+      TARGETS: "{{.TARGETS}}"
     requires:
       vars:
-        - name: "TARGET"
-          enum:
-            - "all"
-            - "spider_client"
-            - "spider_worker"
-            - "spider_task_executor"
-            - "unitTest"
-            - "worker_test"
+        - name: "TARGETS"
     deps: [":config-cmake-project"]
     cmds:
-      - "cmake --build {{.G_BUILD_SPIDER_DIR}} --target {{.TARGET}} --parallel"
+      - "cmake --build {{.G_BUILD_SPIDER_DIR}} --parallel
+      --target {{trimPrefix \"[\" .TARGETS | trimSuffix \"]\"}}"
 
   clean:
     internal: true

--- a/build-tasks.yaml
+++ b/build-tasks.yaml
@@ -15,10 +15,12 @@ tasks:
             - "spider_task_executor"
             - "unitTest"
             - "worker_test"
+    deps: ["::config-cmake-project"]
     cmds:
       - "cmake --build {{.G_BUILD_SPIDER_DIR}} --target {{.TARGET}} --parallel"
 
   clean:
     internal: true
+    deps: ["::config-cmake-project"]
     cmds:
       - "cmake --build {{.G_BUILD_SPIDER_DIR}} --target clean --parallel"

--- a/build-tasks.yaml
+++ b/build-tasks.yaml
@@ -15,7 +15,7 @@ tasks:
             - "spider_task_executor"
             - "unitTest"
             - "worker_test"
-    deps: ["::config-cmake-project"]
+    deps: [":config-cmake-project"]
     cmds:
       - "cmake --build {{.G_BUILD_SPIDER_DIR}} --target {{.TARGET}} --parallel"
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -40,3 +40,19 @@ set correctly.
 ```c++
 REQUIRE( storage->connect(spider::test::cStorageUrl).success() )
 ```
+
+## Test tasks
+
+Three unit-test related tasks are added to taskfile.
+
+* `test:non-storage-unit-tests` runs all unit tests without `[storage]` tag, i.e. do not need a storage to run.
+* `test:storage-unit-tests` runs all unit tests that has `[storage]` tag.
+* `test:all` runs all unit tests.
+
+All unit-test related tasks build `spider_task_executor`, `unitTest` and `worker_test`, which are necessary to run unit
+tests.
+
+## GitHub test workflow
+
+A GitHub workflow `unit_tests.yaml` is set up to run unit test on push, pull request and every day. Currently, it only
+runs unit tests without storage requirement.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -53,8 +53,8 @@ You can use the following tasks to run the set of unit tests that's appropriate.
 
 ## GitHub unit test workflow
 
-The [unit_tests.yaml][gh-workflow-unit-tests] GitHub workflow runs the unit tests on push, pull requests, and daily.
-Currently, it only runs unit tests that don't require a storage backend.
+The [unit_tests.yaml][gh-workflow-unit-tests] GitHub workflow runs the unit tests on push,
+pull requests, and daily. Currently, it only runs unit tests that don't require a storage backend.
 
 If any tests show error messages for the connection function below, revisit
 [setup section](#set-up-mysql-as-storage-backend) and verify that `cStorageUrl` was set correctly.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -41,18 +41,26 @@ set correctly.
 REQUIRE( storage->connect(spider::test::cStorageUrl).success() )
 ```
 
-## Test tasks
+## Running tests
 
-Three unit-test related tasks are added to taskfile.
+You can use the following tasks to run the set of unit tests that's appropriate.
 
-* `test:non-storage-unit-tests` runs all unit tests without `[storage]` tag, i.e. do not need a storage to run.
-* `test:storage-unit-tests` runs all unit tests that has `[storage]` tag.
-* `test:all` runs all unit tests.
+| Task                          | Description                                                       |
+|-------------------------------|-------------------------------------------------------------------|
+| `test:all`                    | Runs all unit tests.                                              |
+| `test:non-storage-unit-tests` | Runs all unit tests which don't require a storage backend to run. |
+| `test:storage-unit-tests`     | Runs all unit tests which require a storage backend to run.       |
 
-All unit-test related tasks build `spider_task_executor`, `unitTest` and `worker_test`, which are necessary to run unit
-tests.
+## GitHub unit test workflow
 
-## GitHub test workflow
+The [unit_tests.yaml][gh-workflow-unit-tests] GitHub workflow runs the unit tests on push, pull requests, and daily.
+Currently, it only runs unit tests that don't require a storage backend.
 
-A GitHub workflow `unit_tests.yaml` is set up to run unit test on push, pull request and every day. Currently, it only
-runs unit tests without storage requirement.
+If any tests show error messages for the connection function below, revisit
+[setup section](#set-up-mysql-as-storage-backend) and verify that `cStorageUrl` was set correctly.
+
+```c++
+REQUIRE( storage->connect(spider::test::cStorageUrl).success() )
+```
+
+[gh-workflow-unit-tests]: ../.github/workflows/unit-tests.yaml

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -23,24 +23,6 @@ require this storage backend.
 4. Set the `cStorageUrl` in `tests/storage/StorageTestHelper.hpp` to
    `jdbc:mariadb://localhost:3306/<db_name>?user=<usr>&password=<pwd>`.
 
-## Build and run unit tests
-
-To build and run the unit tests, run the following commands in project root directory.
-
-```shell
-cmake -S . -B build
-cmake --build build --target unitTest --parallel
-./build/tests/unitTest
-```
-
-If the tests show error messages for connection functions below,
-revisit [Setup storage backend](#setup-storage-backend) section and double check if `cStorageUrl` is
-set correctly.
-
-```c++
-REQUIRE( storage->connect(spider::test::cStorageUrl).success() )
-```
-
 ## Running tests
 
 You can use the following tasks to run the set of unit tests that's appropriate.
@@ -51,16 +33,16 @@ You can use the following tasks to run the set of unit tests that's appropriate.
 | `test:non-storage-unit-tests` | Runs all unit tests which don't require a storage backend to run. |
 | `test:storage-unit-tests`     | Runs all unit tests which require a storage backend to run.       |
 
-## GitHub unit test workflow
-
-The [unit_tests.yaml][gh-workflow-unit-tests] GitHub workflow runs the unit tests on push,
-pull requests, and daily. Currently, it only runs unit tests that don't require a storage backend.
-
-If any tests show error messages for the connection function below, revisit
+If any tests show error messages for the connection function below, revisit the
 [setup section](#set-up-mysql-as-storage-backend) and verify that `cStorageUrl` was set correctly.
 
 ```c++
 REQUIRE( storage->connect(spider::test::cStorageUrl).success() )
 ```
+
+## GitHub unit test workflow
+
+The [unit_tests.yaml][gh-workflow-unit-tests] GitHub workflow runs the unit tests on push,
+pull requests, and daily. Currently, it only runs unit tests that don't require a storage backend.
 
 [gh-workflow-unit-tests]: ../.github/workflows/unit-tests.yaml

--- a/lint-tasks.yaml
+++ b/lint-tasks.yaml
@@ -115,11 +115,11 @@ tasks:
           --strict \
           .gersemirc \
           .github/ \
-          lint-tasks.yaml \
-          dep-tasks.yaml \
-          test-tasks.yaml \
           build-tasks.yaml \
-          taskfile.yaml
+          dep-tasks.yaml \
+          lint-tasks.yaml \
+          taskfile.yaml \
+          test-tasks.yaml
 
   clang-format:
     internal: true

--- a/lint-tasks.yaml
+++ b/lint-tasks.yaml
@@ -118,6 +118,7 @@ tasks:
           lint-tasks.yaml \
           dep-tasks.yaml \
           test-tasks.yaml \
+          build-tasks.yaml \
           taskfile.yaml
 
   clang-format:

--- a/lint-tasks.yaml
+++ b/lint-tasks.yaml
@@ -117,6 +117,7 @@ tasks:
           .github/ \
           lint-tasks.yaml \
           dep-tasks.yaml \
+          test-tasks.yaml \
           taskfile.yaml
 
   clang-format:

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -4,7 +4,6 @@ includes:
   lint: "lint-tasks.yaml"
   deps: "dep-tasks.yaml"
   test: "test-tasks.yaml"
-  build: "build-tasks.yaml"
   utils: "tools/yscope-dev-utils/taskfiles/utils.yml"
 
 vars:

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -3,6 +3,7 @@ version: "3"
 includes:
   lint: "lint-tasks.yaml"
   deps: "dep-tasks.yaml"
+  test: "test-tasks.yaml"
   utils: "tools/yscope-dev-utils/taskfiles/utils.yml"
 
 vars:

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -4,6 +4,7 @@ includes:
   lint: "lint-tasks.yaml"
   deps: "dep-tasks.yaml"
   test: "test-tasks.yaml"
+  build: "build-tasks.yaml"
   utils: "tools/yscope-dev-utils/taskfiles/utils.yml"
 
 vars:

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -1,8 +1,9 @@
 version: "3"
 
 includes:
-  lint: "lint-tasks.yaml"
   deps: "dep-tasks.yaml"
+  build: "build-tasks.yaml"
+  lint: "lint-tasks.yaml"
   test: "test-tasks.yaml"
   utils: "tools/yscope-dev-utils/taskfiles/utils.yml"
 

--- a/test-tasks.yaml
+++ b/test-tasks.yaml
@@ -4,10 +4,26 @@ vars:
   G_TEST_BINARY: "{{.G_BUILD_SPIDER_DIR}}/tests/unitTest"
 
 tasks:
-  unit-test:
+  non-storage-unit-tests:
+    deps:
+      - "build-unit-test"
+    cmds:
+      - "{{.G_TEST_BINARY}} \"~[storage]\""
+
+  storage-unit-tests:
+    deps:
+      - "build-unit-test"
+    cmds:
+      - "{{.G_TEST_BINARY}} \"[storage]\""
+
+  all:
+    deps:
+      - "build-unit-test"
+    cmds:
+      - "{{.G_TEST_BINARY}}"
+
+  build-unit-test:
+    internal: true
     deps:
       - task: ":build:target"
         vars: {TARGETS: ["spider_task_executor", "unitTest", "worker_test"]}
-    cmds:
-      # Tests tagged with storage requires mysql. Skip them for now.
-      - "{{.G_TEST_BINARY}} \"~[storage]\""

--- a/test-tasks.yaml
+++ b/test-tasks.yaml
@@ -1,18 +1,20 @@
 version: "3"
 
+includes:
+  build: "build-tasks.yaml"
+
 vars:
   G_TEST_BINARY: "{{.G_BUILD_SPIDER_DIR}}/tests/unitTest"
 
 tasks:
   unit-test:
-    deps: ["build-unit-test"]
+    deps:
+      - task: "build:target"
+        vars: {TARGET: "unitTest"}
+      - task: "build:target"
+        vars: {TARGET: "spider_task_executor"}
+      - task: "build:target"
+        vars: {TARGET: "worker_test"}
     cmds:
       # Tests tagged with storage requires mysql. Skip them for now.
       - "{{.G_TEST_BINARY}} \"~[storage]\""
-
-  build-unit-test:
-    internal: true
-    # depends on build tool, i.e. make, to check source changes
-    deps: [":config-cmake-project"]
-    cmds:
-      - "cmake --build {{.G_BUILD_SPIDER_DIR}} --target unitTest --parallel"

--- a/test-tasks.yaml
+++ b/test-tasks.yaml
@@ -5,13 +5,9 @@ vars:
 
 tasks:
   unit-test:
+    deps:
+      - task: ":build:target"
+        vars: {TARGETS: ["spider_task_executor", "unitTest", "worker_test"]}
     cmds:
-      # Add build in cmds to serialize the build
-      - task: ":build:target"
-        vars: {TARGET: "unitTest"}
-      - task: ":build:target"
-        vars: {TARGET: "spider_task_executor"}
-      - task: ":build:target"
-        vars: {TARGET: "worker_test"}
       # Tests tagged with storage requires mysql. Skip them for now.
       - "{{.G_TEST_BINARY}} \"~[storage]\""

--- a/test-tasks.yaml
+++ b/test-tasks.yaml
@@ -1,8 +1,5 @@
 version: "3"
 
-includes:
-  build: "build-tasks.yaml"
-
 vars:
   G_TEST_BINARY: "{{.G_BUILD_SPIDER_DIR}}/tests/unitTest"
 
@@ -10,11 +7,11 @@ tasks:
   unit-test:
     cmds:
       # Add build in cmds to serialize the build
-      - task: "build:target"
+      - task: ":build:target"
         vars: {TARGET: "unitTest"}
-      - task: "build:target"
+      - task: ":build:target"
         vars: {TARGET: "spider_task_executor"}
-      - task: "build:target"
+      - task: ":build:target"
         vars: {TARGET: "worker_test"}
       # Tests tagged with storage requires mysql. Skip them for now.
       - "{{.G_TEST_BINARY}} \"~[storage]\""

--- a/test-tasks.yaml
+++ b/test-tasks.yaml
@@ -1,0 +1,18 @@
+version: "3"
+
+vars:
+  G_TEST_BINARY: "{{.G_BUILD_SPIDER_DIR}}/tests/unitTest"
+
+tasks:
+  unit-test:
+    deps: ["build-unit-test"]
+    cmds:
+      # Tests tagged with storage requires mysql. Skip them for now.
+      - "{{.G_TEST_BINARY}} \"~[storage]\""
+
+  build-unit-test:
+    internal: true
+    # depends on build tool, i.e. make, to check source changes
+    deps: [":config-cmake-project"]
+    cmds:
+      - "cmake --build {{.G_BUILD_SPIDER_DIR}} --target unitTest --parallel"

--- a/test-tasks.yaml
+++ b/test-tasks.yaml
@@ -26,4 +26,5 @@ tasks:
     internal: true
     deps:
       - task: ":build:target"
-        vars: {TARGETS: ["spider_task_executor", "unitTest", "worker_test"]}
+        vars:
+          TARGETS: ["spider_task_executor", "unitTest", "worker_test"]

--- a/test-tasks.yaml
+++ b/test-tasks.yaml
@@ -8,13 +8,13 @@ vars:
 
 tasks:
   unit-test:
-    deps:
+    cmds:
+      # Add build in cmds to serialize the build
       - task: "build:target"
         vars: {TARGET: "unitTest"}
       - task: "build:target"
         vars: {TARGET: "spider_task_executor"}
       - task: "build:target"
         vars: {TARGET: "worker_test"}
-    cmds:
       # Tests tagged with storage requires mysql. Skip them for now.
       - "{{.G_TEST_BINARY}} \"~[storage]\""


### PR DESCRIPTION
# Description
Add unit test to github workflow. Unit tests with "[storage]" tag requires MySQL set up to run, so they are excluded from the workflow.


# Validation performed
- [x] Github workflow started unit test and succeeded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new CI/CD pipeline for running unit tests, triggered on pull requests and scheduled events.
	- Added a structured configuration for managing unit testing tasks, allowing for more granular control over test execution.
	- New tasks for building and cleaning components have been defined.

- **Enhancements**
	- Expanded YAML linting to cover additional files for improved validation.
	- Simplified code linting checks workflow for clearer execution.
	- Integrated test-related tasks into the existing task management structure.
	- Updated documentation to include details on unit testing tasks and GitHub Actions workflow.
	- Updated version requirement for the Task tool in the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->