### PR TITLE
build: Change `CMAKE_SOURCE_DIR` to `PROJECT_SOURCE_DIR`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,12 +35,12 @@ endif()
 # Add local CMake module directory to CMake's modules path
 set(CMAKE_MODULE_PATH
     ${CMAKE_MODULE_PATH}
-    "${CMAKE_SOURCE_DIR}/cmake/Modules/"
+    "${PROJECT_SOURCE_DIR}/cmake/Modules/"
 )
 
 # Macro providing the length of the absolute source directory path so we can
 # create a relative (rather than absolute) __FILE__ macro
-string(LENGTH "${CMAKE_SOURCE_DIR}/" SOURCE_PATH_SIZE)
+string(LENGTH "${PROJECT_SOURCE_DIR}/" SOURCE_PATH_SIZE)
 add_definitions("-DSOURCE_PATH_SIZE=${SOURCE_PATH_SIZE}")
 
 # Profiling options


### PR DESCRIPTION
# Description
We use `CMAKE_SOURCE_DIR` in `CMakeLists.txt` to get the top level source directory. However, when the project is added as a sub directory in another project, then `CMAKE_SOURCE_DIR` refer to the outer project source directory, instead of the top level source directory of the inner project we want, which is represented by `PROJECT_SOURCE_DIR` macro.


# Validation performed
- [x] GitHub workflows pass
- [x] Unit tests pass in dev container
- [x] Integration tests pass in dev container
- [x] Add project as sub directory builds and compiles


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated CMake configuration to use consistent source directory path references
	- Improved project build system configuration for better maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->