### PR TITLE
feat: Add host address as scheduler and worker command line argument

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -146,6 +146,7 @@ To start the scheduler, run:
 build/spider/src/spider/spider_scheduler \
         --storage_url \
         "jdbc:mariadb://localhost:3306/spider-storage?user=spider&password=password" \
+        --host "127.0.0.1" \
         --port 6000
 ```
 
@@ -153,6 +154,7 @@ NOTE:
 
 * If you used a different set of arguments to set up the storage backend, ensure you update the
   `storage_url` argument in the command.
+* In production, change the host to the real IP address of the machine running the scheduler.
 * If the scheduler fails to bind to port `6000`, change the port in the command and try again.
 
 ## Setting up a worker
@@ -169,13 +171,17 @@ To start a worker, run:
 build/spider/src/spider/spider_worker \
         --storage_url \
         "jdbc:mariadb://localhost:3306/spider-storage?user=spider&password=password" \
-        --port 6000
+        --host "127.0.0.1" \
+        --libs "build/libtasks.so"
 ```
 
 NOTE:
 
-If you used a different set of arguments to set up the storage backend, ensure you update the
-`storage_url` argument in the command.
+* If you used a different set of arguments to set up the storage backend, ensure you update the
+  `storage_url` argument in the command.
+* In production, change the host to the real IP address of the machine running the worker.
+* You can specify multiple task libraries to load. The task libraries must be built with linkage
+  to the Spider client library. 
 
 > [!TIP]
 > You can start multiple workers to increase the number of concurrent tasks that can be run on the

--- a/src/spider/client/Driver.cpp
+++ b/src/spider/client/Driver.cpp
@@ -34,12 +34,7 @@ Driver::Driver(std::string const& storage_url) {
         throw ConnectionException(err.description);
     }
 
-    std::optional<std::string> const optional_addr = core::get_address();
-    if (!optional_addr.has_value()) {
-        throw ConnectionException("Cannot get machine address");
-    }
-    std::string const& addr = optional_addr.value();
-    err = m_metadata_storage->add_driver(core::Driver{m_id, addr});
+    err = m_metadata_storage->add_driver(core::Driver{m_id});
     if (!err.success()) {
         if (core::StorageErrType::DuplicateKeyErr == err.type) {
             throw DriverIdInUseException(m_id);
@@ -72,12 +67,7 @@ Driver::Driver(std::string const& storage_url, boost::uuids::uuid const id) : m_
         throw ConnectionException(err.description);
     }
 
-    std::optional<std::string> const optional_addr = core::get_address();
-    if (!optional_addr.has_value()) {
-        throw ConnectionException("Cannot get machine address");
-    }
-    std::string const& addr = optional_addr.value();
-    err = m_metadata_storage->add_driver(core::Driver{m_id, addr});
+    err = m_metadata_storage->add_driver(core::Driver{m_id});
     if (!err.success()) {
         if (core::StorageErrType::DuplicateKeyErr == err.type) {
             throw DriverIdInUseException(m_id);

--- a/src/spider/core/Driver.hpp
+++ b/src/spider/core/Driver.hpp
@@ -10,15 +10,12 @@ namespace spider::core {
 
 class Driver {
 public:
-    Driver(boost::uuids::uuid const id, std::string addr) : m_id{id}, m_addr{std::move(addr)} {}
+    explicit Driver(boost::uuids::uuid const id) : m_id{id} {}
 
     [[nodiscard]] auto get_id() const -> boost::uuids::uuid const& { return m_id; }
 
-    [[nodiscard]] auto get_addr() const -> std::string const& { return m_addr; }
-
 private:
     boost::uuids::uuid m_id;
-    std::string m_addr;
 };
 
 class Scheduler {

--- a/src/spider/io/BoostAsio.hpp
+++ b/src/spider/io/BoostAsio.hpp
@@ -40,35 +40,4 @@
 // IWYU pragma: end_exports
 // clang-format on
 
-#include <string>
-
-#include <spdlog/spdlog.h>
-
-namespace spider::core {
-inline auto get_address() -> std::optional<std::string> {
-    try {
-        boost::asio::io_context io_context;
-        boost::asio::ip::tcp::resolver resolver(io_context);
-        auto const endpoints = resolver.resolve(boost::asio::ip::host_name(), "");
-        for (auto const& endpoint : endpoints) {
-            if (endpoint.endpoint().address().is_v4()
-                && !endpoint.endpoint().address().is_loopback())
-            {
-                return endpoint.endpoint().address().to_string();
-            }
-        }
-        // If no non-loopback address found, return loopback address
-        spdlog::warn("No non-loopback address found, using loopback address");
-        for (auto const& endpoint : endpoints) {
-            if (endpoint.endpoint().address().is_v4()) {
-                return endpoint.endpoint().address().to_string();
-            }
-        }
-        return std::nullopt;
-    } catch (boost::system::system_error const& e) {
-        return std::nullopt;
-    }
-}
-}  // namespace spider::core
-
 #endif  // SPIDER_CORE_BOOSTASIO_HPP

--- a/src/spider/io/BoostAsio.hpp
+++ b/src/spider/io/BoostAsio.hpp
@@ -1,8 +1,6 @@
 #ifndef SPIDER_CORE_BOOSTASIO_HPP
 #define SPIDER_CORE_BOOSTASIO_HPP
 
-#include <optional>
-
 // clang-format off
 // IWYU pragma: begin_exports
 

--- a/src/spider/scheduler/scheduler.cpp
+++ b/src/spider/scheduler/scheduler.cpp
@@ -43,6 +43,11 @@ auto parse_args(int const argc, char** argv) -> boost::program_options::variable
     boost::program_options::options_description desc;
     desc.add_options()("help", "spider scheduler");
     desc.add_options()(
+            "host",
+            boost::program_options::value<std::string>(),
+            "scheduler host address"
+    );
+    desc.add_options()(
             "port",
             boost::program_options::value<unsigned short>(),
             "port to listen on"
@@ -136,6 +141,7 @@ auto main(int argc, char** argv) -> int {
     boost::program_options::variables_map const args = parse_args(argc, argv);
 
     unsigned short port = 0;
+    std::string scheduler_addr;
     std::string storage_url;
     try {
         if (!args.contains("port")) {
@@ -143,6 +149,11 @@ auto main(int argc, char** argv) -> int {
             return cCmdArgParseErr;
         }
         port = args["port"].as<unsigned short>();
+        if (!args.contains("host")) {
+            spdlog::error("host is required");
+            return cCmdArgParseErr;
+        }
+        scheduler_addr = args["host"].as<std::string>();
         if (!args.contains("storage_url")) {
             spdlog::error("storage_url is required");
             return cCmdArgParseErr;
@@ -185,12 +196,6 @@ auto main(int argc, char** argv) -> int {
     // Get scheduler id and addr
     boost::uuids::random_generator gen;
     boost::uuids::uuid const scheduler_id = gen();
-    std::optional<std::string> const optional_scheduler_addr = spider::core::get_address();
-    if (!optional_scheduler_addr.has_value()) {
-        spdlog::error("Failed to get scheduler address");
-        return cSchedulerAddrErr;
-    }
-    std::string const& scheduler_addr = optional_scheduler_addr.value();
 
     // Start scheduler server
     spider::core::StopToken stop_token;

--- a/src/spider/scheduler/scheduler.cpp
+++ b/src/spider/scheduler/scheduler.cpp
@@ -3,7 +3,6 @@
 #include <cstddef>
 #include <functional>
 #include <memory>
-#include <optional>
 #include <string>
 #include <system_error>
 #include <thread>

--- a/src/spider/storage/MetadataStorage.hpp
+++ b/src/spider/storage/MetadataStorage.hpp
@@ -28,7 +28,6 @@ public:
 
     virtual auto add_driver(Driver const& driver) -> StorageErr = 0;
     virtual auto add_scheduler(Scheduler const& scheduler) -> StorageErr = 0;
-    virtual auto get_driver(boost::uuids::uuid id, std::string* addr) -> StorageErr = 0;
     virtual auto get_active_scheduler(std::vector<Scheduler>* schedulers) -> StorageErr = 0;
 
     virtual auto

--- a/src/spider/storage/MysqlStorage.hpp
+++ b/src/spider/storage/MysqlStorage.hpp
@@ -34,7 +34,6 @@ public:
     auto initialize() -> StorageErr override;
     auto add_driver(Driver const& driver) -> StorageErr override;
     auto add_scheduler(Scheduler const& scheduler) -> StorageErr override;
-    auto get_driver(boost::uuids::uuid id, std::string* addr) -> StorageErr override;
     auto get_active_scheduler(std::vector<Scheduler>* schedulers) -> StorageErr override;
     auto
     add_job(boost::uuids::uuid job_id, boost::uuids::uuid client_id, TaskGraph const& task_graph

--- a/tests/integration/client.py
+++ b/tests/integration/client.py
@@ -42,7 +42,6 @@ class TaskGraph:
 @dataclass
 class Driver:
     id: uuid.UUID
-    addr: str
 
 
 @dataclass
@@ -180,9 +179,7 @@ def remove_job(conn, job_id: uuid.UUID):
 def add_driver(conn, driver: Driver):
     cursor = conn.cursor()
 
-    cursor.execute(
-        "INSERT INTO drivers (id, address) VALUES (%s, %s)", (driver.id.bytes, driver.addr)
-    )
+    cursor.execute("INSERT INTO drivers (id) VALUES (%s)", (driver.id.bytes,))
 
     conn.commit()
     cursor.close()

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -19,6 +19,8 @@ def start_scheduler_workers(
     dir_path = dir_path / ".." / ".." / "src" / "spider"
     scheduler_cmds = [
         str(dir_path / "spider_scheduler"),
+        "--host",
+        "127.0.0.1",
         "--port",
         str(scheduler_port),
         "--storage_url",
@@ -27,6 +29,8 @@ def start_scheduler_workers(
     scheduler_process = subprocess.Popen(scheduler_cmds)
     worker_cmds = [
         str(dir_path / "spider_worker"),
+        "--host",
+        "127.0.0.1",
         "--storage_url",
         storage_url,
         "--libs",

--- a/tests/integration/test_scheduler_worker.py
+++ b/tests/integration/test_scheduler_worker.py
@@ -106,9 +106,21 @@ def success_job(storage):
     )
 
     submit_job(storage, uuid.uuid4(), graph)
-    assert get_task_state(storage, parent_1.id) == "ready"
-    assert get_task_state(storage, parent_2.id) == "ready"
-    assert get_task_state(storage, child.id) == "pending"
+    assert (
+        get_task_state(storage, parent_1.id) == "ready"
+        or get_task_state(storage, parent_1.id) == "running"
+        or get_task_state(storage, parent_1.id) == "success"
+    )
+    assert (
+        get_task_state(storage, parent_2.id) == "ready"
+        or get_task_state(storage, parent_2.id) == "running"
+        or get_task_state(storage, parent_2.id) == "success"
+    )
+    assert (
+        get_task_state(storage, child.id) == "pending"
+        or get_task_state(storage, child.id) == "running"
+        or get_task_state(storage, child.id) == "success"
+    )
     print("success job task ids:", parent_1.id, parent_2.id, child.id)
 
     yield graph, parent_1, parent_2, child
@@ -144,7 +156,7 @@ def data_job(storage):
         id=uuid.uuid4(),
         value=msgpack.packb(2),
     )
-    driver = Driver(id=uuid.uuid4(), addr="127.0.0.1")
+    driver = Driver(id=uuid.uuid4())
     add_driver(storage, driver)
     add_driver_data(storage, driver, data)
 
@@ -175,7 +187,7 @@ def random_fail_job(storage):
         id=uuid.uuid4(),
         value=msgpack.packb(2),
     )
-    driver = Driver(id=uuid.uuid4(), addr="127.0.0.1")
+    driver = Driver(id=uuid.uuid4())
     add_driver(storage, driver)
     add_driver_data(storage, driver, data)
 

--- a/tests/integration/test_scheduler_worker.py
+++ b/tests/integration/test_scheduler_worker.py
@@ -34,6 +34,8 @@ def start_scheduler_worker(
     dir_path = dir_path / ".." / ".." / "src" / "spider"
     scheduler_cmds = [
         str(dir_path / "spider_scheduler"),
+        "--host",
+        "127.0.0.1",
         "--port",
         str(scheduler_port),
         "--storage_url",
@@ -42,6 +44,8 @@ def start_scheduler_worker(
     scheduler_process = subprocess.Popen(scheduler_cmds)
     worker_cmds = [
         str(dir_path / "spider_worker"),
+        "--host",
+        "127.0.0.1",
         "--storage_url",
         storage_url,
         "--libs",

--- a/tests/scheduler/test-SchedulerPolicy.cpp
+++ b/tests/scheduler/test-SchedulerPolicy.cpp
@@ -94,7 +94,7 @@ TEMPLATE_LIST_TEST_CASE(
     spider::core::Data data{"value"};
     data.set_hard_locality(true);
     data.set_locality({"127.0.0.1"});
-    REQUIRE(metadata_store->add_driver(spider::core::Driver{client_id, "127.0.0.1"}).success());
+    REQUIRE(metadata_store->add_driver(spider::core::Driver{client_id}).success());
     REQUIRE(data_store->add_driver_data(client_id, data).success());
     task.add_input(spider::core::TaskInput{data.get_id()});
     spider::core::TaskGraph graph;
@@ -141,7 +141,7 @@ TEMPLATE_LIST_TEST_CASE(
     spider::core::Data data;
     data.set_hard_locality(false);
     data.set_locality({"127.0.0.1"});
-    REQUIRE(metadata_store->add_driver(spider::core::Driver{client_id, "127.0.0.1"}).success());
+    REQUIRE(metadata_store->add_driver(spider::core::Driver{client_id}).success());
     REQUIRE(data_store->add_driver_data(client_id, data).success());
     task.add_input(spider::core::TaskInput{data.get_id()});
     spider::core::TaskGraph graph;

--- a/tests/storage/test-DataStorage.cpp
+++ b/tests/storage/test-DataStorage.cpp
@@ -25,7 +25,7 @@ TEMPLATE_LIST_TEST_CASE("Add, get and remove data", "[storage]", spider::test::S
     spider::core::Data const data{"value"};
     boost::uuids::random_generator gen;
     boost::uuids::uuid const driver_id = gen();
-    REQUIRE(metadata_storage->add_driver(spider::core::Driver{driver_id, "127.0.0.1"}).success());
+    REQUIRE(metadata_storage->add_driver(spider::core::Driver{driver_id}).success());
     REQUIRE(data_storage->add_driver_data(driver_id, data).success());
 
     // Add data with same id again should fail
@@ -57,7 +57,7 @@ TEMPLATE_LIST_TEST_CASE(
     // Add driver
     boost::uuids::random_generator gen;
     boost::uuids::uuid const driver_id = gen();
-    REQUIRE(metadata_storage->add_driver(spider::core::Driver{driver_id, "127.0.0.1"}).success());
+    REQUIRE(metadata_storage->add_driver(spider::core::Driver{driver_id}).success());
 
     // Add data
     spider::core::KeyValueData const data{"key", "value", driver_id};
@@ -176,8 +176,8 @@ TEMPLATE_LIST_TEST_CASE(
     // Add driver
     boost::uuids::uuid const driver_id = gen();
     boost::uuids::uuid const driver_id_2 = gen();
-    REQUIRE(metadata_storage->add_driver(spider::core::Driver{driver_id, "127.0.0.1"}).success());
-    REQUIRE(metadata_storage->add_driver(spider::core::Driver{driver_id_2, "127.0.0.1"}).success());
+    REQUIRE(metadata_storage->add_driver(spider::core::Driver{driver_id}).success());
+    REQUIRE(metadata_storage->add_driver(spider::core::Driver{driver_id_2}).success());
 
     // Add driver reference without data should fail
     REQUIRE(!data_storage->add_driver_reference(gen(), driver_id).success());

--- a/tests/storage/test-MetadataStorage.cpp
+++ b/tests/storage/test-MetadataStorage.cpp
@@ -31,11 +31,7 @@ TEMPLATE_LIST_TEST_CASE("Driver heartbeat", "[storage]", spider::test::MetadataS
     // Add driver should succeed
     boost::uuids::random_generator gen;
     boost::uuids::uuid const driver_id = gen();
-    REQUIRE(storage->add_driver(spider::core::Driver{driver_id, "127.0.0.1"}).success());
-
-    std::string addr;
-    REQUIRE(storage->get_driver(driver_id, &addr).success());
-    REQUIRE("127.0.0.1" == addr);
+    REQUIRE(storage->add_driver(spider::core::Driver{driver_id}).success());
 
     std::vector<boost::uuids::uuid> ids{};
     // Driver should not time out

--- a/tests/worker/test-FunctionManager.cpp
+++ b/tests/worker/test-FunctionManager.cpp
@@ -153,7 +153,7 @@ TEMPLATE_LIST_TEST_CASE(
     spider::core::Data const data{std::string{buffer.data(), buffer.size()}};
     boost::uuids::random_generator gen;
     boost::uuids::uuid const driver_id = gen();
-    spider::core::Driver const driver{driver_id, "127.0.0.1"};
+    spider::core::Driver const driver{driver_id};
     REQUIRE(metadata_storage->add_driver(driver).success());
     REQUIRE(data_storage->add_driver_data(driver_id, data).success());
 

--- a/tests/worker/test-TaskExecutor.cpp
+++ b/tests/worker/test-TaskExecutor.cpp
@@ -152,7 +152,7 @@ TEMPLATE_LIST_TEST_CASE(
     spider::core::Data const data{std::string{buffer.data(), buffer.size()}};
     boost::uuids::random_generator gen;
     boost::uuids::uuid const driver_id = gen();
-    spider::core::Driver const driver{driver_id, "127.0.0.1"};
+    spider::core::Driver const driver{driver_id};
     REQUIRE(metadata_storage->add_driver(driver).success());
     REQUIRE(data_storage->add_driver_data(driver_id, data).success());
 


### PR DESCRIPTION
# Description
Previously, clients, schedulers and workers get their IP addresses at runtime. This approach does not work when running inside a container. Thus, now scheduler and worker gets their IP addresses as command line argument, and clients no longer need to get their addresses.


# Validation performed
- [x] GitHub workflow passes
- [x] Unit tests pass in dev container
- [x] Integration tests pass in dev container


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Documentation**
	- Updated quick-start guide with new scheduler and worker configuration parameters.
	- Added notes about host configuration and task library management.

- **Configuration Changes**
	- Introduced `--host` parameter for scheduler and worker startup.
	- Simplified driver address handling across the system.

- **Database Updates**
	- Removed address-related fields from driver and scheduler storage.
	- Updated database schema to focus on driver and scheduler identification.

- **Testing**
	- Updated test cases to reflect new driver initialization process.
	- Expanded test flexibility for task state checking.

These changes streamline the Spider system's configuration and improve its network setup flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->