### PR TITLE
feat: Add scheduler that schedules tasks and garbage collect periodically

### DIFF
--- a/src/spider/CMakeLists.txt
+++ b/src/spider/CMakeLists.txt
@@ -99,6 +99,7 @@ set(SPIDER_SCHEDULER_SOURCES
     scheduler/SchedulerMessage.hpp
     scheduler/SchedulerServer.cpp
     scheduler/SchedulerServer.hpp
+    utils/StopToken.hpp
     CACHE INTERNAL
     "spider scheduler source files"
 )
@@ -110,6 +111,7 @@ target_link_libraries(
     spider_scheduler
     PRIVATE
         Boost::headers
+        Boost::program_options
         absl::flat_hash_map
         spdlog::spdlog
 )

--- a/src/spider/io/BoostAsio.hpp
+++ b/src/spider/io/BoostAsio.hpp
@@ -1,6 +1,8 @@
 #ifndef SPIDER_CORE_BOOSTASIO_HPP
 #define SPIDER_CORE_BOOSTASIO_HPP
 
+#include <optional>
+
 // clang-format off
 // IWYU pragma: begin_exports
 
@@ -20,6 +22,7 @@
 
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/ip/address.hpp>
+#include <boost/asio/ip/host_name.hpp>
 #include <boost/asio/impl/connect.hpp>
 
 #include <boost/asio/detached.hpp>
@@ -27,6 +30,7 @@
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/use_awaitable.hpp>
 #include <boost/asio/use_future.hpp>
+#include <boost/asio/executor_work_guard.hpp>
 
 #include <boost/asio/impl/write.hpp>
 #include <boost/asio/impl/read.hpp>
@@ -35,4 +39,36 @@
 
 // IWYU pragma: end_exports
 // clang-format on
+
+#include <string>
+
+#include <spdlog/spdlog.h>
+
+namespace spider::core {
+inline auto get_address() -> std::optional<std::string> {
+    try {
+        boost::asio::io_context io_context;
+        boost::asio::ip::tcp::resolver resolver(io_context);
+        auto const endpoints = resolver.resolve(boost::asio::ip::host_name(), "");
+        for (auto const& endpoint : endpoints) {
+            if (endpoint.endpoint().address().is_v4()
+                && !endpoint.endpoint().address().is_loopback())
+            {
+                return endpoint.endpoint().address().to_string();
+            }
+        }
+        // If no non-loopback address found, return loopback address
+        spdlog::warn("No non-loopback address found, using loopback address");
+        for (auto const& endpoint : endpoints) {
+            if (endpoint.endpoint().address().is_v4()) {
+                return endpoint.endpoint().address().to_string();
+            }
+        }
+        return std::nullopt;
+    } catch (boost::system::system_error const& e) {
+        return std::nullopt;
+    }
+}
+}  // namespace spider::core
+
 #endif  // SPIDER_CORE_BOOSTASIO_HPP

--- a/src/spider/io/Serializer.hpp
+++ b/src/spider/io/Serializer.hpp
@@ -41,12 +41,15 @@ struct msgpack::adaptor::pack<boost::uuids::uuid> {
     }
 };
 
-template <class T>
-concept SerializableImpl = requires(T t) {
+template <class Buffer, class T>
+concept Packable = requires(Buffer buffer, T t) {
     {
-        msgpack::pack(msgpack::sbuffer{}, t)
+        msgpack::pack(buffer, t)
     };
 };
+
+template <class T>
+concept SerializableImpl = Packable<msgpack::sbuffer, T>;
 
 template <class T>
 concept DeSerializableImpl = requires(T t) {

--- a/src/spider/scheduler/SchedulerServer.cpp
+++ b/src/spider/scheduler/SchedulerServer.cpp
@@ -4,6 +4,7 @@
 #include <mutex>
 #include <optional>
 #include <stdexcept>
+#include <thread>
 #include <utility>
 
 #include <boost/uuid/uuid.hpp>
@@ -16,6 +17,7 @@
 #include "../io/Serializer.hpp"  // IWYU pragma: keep
 #include "../storage/DataStorage.hpp"
 #include "../storage/MetadataStorage.hpp"
+#include "../utils/StopToken.hpp"
 #include "SchedulerMessage.hpp"
 #include "SchedulerPolicy.hpp"
 
@@ -25,47 +27,75 @@ SchedulerServer::SchedulerServer(
         unsigned short const port,
         std::shared_ptr<SchedulerPolicy> policy,
         std::shared_ptr<core::MetadataStorage> metadata_store,
-        std::shared_ptr<core::DataStorage> data_store
+        std::shared_ptr<core::DataStorage> data_store,
+        core::StopToken& stop_token
 )
-        : m_acceptor{m_context, {boost::asio::ip::tcp::v4(), port}},
+        : m_port{port},
           m_policy{std::move(policy)},
           m_metadata_store{std::move(metadata_store)},
-          m_data_store{std::move(data_store)} {
-    // Ignore the returned future as we do not need its value
-    boost::asio::co_spawn(m_context, receive_message(), boost::asio::use_future);
+          m_data_store{std::move(data_store)},
+          m_stop_token{stop_token} {
+    boost::asio::co_spawn(m_context, receive_message(), boost::asio::detached);
+    std::lock_guard const lock{m_mutex};
+    m_thread = std::make_unique<std::thread>([&] { m_context.run(); });
 }
 
-auto SchedulerServer::run() -> void {
-    m_context.run();
+auto SchedulerServer::pause() -> void {
+    std::lock_guard const lock{m_mutex};
+    if (m_thread == nullptr) {
+        return;
+    }
+    m_context.stop();
+    m_thread->join();
+    m_thread = nullptr;
+}
+
+auto SchedulerServer::resume() -> void {
+    std::lock_guard const lock{m_mutex};
+    if (m_thread != nullptr) {
+        return;
+    }
+    m_thread = std::make_unique<std::thread>([&] {
+        m_context.restart();
+        m_context.run();
+    });
 }
 
 auto SchedulerServer::stop() -> void {
-    m_context.stop();
     std::lock_guard const lock{m_mutex};
-    m_stop = true;
+    if (m_thread == nullptr) {
+        return;
+    }
+    m_context.stop();
+    m_thread->join();
+    m_thread = nullptr;
 }
 
 auto SchedulerServer::receive_message() -> boost::asio::awaitable<void> {
-    while (!should_stop()) {
-        // std::unique_ptr<boost::asio::ip::tcp::socket> socket
-        //         = std::make_unique<boost::asio::ip::tcp::socket>(m_context);
-        boost::asio::ip::tcp::socket socket{m_context};
-        auto const& [ec] = co_await m_acceptor.async_accept(
-                socket,
-                boost::asio::as_tuple(boost::asio::use_awaitable)
-        );
-        if (ec) {
-            spdlog::error("Cannot accept connection {}: {}", ec.value(), ec.what());
-            continue;
+    try {
+        boost::asio::ip::tcp::acceptor acceptor{m_context, {boost::asio::ip::tcp::v4(), m_port}};
+        while (true) {
+            boost::asio::ip::tcp::socket socket{m_context};
+            auto const& [ec] = co_await acceptor.async_accept(
+                    socket,
+                    boost::asio::as_tuple(boost::asio::use_awaitable)
+            );
+            if (ec) {
+                spdlog::error("Cannot accept connection {}: {}", ec.value(), ec.what());
+                continue;
+            }
+            boost::asio::co_spawn(
+                    m_context,
+                    process_message(std::move(socket)),
+                    boost::asio::detached
+            );
         }
-        // Ignore the returned future as we do not need its value
-        boost::asio::co_spawn(
-                m_context,
-                process_message(std::move(socket)),
-                boost::asio::use_future
-        );
+        co_return;
+    } catch (boost::system::system_error& e) {
+        spdlog::error("Fail to accept connection: {}", e.what());
+        m_stop_token.request_stop();
+        co_return;
     }
-    co_return;
 }
 
 namespace {
@@ -123,11 +153,6 @@ auto SchedulerServer::process_message(boost::asio::ip::tcp::socket socket
         );
     }
     co_return;
-}
-
-auto SchedulerServer::should_stop() -> bool {
-    std::lock_guard const lock{m_mutex};
-    return m_stop;
 }
 
 }  // namespace spider::scheduler

--- a/src/spider/scheduler/scheduler.cpp
+++ b/src/spider/scheduler/scheduler.cpp
@@ -1,2 +1,237 @@
 
-auto main(int argc, char** argv) -> int {}
+#include <chrono>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <system_error>
+#include <thread>
+
+#include <boost/any/bad_any_cast.hpp>
+#include <boost/program_options/errors.hpp>
+#include <boost/program_options/options_description.hpp>
+#include <boost/program_options/parsers.hpp>
+#include <boost/program_options/value_semantic.hpp>
+#include <boost/program_options/variables_map.hpp>
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid.hpp>
+#include <spdlog/sinks/stdout_color_sinks.h>  // IWYU pragma: keep
+#include <spdlog/spdlog.h>
+
+#include "../core/Driver.hpp"
+#include "../core/Error.hpp"
+#include "../io/BoostAsio.hpp"  // IWYU pragma: keep
+#include "../storage/DataStorage.hpp"
+#include "../storage/MetadataStorage.hpp"
+#include "../storage/MysqlStorage.hpp"
+#include "../utils/StopToken.hpp"
+#include "FifoPolicy.hpp"
+#include "SchedulerPolicy.hpp"
+#include "SchedulerServer.hpp"
+
+constexpr int cCmdArgParseErr = 1;
+constexpr int cStorageConnectionErr = 2;
+constexpr int cSchedulerAddrErr = 3;
+constexpr int cStorageErr = 4;
+
+constexpr int cCleanupInterval = 5;
+constexpr int cRetryCount = 5;
+
+namespace {
+auto parse_args(int const argc, char** argv) -> boost::program_options::variables_map {
+    boost::program_options::options_description desc;
+    desc.add_options()("help", "spider scheduler");
+    desc.add_options()(
+            "port",
+            boost::program_options::value<unsigned short>(),
+            "port to listen on"
+    );
+    desc.add_options()(
+            "storage_url",
+            boost::program_options::value<std::string>(),
+            "storage server url"
+    );
+
+    boost::program_options::variables_map variables;
+    boost::program_options::store(
+            // NOLINTNEXTLINE(misc-include-cleaner)
+            boost::program_options::parse_command_line(argc, argv, desc),
+            variables
+    );
+    boost::program_options::notify(variables);
+    return variables;
+}
+
+auto heartbeat_loop(
+        std::shared_ptr<spider::core::MetadataStorage> const& metadata_store,
+        spider::core::Scheduler const& scheduler,
+        spider::core::StopToken& stop_token
+) -> void {
+    int fail_count = 0;
+    while (!stop_token.stop_requested()) {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        spdlog::debug("Updating heartbeat");
+        spider::core::StorageErr const err = metadata_store->update_heartbeat(scheduler.get_id());
+        if (!err.success()) {
+            spdlog::error("Failed to update scheduler heartbeat: {}", err.description);
+            fail_count++;
+        } else {
+            fail_count = 0;
+        }
+        if (fail_count >= cRetryCount - 1) {
+            stop_token.request_stop();
+            break;
+        }
+    }
+}
+
+auto cleanup_loop(
+        std::shared_ptr<spider::core::MetadataStorage> const& metadata_store,
+        std::shared_ptr<spider::core::DataStorage> const& data_store,
+        spider::scheduler::SchedulerServer& server,
+        std::shared_ptr<spider::scheduler::SchedulerPolicy> const& policy,
+        spider::core::Scheduler const& scheduler,
+        spider::core::StopToken& stop_token
+) -> void {
+    while (!stop_token.stop_requested()) {
+        std::this_thread::sleep_for(std::chrono::seconds(cCleanupInterval));
+        spdlog::debug("Starting cleanup");
+        spider::core::StorageErr err
+                = metadata_store->set_scheduler_state(scheduler.get_id(), "gc");
+        if (!err.success()) {
+            spdlog::error("Failed to set scheduler state to gc: {}", err.description);
+            continue;
+        }
+        server.pause();
+        policy->cleanup();
+        data_store->remove_dangling_data();
+        server.resume();
+        for (size_t i = 0; i < cRetryCount; ++i) {
+            err = metadata_store->set_scheduler_state(scheduler.get_id(), "normal");
+            if (!err.success()) {
+                spdlog::error("Failed to set scheduler state to normal: {}", err.description);
+                if (i >= cRetryCount - 1) {
+                    stop_token.request_stop();
+                    return;
+                }
+            } else {
+                break;
+            }
+        }
+        spdlog::debug("Finished cleanup");
+    }
+}
+}  // namespace
+
+// NOLINTNEXTLINE(bugprone-exception-escape)
+auto main(int argc, char** argv) -> int {
+    // Set up spdlog to write to stderr
+    // NOLINTNEXTLINE(misc-include-cleaner)
+    spdlog::set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%^%l%$] [spider][scheduler] %v");
+#ifndef NDEBUG
+    spdlog::set_level(spdlog::level::trace);
+#endif
+
+    boost::program_options::variables_map const args = parse_args(argc, argv);
+
+    unsigned short port = 0;
+    std::string storage_url;
+    try {
+        if (!args.contains("port")) {
+            spdlog::error("port is required");
+            return cCmdArgParseErr;
+        }
+        port = args["port"].as<unsigned short>();
+        if (!args.contains("storage_url")) {
+            spdlog::error("storage_url is required");
+            return cCmdArgParseErr;
+        }
+        storage_url = args["storage_url"].as<std::string>();
+    } catch (boost::bad_any_cast& e) {
+        return cCmdArgParseErr;
+    } catch (boost::program_options::error& e) {
+        return cCmdArgParseErr;
+    }
+
+    // Create storages
+    std::shared_ptr<spider::core::MetadataStorage> const metadata_store
+            = std::make_shared<spider::core::MySqlMetadataStorage>();
+    spider::core::StorageErr err = metadata_store->connect(storage_url);
+    if (!err.success()) {
+        spdlog::error("Failed to connect to storage server: {}", err.description);
+        return cStorageConnectionErr;
+    }
+    std::shared_ptr<spider::core::DataStorage> const data_store
+            = std::make_shared<spider::core::MySqlDataStorage>();
+    err = data_store->connect(storage_url);
+    if (!err.success()) {
+        spdlog::error("Failed to connect to storage server: {}", err.description);
+        return cStorageConnectionErr;
+    }
+
+    // Initialize storages
+    err = metadata_store->initialize();
+    if (!err.success()) {
+        spdlog::error("Failed to initialize metadata storage: {}", err.description);
+        return cStorageErr;
+    }
+    err = data_store->initialize();
+    if (!err.success()) {
+        spdlog::error("Failed to initialize data storage: {}", err.description);
+        return cStorageErr;
+    }
+
+    // Get scheduler id and addr
+    boost::uuids::random_generator gen;
+    boost::uuids::uuid const scheduler_id = gen();
+    std::optional<std::string> const optional_scheduler_addr = spider::core::get_address();
+    if (!optional_scheduler_addr.has_value()) {
+        spdlog::error("Failed to get scheduler address");
+        return cSchedulerAddrErr;
+    }
+    std::string const& scheduler_addr = optional_scheduler_addr.value();
+
+    // Start scheduler server
+    spider::core::StopToken stop_token;
+    std::shared_ptr<spider::scheduler::SchedulerPolicy> const policy
+            = std::make_shared<spider::scheduler::FifoPolicy>();
+    spider::scheduler::SchedulerServer server{port, policy, metadata_store, data_store, stop_token};
+
+    // Register scheduler with storage
+    spider::core::Scheduler const scheduler{scheduler_id, scheduler_addr, port};
+    err = metadata_store->add_scheduler(scheduler);
+    if (!err.success()) {
+        spdlog::error("Failed to register scheduler with storage server: {}", err.description);
+        return cStorageErr;
+    }
+
+    try {
+        // Start a thread that periodically updates the scheduler's heartbeat
+        std::thread heartbeat_thread{
+                heartbeat_loop,
+                std::cref(metadata_store),
+                std::ref(scheduler),
+                std::ref(stop_token),
+        };
+
+        // Start a thread that periodically starts cleanup
+        std::thread cleanup_thread{
+                cleanup_loop,
+                std::cref(metadata_store),
+                std::cref(data_store),
+                std::ref(server),
+                std::cref(policy),
+                std::cref(scheduler),
+                std::ref(stop_token)
+        };
+
+        heartbeat_thread.join();
+        cleanup_thread.join();
+        server.stop();
+    } catch (std::system_error& e) {
+        spdlog::error("Failed to join thread: {}", e.what());
+    }
+
+    return 0;
+}

--- a/src/spider/utils/StopToken.hpp
+++ b/src/spider/utils/StopToken.hpp
@@ -1,0 +1,22 @@
+#ifndef SPIDER_UTILS_STOPTOKEN_HPP
+#define SPIDER_UTILS_STOPTOKEN_HPP
+
+#include <atomic>
+
+namespace spider::core {
+class StopToken {
+public:
+    StopToken() : m_stop{false} {}
+
+    auto request_stop() -> void { m_stop = true; }
+
+    [[nodiscard]] auto stop_requested() const -> bool { return m_stop; }
+
+    auto reset() -> void { m_stop = false; }
+
+private:
+    std::atomic<bool> m_stop;
+};
+}  // namespace spider::core
+
+#endif


### PR DESCRIPTION
# Description
As title. Scheduler also send heartbeat message to storage periodcially.


# Validation performed
- [x] GitHub workflows pass.
- [x] All unit tests pass in devcontainer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `StopToken` class for managing stop signals in a thread-safe manner.
	- Added methods for pausing and resuming the `SchedulerServer`.
	- Implemented new functionality for retrieving the local machine's IP address.
	- Enhanced command-line argument parsing and logging in the main application.

- **Bug Fixes**
	- Improved error handling and logging in the `SchedulerServer` and heartbeat processes.

- **Documentation**
	- Updated method signatures and class structures to reflect new functionalities.

- **Tests**
	- Streamlined tests for `SchedulerServer` to directly control server state without threading complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->