### PR TITLE
build: Add headers specification in CMakeLists.txt and remove spdlog in public headers

### DIFF
--- a/src/spider/CMakeLists.txt
+++ b/src/spider/CMakeLists.txt
@@ -32,7 +32,14 @@ set(SPIDER_CORE_HEADERS
 
 add_library(spider_core)
 target_sources(spider_core PRIVATE ${SPIDER_CORE_SOURCES})
-target_sources(spider_core PUBLIC ${SPIDER_CORE_HEADERS})
+target_sources(
+    spider_core
+    PUBLIC
+        FILE_SET spider_core_headers
+        TYPE HEADERS
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/..
+        FILES ${SPIDER_CORE_HEADERS}
+)
 target_link_libraries(
     spider_core
     PUBLIC
@@ -150,7 +157,14 @@ set(SPIDER_CLIENT_SHARED_HEADERS
 
 add_library(spider_client)
 target_sources(spider_client PRIVATE ${SPIDER_CLIENT_SHARED_SOURCES})
-target_sources(spider_client PUBLIC ${SPIDER_CLIENT_SHARED_HEADERS})
+target_sources(
+    spider_client
+    PUBLIC
+        FILE_SET spider_client_shared_headers
+        TYPE HEADERS
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/..
+        FILES ${SPIDER_CLIENT_SHARED_HEADERS}
+)
 target_link_libraries(
     spider_client
     PUBLIC

--- a/src/spider/worker/FunctionManager.cpp
+++ b/src/spider/worker/FunctionManager.cpp
@@ -1,8 +1,11 @@
 #include "FunctionManager.hpp"
 
+#include <cstddef>
 #include <optional>
 #include <string>
 #include <tuple>
+#include <type_traits>
+#include <vector>
 
 #include <boost/dll/alias.hpp>
 #include <spdlog/spdlog.h>

--- a/src/spider/worker/FunctionManager.hpp
+++ b/src/spider/worker/FunctionManager.hpp
@@ -16,7 +16,6 @@
 #include <absl/container/flat_hash_map.h>
 #include <boost/uuid/uuid.hpp>
 #include <fmt/format.h>
-#include <spdlog/spdlog.h>
 
 #include "../client/Data.hpp"
 #include "../client/task.hpp"
@@ -162,43 +161,8 @@ auto response_get_result(msgpack::sbuffer const& buffer) -> std::optional<std::t
     // NOLINTEND(cppcoreguidelines-pro-type-union-access,cppcoreguidelines-pro-bounds-pointer-arithmetic)
 }
 
-inline auto response_get_result_buffers(msgpack::sbuffer const& buffer
-) -> std::optional<std::vector<msgpack::sbuffer>> {
-    // NOLINTBEGIN(cppcoreguidelines-pro-type-union-access,cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    try {
-        std::vector<msgpack::sbuffer> result_buffers;
-        msgpack::object_handle const handle = msgpack::unpack(buffer.data(), buffer.size());
-        msgpack::object const object = handle.get();
-
-        if (msgpack::type::ARRAY != object.type || object.via.array.size < 2) {
-            spdlog::error("Cannot split result into buffers: Wrong type");
-            return std::nullopt;
-        }
-
-        if (worker::TaskExecutorResponseType::Result
-            != object.via.array.ptr[0].as<worker::TaskExecutorResponseType>())
-        {
-            spdlog::error(
-                    "Cannot split result into buffers: Wrong response type {}",
-                    static_cast<std::underlying_type_t<worker::TaskExecutorResponseType>>(
-                            object.via.array.ptr[0].as<worker::TaskExecutorResponseType>()
-                    )
-            );
-            return std::nullopt;
-        }
-
-        for (size_t i = 1; i < object.via.array.size; ++i) {
-            msgpack::object const& obj = object.via.array.ptr[i];
-            result_buffers.emplace_back();
-            msgpack::pack(result_buffers.back(), obj);
-        }
-        return result_buffers;
-    } catch (msgpack::type_error& e) {
-        spdlog::error("Cannot split result into buffers: {}", e.what());
-        return std::nullopt;
-    }
-    // NOLINTEND(cppcoreguidelines-pro-type-union-access,cppcoreguidelines-pro-bounds-pointer-arithmetic)
-}
+auto response_get_result_buffers(msgpack::sbuffer const& buffer
+) -> std::optional<std::vector<msgpack::sbuffer>>;
 
 template <TaskIo T>
 auto create_result_response(T const& t) -> msgpack::sbuffer {

--- a/src/spider/worker/FunctionManager.hpp
+++ b/src/spider/worker/FunctionManager.hpp
@@ -1,7 +1,6 @@
 #ifndef SPIDER_WORKER_FUNCTIONMANAGER_HPP
 #define SPIDER_WORKER_FUNCTIONMANAGER_HPP
 
-#include <cstddef>
 #include <cstdint>
 #include <exception>
 #include <functional>

--- a/tests/worker/worker-test.cpp
+++ b/tests/worker/worker-test.cpp
@@ -4,11 +4,11 @@
 #include <random>
 #include <stdexcept>
 
-#include "../../src/spider/client/Data.hpp"
-#include "../../src/spider/client/Driver.hpp"
-#include "../../src/spider/client/Job.hpp"
-#include "../../src/spider/client/TaskContext.hpp"
-#include "../../src/spider/client/TaskGraph.hpp"
+#include <spider/client/Data.hpp>
+#include <spider/client/Driver.hpp>
+#include <spider/client/Job.hpp>
+#include <spider/client/TaskContext.hpp>
+#include <spider/client/TaskGraph.hpp>
 
 auto sum_test(spider::TaskContext& /*context*/, int const x, int const y) -> int {
     std::cerr << x << " + " << y << " = " << x + y << "\n";

--- a/tests/worker/worker-test.hpp
+++ b/tests/worker/worker-test.hpp
@@ -1,8 +1,8 @@
 #ifndef SPIDER_TEST_WORKER_TEST_HPP
 #define SPIDER_TEST_WORKER_TEST_HPP
 
-#include "../../src/spider/client/Data.hpp"
-#include "../../src/spider/client/TaskContext.hpp"
+#include <spider/client/Data.hpp>
+#include <spider/client/TaskContext.hpp>
 
 auto sum_test(spider::TaskContext& /*context*/, int x, int y) -> int;
 


### PR DESCRIPTION
# Description
As title. Move more functions from `FunctionManager.hpp` to `FunctionManager.cpp` to remove dependencies on `spdlog`.


# Validation performed
- [x] GitHub workflows pass
- [x] Unit tests pass
- [x] Integration tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Build System**
  - Updated CMake configuration to use `FILE_SET` for managing header files in `spider_core` and `spider_client` libraries.
  - Improved header file organization and build system handling.

- **New Features**
  - Added `response_get_result_buffers` function to process message pack buffers with error handling.

- **Code Improvements**
  - Refactored include paths in test files to use absolute paths.
  - Removed inline implementation of `response_get_result_buffers` function.

These changes enhance the project's build process and code structure while maintaining existing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->