### PR TITLE
feat: Add worker client that submit tasks and get next task from schedulers

### DIFF
--- a/src/spider/CMakeLists.txt
+++ b/src/spider/CMakeLists.txt
@@ -48,6 +48,8 @@ set(SPIDER_WORKER_SOURCES
     worker/TaskExecutorMessage.hpp
     worker/message_pipe.cpp
     worker/message_pipe.hpp
+    worker/WorkerClient.hpp
+    worker/WorkerClient.cpp
     CACHE INTERNAL
     "spider worker source files"
 )

--- a/src/spider/CMakeLists.txt
+++ b/src/spider/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SPIDER_CORE_SOURCES
 set(SPIDER_CORE_HEADERS
     core/Error.hpp
     core/Data.hpp
+    core/Driver.hpp
     core/KeyValueData.hpp
     core/Task.hpp
     core/TaskGraph.hpp

--- a/src/spider/core/Driver.hpp
+++ b/src/spider/core/Driver.hpp
@@ -1,0 +1,44 @@
+#ifndef SPIDER_CORE_DRIVER_HPP
+#define SPIDER_CORE_DRIVER_HPP
+
+#include <string>
+
+#include <boost/uuid/uuid.hpp>
+
+namespace spider::core {
+
+class Driver {
+public:
+    Driver(boost::uuids::uuid const id, std::string const& addr) : m_id{id}, m_addr{addr} {}
+
+    [[nodiscard]] auto get_id() const -> boost::uuids::uuid { return m_id; }
+
+    [[nodiscard]] auto get_addr() const -> std::string { return m_addr; }
+
+private:
+    boost::uuids::uuid m_id;
+    std::string m_addr;
+};
+
+class Scheduler {
+public:
+    Scheduler(boost::uuids::uuid const id, std::string const& addr, int port)
+            : m_id{id},
+              m_addr{addr},
+              m_port{port} {}
+
+    [[nodiscard]] auto get_id() const -> boost::uuids::uuid { return m_id; }
+
+    [[nodiscard]] auto get_addr() const -> std::string { return m_addr; }
+
+    [[nodiscard]] auto get_port() const -> int { return m_port; }
+
+private:
+    boost::uuids::uuid m_id;
+    std::string m_addr;
+    int m_port;
+};
+
+}  // namespace spider::core
+
+#endif  // SPIDER_CORE_DRIVER_HPP

--- a/src/spider/core/Driver.hpp
+++ b/src/spider/core/Driver.hpp
@@ -9,7 +9,7 @@ namespace spider::core {
 
 class Driver {
 public:
-    Driver(boost::uuids::uuid const id, std::string const& addr) : m_id{id}, m_addr{addr} {}
+    Driver(boost::uuids::uuid const id, std::string addr) : m_id{id}, m_addr{std::move(addr)} {}
 
     [[nodiscard]] auto get_id() const -> boost::uuids::uuid { return m_id; }
 
@@ -22,9 +22,9 @@ private:
 
 class Scheduler {
 public:
-    Scheduler(boost::uuids::uuid const id, std::string const& addr, int port)
+    Scheduler(boost::uuids::uuid const id, std::string addr, int port)
             : m_id{id},
-              m_addr{addr},
+              m_addr{std::move(addr)},
               m_port{port} {}
 
     [[nodiscard]] auto get_id() const -> boost::uuids::uuid { return m_id; }

--- a/src/spider/core/Driver.hpp
+++ b/src/spider/core/Driver.hpp
@@ -12,9 +12,9 @@ class Driver {
 public:
     Driver(boost::uuids::uuid const id, std::string addr) : m_id{id}, m_addr{std::move(addr)} {}
 
-    [[nodiscard]] auto get_id() const -> boost::uuids::uuid { return m_id; }
+    [[nodiscard]] auto get_id() const -> boost::uuids::uuid const& { return m_id; }
 
-    [[nodiscard]] auto get_addr() const -> std::string { return m_addr; }
+    [[nodiscard]] auto get_addr() const -> std::string const& { return m_addr; }
 
 private:
     boost::uuids::uuid m_id;
@@ -28,9 +28,9 @@ public:
               m_addr{std::move(addr)},
               m_port{port} {}
 
-    [[nodiscard]] auto get_id() const -> boost::uuids::uuid { return m_id; }
+    [[nodiscard]] auto get_id() const -> boost::uuids::uuid const& { return m_id; }
 
-    [[nodiscard]] auto get_addr() const -> std::string { return m_addr; }
+    [[nodiscard]] auto get_addr() const -> std::string const& { return m_addr; }
 
     [[nodiscard]] auto get_port() const -> int { return m_port; }
 

--- a/src/spider/core/Driver.hpp
+++ b/src/spider/core/Driver.hpp
@@ -2,6 +2,7 @@
 #define SPIDER_CORE_DRIVER_HPP
 
 #include <string>
+#include <utility>
 
 #include <boost/uuid/uuid.hpp>
 

--- a/src/spider/storage/MetadataStorage.hpp
+++ b/src/spider/storage/MetadataStorage.hpp
@@ -6,6 +6,7 @@
 
 #include <boost/uuid/uuid.hpp>
 
+#include "../core/Driver.hpp"
 #include "../core/Error.hpp"
 #include "../core/JobMetadata.hpp"
 #include "../core/Task.hpp"
@@ -25,10 +26,10 @@ public:
     virtual void close() = 0;
     virtual auto initialize() -> StorageErr = 0;
 
-    virtual auto add_driver(boost::uuids::uuid id, std::string const& addr) -> StorageErr = 0;
-    virtual auto add_driver(boost::uuids::uuid id, std::string const& addr, int port) -> StorageErr
-                                                                                         = 0;
+    virtual auto add_driver(Driver const& driver) -> StorageErr = 0;
+    virtual auto add_scheduler(Scheduler const& scheduler) -> StorageErr = 0;
     virtual auto get_driver(boost::uuids::uuid id, std::string* addr) -> StorageErr = 0;
+    virtual auto get_active_scheduler(std::vector<Scheduler>* schedulers) -> StorageErr = 0;
 
     virtual auto
     add_job(boost::uuids::uuid job_id, boost::uuids::uuid client_id, TaskGraph const& task_graph

--- a/src/spider/storage/MetadataStorage.hpp
+++ b/src/spider/storage/MetadataStorage.hpp
@@ -48,7 +48,8 @@ public:
     virtual auto get_ready_tasks(std::vector<Task>* tasks) -> StorageErr = 0;
     virtual auto set_task_state(boost::uuids::uuid id, TaskState state) -> StorageErr = 0;
     virtual auto add_task_instance(TaskInstance const& instance) -> StorageErr = 0;
-    virtual auto task_finish(TaskInstance const& instance) -> StorageErr = 0;
+    virtual auto task_finish(TaskInstance const& instance, std::vector<TaskOutput> const& outputs)
+            -> StorageErr = 0;
     virtual auto get_task_timeout(std::vector<TaskInstance>* tasks) -> StorageErr = 0;
     virtual auto get_child_tasks(boost::uuids::uuid id, std::vector<Task>* children) -> StorageErr
                                                                                         = 0;

--- a/src/spider/storage/MysqlStorage.cpp
+++ b/src/spider/storage/MysqlStorage.cpp
@@ -365,9 +365,9 @@ auto MySqlMetadataStorage::get_active_scheduler(std::vector<Scheduler>* schedule
                 "`schedulers`.`id` = `drivers`.`id` WHERE `state` = 'normal'"
         ));
         while (res->next()) {
-            boost::uuids::uuid id = read_id(res->getBinaryStream(1));
-            std::string addr = res->getString(2).c_str();
-            int port = res->getInt(3);
+            boost::uuids::uuid const id = read_id(res->getBinaryStream(1));
+            std::string const addr = res->getString(2).c_str();
+            int const port = res->getInt(3);
             schedulers->emplace_back(id, addr, port);
         }
     } catch (sql::SQLException& e) {

--- a/src/spider/storage/MysqlStorage.hpp
+++ b/src/spider/storage/MysqlStorage.hpp
@@ -52,7 +52,8 @@ public:
     auto get_ready_tasks(std::vector<Task>* tasks) -> StorageErr override;
     auto set_task_state(boost::uuids::uuid id, TaskState state) -> StorageErr override;
     auto add_task_instance(TaskInstance const& instance) -> StorageErr override;
-    auto task_finish(TaskInstance const& instance) -> StorageErr override;
+    auto task_finish(TaskInstance const& instance, std::vector<TaskOutput> const& outputs)
+            -> StorageErr override;
     auto get_task_timeout(std::vector<TaskInstance>* tasks) -> StorageErr override;
     auto get_child_tasks(boost::uuids::uuid id, std::vector<Task>* children) -> StorageErr override;
     auto get_parent_tasks(boost::uuids::uuid id, std::vector<Task>* tasks) -> StorageErr override;

--- a/src/spider/storage/MysqlStorage.hpp
+++ b/src/spider/storage/MysqlStorage.hpp
@@ -11,6 +11,7 @@
 #include <mariadb/conncpp/ResultSet.hpp>
 
 #include "../core/Data.hpp"
+#include "../core/Driver.hpp"
 #include "../core/Error.hpp"
 #include "../core/JobMetadata.hpp"
 #include "../core/KeyValueData.hpp"
@@ -31,10 +32,10 @@ public:
     auto connect(std::string const& url) -> StorageErr override;
     void close() override;
     auto initialize() -> StorageErr override;
-    auto add_driver(boost::uuids::uuid id, std::string const& addr) -> StorageErr override;
-    auto
-    add_driver(boost::uuids::uuid id, std::string const& addr, int port) -> StorageErr override;
+    auto add_driver(Driver const& driver) -> StorageErr override;
+    auto add_scheduler(Scheduler const& scheduler) -> StorageErr override;
     auto get_driver(boost::uuids::uuid id, std::string* addr) -> StorageErr override;
+    auto get_active_scheduler(std::vector<Scheduler>* schedulers) -> StorageErr override;
     auto
     add_job(boost::uuids::uuid job_id, boost::uuids::uuid client_id, TaskGraph const& task_graph
     ) -> StorageErr override;

--- a/src/spider/worker/WorkerClient.cpp
+++ b/src/spider/worker/WorkerClient.cpp
@@ -1,12 +1,16 @@
 #include "WorkerClient.hpp"
 
+#include <memory>
 #include <optional>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
 
 #include <boost/uuid/uuid.hpp>
 
 #include "../core/Task.hpp"
 #include "../io/MsgPack.hpp"  // IWYU pragma: keep
-#include "../io/msgpack_message.hpp"
 #include "../scheduler/SchedulerMessage.hpp"
 #include "../storage/DataStorage.hpp"
 #include "../storage/MetadataStorage.hpp"

--- a/src/spider/worker/WorkerClient.cpp
+++ b/src/spider/worker/WorkerClient.cpp
@@ -36,6 +36,10 @@ auto WorkerClient::task_finish(
 ) -> std::optional<boost::uuids::uuid> {
     m_metadata_store->task_finish(instance, outputs);
 
+    return get_next_task();
+}
+
+auto WorkerClient::get_next_task() -> std::optional<boost::uuids::uuid> {
     // Get schedulers
     std::vector<core::Scheduler> schedulers;
     if (!m_metadata_store->get_active_scheduler(&schedulers).success()) {

--- a/src/spider/worker/WorkerClient.cpp
+++ b/src/spider/worker/WorkerClient.cpp
@@ -1,0 +1,12 @@
+#include "WorkerClient.hpp"
+
+namespace spider::worker {
+
+WorkerClient::WorkerClient(
+        std::shared_ptr<core::DataStorage> data_store,
+        std::shared_ptr<core::MetadataStorage> metadata_store
+)
+        : m_data_store(std::move(data_store)),
+          m_metadata_store(std::move(metadata_store)) {}
+
+}  // namespace spider::worker

--- a/src/spider/worker/WorkerClient.cpp
+++ b/src/spider/worker/WorkerClient.cpp
@@ -1,12 +1,39 @@
 #include "WorkerClient.hpp"
 
+#include <optional>
+
+#include <boost/uuid/uuid.hpp>
+
+#include "../core/Task.hpp"
+#include "../io/MsgPack.hpp"  // IWYU pragma: keep
+#include "../io/msgpack_message.hpp"
+#include "../scheduler/SchedulerMessage.hpp"
+#include "../storage/DataStorage.hpp"
+#include "../storage/MetadataStorage.hpp"
+
 namespace spider::worker {
 
 WorkerClient::WorkerClient(
+        boost::uuids::uuid const worker_id,
+        std::string worker_addr,
         std::shared_ptr<core::DataStorage> data_store,
         std::shared_ptr<core::MetadataStorage> metadata_store
 )
-        : m_data_store(std::move(data_store)),
+        : m_worker_id{worker_id},
+          m_worker_addr{std::move(worker_addr)},
+          m_data_store(std::move(data_store)),
           m_metadata_store(std::move(metadata_store)) {}
+
+auto WorkerClient::task_finish(
+        core::TaskInstance const& instance,
+        std::vector<std::variant<std::string, boost::uuids::uuid>> const& outputs
+) -> std::optional<boost::uuids::uuid> {
+    m_metadata_store->task_finish(instance);
+
+    scheduler::ScheduleTaskRequest const request{m_worker_id, m_worker_addr};
+    msgpack::sbuffer request_buffer;
+    msgpack::pack(request_buffer, request);
+    return std::nullopt;
+}
 
 }  // namespace spider::worker

--- a/src/spider/worker/WorkerClient.cpp
+++ b/src/spider/worker/WorkerClient.cpp
@@ -1,16 +1,18 @@
 #include "WorkerClient.hpp"
 
+#include <algorithm>
 #include <memory>
 #include <optional>
+#include <random>
 #include <string>
 #include <utility>
-#include <variant>
 #include <vector>
 
 #include <boost/uuid/uuid.hpp>
 
 #include "../core/Task.hpp"
 #include "../io/MsgPack.hpp"  // IWYU pragma: keep
+#include "../io/msgpack_message.hpp"
 #include "../scheduler/SchedulerMessage.hpp"
 #include "../storage/DataStorage.hpp"
 #include "../storage/MetadataStorage.hpp"
@@ -34,10 +36,55 @@ auto WorkerClient::task_finish(
 ) -> std::optional<boost::uuids::uuid> {
     m_metadata_store->task_finish(instance, outputs);
 
-    scheduler::ScheduleTaskRequest const request{m_worker_id, m_worker_addr};
-    msgpack::sbuffer request_buffer;
-    msgpack::pack(request_buffer, request);
-    return std::nullopt;
+    // Get schedulers
+    std::vector<core::Scheduler> schedulers;
+    if (!m_metadata_store->get_active_scheduler(&schedulers).success()) {
+        return std::nullopt;
+    }
+    std::default_random_engine rng;
+    std::ranges::shuffle(schedulers, rng);
+
+    std::vector<boost::asio::ip::tcp::endpoint> endpoints;
+    std::ranges::transform(
+            schedulers,
+            std::back_inserter(endpoints),
+            [](core::Scheduler const& scheduler) {
+                return boost::asio::ip::tcp::endpoint{
+                        boost::asio::ip::make_address(scheduler.get_addr()),
+                        static_cast<unsigned short>(scheduler.get_port())
+                };
+            }
+    );
+    try {
+        // Create socket to scheduler
+        boost::asio::ip::tcp::socket socket(m_context);
+        boost::asio::connect(socket, endpoints);
+
+        scheduler::ScheduleTaskRequest const request{m_worker_id, m_worker_addr};
+        msgpack::sbuffer request_buffer;
+        msgpack::pack(request_buffer, request);
+
+        core::send_message(socket, request_buffer);
+
+        // Receive response
+        std::optional<msgpack::sbuffer> const optional_response_buffer
+                = core::receive_message(socket);
+        if (!optional_response_buffer.has_value()) {
+            return std::nullopt;
+        }
+        msgpack::sbuffer const& response_buffer = optional_response_buffer.value();
+
+        scheduler::ScheduleTaskResponse response;
+        msgpack::object_handle const response_handle
+                = msgpack::unpack(response_buffer.data(), response_buffer.size());
+        response_handle.get().convert(response);
+
+        return response.get_task_id();
+    } catch (boost::system::system_error const& e) {
+        return std::nullopt;
+    } catch (msgpack::unpack_error const& e) {
+        return std::nullopt;
+    }
 }
 
 }  // namespace spider::worker

--- a/src/spider/worker/WorkerClient.cpp
+++ b/src/spider/worker/WorkerClient.cpp
@@ -30,9 +30,9 @@ WorkerClient::WorkerClient(
 
 auto WorkerClient::task_finish(
         core::TaskInstance const& instance,
-        std::vector<std::variant<std::string, boost::uuids::uuid>> const& outputs
+        std::vector<core::TaskOutput> const& outputs
 ) -> std::optional<boost::uuids::uuid> {
-    m_metadata_store->task_finish(instance);
+    m_metadata_store->task_finish(instance, outputs);
 
     scheduler::ScheduleTaskRequest const request{m_worker_id, m_worker_addr};
     msgpack::sbuffer request_buffer;

--- a/src/spider/worker/WorkerClient.cpp
+++ b/src/spider/worker/WorkerClient.cpp
@@ -49,6 +49,10 @@ auto WorkerClient::get_next_task() -> std::optional<boost::uuids::uuid> {
     if (!m_metadata_store->get_active_scheduler(&schedulers).success()) {
         return std::nullopt;
     }
+    if (schedulers.empty()) {
+        return std::nullopt;
+    }
+
     std::random_device random_device;
     std::default_random_engine rng{random_device()};
     std::ranges::shuffle(schedulers, rng);

--- a/src/spider/worker/WorkerClient.hpp
+++ b/src/spider/worker/WorkerClient.hpp
@@ -5,9 +5,11 @@
 #include <optional>
 #include <string>
 #include <variant>
+#include <vector>
 
 #include <boost/uuid/uuid.hpp>
 
+#include "../core/Task.hpp"
 #include "../io/BoostAsio.hpp"  // IWYU pragma: keep
 #include "../storage/DataStorage.hpp"
 #include "../storage/MetadataStorage.hpp"

--- a/src/spider/worker/WorkerClient.hpp
+++ b/src/spider/worker/WorkerClient.hpp
@@ -4,7 +4,6 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <variant>
 #include <vector>
 
 #include <boost/uuid/uuid.hpp>
@@ -33,7 +32,7 @@ public:
 
     auto task_finish(
             core::TaskInstance const& instance,
-            std::vector<std::variant<std::string, boost::uuids::uuid>> const& outputs
+            std::vector<core::TaskOutput> const& outputs
     ) -> std::optional<boost::uuids::uuid>;
 
 private:

--- a/src/spider/worker/WorkerClient.hpp
+++ b/src/spider/worker/WorkerClient.hpp
@@ -1,0 +1,42 @@
+#ifndef SPIDER_WORKER_WORKERCLIENT_HPP
+#define SPIDER_WORKER_WORKERCLIENT_HPP
+
+#include <future>
+#include <memory>
+#include <string>
+#include <variant>
+
+#include <boost/uuid/uuid.hpp>
+
+#include "../io/BoostAsio.hpp"  // IWYU pragma: keep
+#include "../storage/DataStorage.hpp"
+#include "../storage/MetadataStorage.hpp"
+
+namespace spider::worker {
+class WorkerClient {
+public:
+    // Delete copy & move constructors and assignment operators
+    WorkerClient(WorkerClient const&) = delete;
+    auto operator=(WorkerClient const&) -> WorkerClient& = delete;
+    WorkerClient(WorkerClient&&) = delete;
+    auto operator=(WorkerClient&&) -> WorkerClient& = delete;
+    ~WorkerClient() = default;
+
+    WorkerClient(
+            std::shared_ptr<core::DataStorage> data_store,
+            std::shared_ptr<core::MetadataStorage> metadata_store
+    );
+
+    auto task_finish(
+            core::TaskInstance const& instance,
+            std::vector<std::variant<std::string, boost::uuids::uuid>> const& outputs
+    ) -> std::future<boost::uuids::uuid>;
+
+private:
+    boost::asio::io_context m_context;
+
+    std::shared_ptr<core::DataStorage> m_data_store;
+    std::shared_ptr<core::MetadataStorage> m_metadata_store;
+};
+}  // namespace spider::worker
+#endif  // SPIDER_WORKER_WORKERCLIENT_HPP

--- a/src/spider/worker/WorkerClient.hpp
+++ b/src/spider/worker/WorkerClient.hpp
@@ -35,6 +35,8 @@ public:
             std::vector<core::TaskOutput> const& outputs
     ) -> std::optional<boost::uuids::uuid>;
 
+    auto get_next_task() -> std::optional<boost::uuids::uuid>;
+
 private:
     boost::uuids::uuid m_worker_id;
     std::string m_worker_addr;

--- a/src/spider/worker/WorkerClient.hpp
+++ b/src/spider/worker/WorkerClient.hpp
@@ -1,8 +1,8 @@
 #ifndef SPIDER_WORKER_WORKERCLIENT_HPP
 #define SPIDER_WORKER_WORKERCLIENT_HPP
 
-#include <future>
 #include <memory>
+#include <optional>
 #include <string>
 #include <variant>
 
@@ -23,6 +23,8 @@ public:
     ~WorkerClient() = default;
 
     WorkerClient(
+            boost::uuids::uuid worker_id,
+            std::string worker_addr,
             std::shared_ptr<core::DataStorage> data_store,
             std::shared_ptr<core::MetadataStorage> metadata_store
     );
@@ -30,9 +32,12 @@ public:
     auto task_finish(
             core::TaskInstance const& instance,
             std::vector<std::variant<std::string, boost::uuids::uuid>> const& outputs
-    ) -> std::future<boost::uuids::uuid>;
+    ) -> std::optional<boost::uuids::uuid>;
 
 private:
+    boost::uuids::uuid m_worker_id;
+    std::string m_worker_addr;
+
     boost::asio::io_context m_context;
 
     std::shared_ptr<core::DataStorage> m_data_store;

--- a/tests/scheduler/test-SchedulerPolicy.cpp
+++ b/tests/scheduler/test-SchedulerPolicy.cpp
@@ -13,6 +13,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "../../src/spider/core/Data.hpp"
+#include "../../src/spider/core/Driver.hpp"
 #include "../../src/spider/core/Task.hpp"
 #include "../../src/spider/core/TaskGraph.hpp"
 #include "../../src/spider/scheduler/FifoPolicy.hpp"
@@ -89,7 +90,7 @@ TEMPLATE_LIST_TEST_CASE(
     spider::core::Data data{"value"};
     data.set_hard_locality(true);
     data.set_locality({"127.0.0.1"});
-    REQUIRE(metadata_store->add_driver(client_id, "127.0.0.1").success());
+    REQUIRE(metadata_store->add_driver(spider::core::Driver{client_id, "127.0.0.1"}).success());
     REQUIRE(data_store->add_driver_data(client_id, data).success());
     task.add_input(spider::core::TaskInput{data.get_id(), "int"});
     spider::core::TaskGraph graph;
@@ -134,7 +135,7 @@ TEMPLATE_LIST_TEST_CASE(
     spider::core::Data data;
     data.set_hard_locality(false);
     data.set_locality({"127.0.0.1"});
-    REQUIRE(metadata_store->add_driver(client_id, "127.0.0.1").success());
+    REQUIRE(metadata_store->add_driver(spider::core::Driver{client_id, "127.0.0.1"}).success());
     REQUIRE(data_store->add_driver_data(client_id, data).success());
     task.add_input(spider::core::TaskInput{data.get_id(), "int"});
     spider::core::TaskGraph graph;

--- a/tests/storage/test-DataStorage.cpp
+++ b/tests/storage/test-DataStorage.cpp
@@ -7,6 +7,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "../../src/spider/core/Data.hpp"
+#include "../../src/spider/core/Driver.hpp"
 #include "../../src/spider/core/Error.hpp"
 #include "../../src/spider/core/KeyValueData.hpp"
 #include "../../src/spider/core/Task.hpp"
@@ -24,7 +25,7 @@ TEMPLATE_LIST_TEST_CASE("Add, get and remove data", "[storage]", spider::test::S
     spider::core::Data const data{"value"};
     boost::uuids::random_generator gen;
     boost::uuids::uuid const driver_id = gen();
-    REQUIRE(metadata_storage->add_driver(driver_id, "127.0.0.1").success());
+    REQUIRE(metadata_storage->add_driver(spider::core::Driver{driver_id, "127.0.0.1"}).success());
     REQUIRE(data_storage->add_driver_data(driver_id, data).success());
 
     // Add data with same id again should fail
@@ -56,7 +57,7 @@ TEMPLATE_LIST_TEST_CASE(
     // Add driver
     boost::uuids::random_generator gen;
     boost::uuids::uuid const driver_id = gen();
-    REQUIRE(metadata_storage->add_driver(driver_id, "127.0.0.1").success());
+    REQUIRE(metadata_storage->add_driver(spider::core::Driver{driver_id, "127.0.0.1"}).success());
 
     // Add data
     spider::core::KeyValueData const data{"key", "value", driver_id};
@@ -170,8 +171,8 @@ TEMPLATE_LIST_TEST_CASE(
     // Add driver
     boost::uuids::uuid const driver_id = gen();
     boost::uuids::uuid const driver_id_2 = gen();
-    REQUIRE(metadata_storage->add_driver(driver_id, "127.0.0.1").success());
-    REQUIRE(metadata_storage->add_driver(driver_id_2, "127.0.0.1").success());
+    REQUIRE(metadata_storage->add_driver(spider::core::Driver{driver_id, "127.0.0.1"}).success());
+    REQUIRE(metadata_storage->add_driver(spider::core::Driver{driver_id_2, "127.0.0.1"}).success());
 
     // Add driver reference without data should fail
     REQUIRE(!data_storage->add_driver_reference(gen(), driver_id).success());

--- a/tests/storage/test-MetadataStorage.cpp
+++ b/tests/storage/test-MetadataStorage.cpp
@@ -12,6 +12,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include "../../src/spider/core/Driver.hpp"
 #include "../../src/spider/core/Error.hpp"
 #include "../../src/spider/core/JobMetadata.hpp"
 #include "../../src/spider/core/Task.hpp"
@@ -31,7 +32,7 @@ TEMPLATE_LIST_TEST_CASE("Driver heartbeat", "[storage]", spider::test::MetadataS
     // Add driver should succeed
     boost::uuids::random_generator gen;
     boost::uuids::uuid const driver_id = gen();
-    REQUIRE(storage->add_driver(driver_id, "127.0.0.1").success());
+    REQUIRE(storage->add_driver(spider::core::Driver{driver_id, "127.0.0.1"}).success());
 
     std::string addr;
     REQUIRE(storage->get_driver(driver_id, &addr).success());
@@ -77,7 +78,8 @@ TEMPLATE_LIST_TEST_CASE(
     constexpr int cPort = 3306;
 
     // Add scheduler should succeed
-    REQUIRE(storage->add_driver(scheduler_id, "127.0.0.1", cPort).success());
+    REQUIRE(storage->add_scheduler(spider::core::Scheduler{scheduler_id, "127.0.0.1", cPort})
+                    .success());
 
     // Get scheduler addr should succeed
     std::string addr_res;


### PR DESCRIPTION
# Description
Add get normal schedulers in metadata storage. Add logic to update outputs, update dependent tasks inputs and states in metadata storage `task_finish`. Add worker client that submit tasks and get next task from scheduler.


# Validation performed
- [x] GitHub workflows pass
- [x] Unit tests for metadata storage in devcontainer 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `Driver` and `Scheduler` classes for enhanced task and driver management.
	- Added functionality to manage task completion and retrieval of active schedulers.
	- New test case for task completion handling.

- **Bug Fixes**
	- Updated method signatures for adding drivers and schedulers to improve encapsulation.

- **Tests**
	- Refactored test cases to utilize `Driver` and `Scheduler` objects.
	- Added new test case for verifying task completion functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->