### PR TITLE
build: Use `target_include_directories` instead of `FILE_SET`

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -18,7 +18,10 @@ concurrency:
 
 jobs:
   non-storage-unit-tests:
-    runs-on: "ubuntu-latest"
+    strategy:
+      matrix:
+        os: ["ubuntu-22.04", "ubuntu-24.04"]
+    runs-on: "${{matrix.os}}"
     steps:
       - uses: "actions/checkout@v4"
         with:

--- a/src/spider/CMakeLists.txt
+++ b/src/spider/CMakeLists.txt
@@ -32,14 +32,7 @@ set(SPIDER_CORE_HEADERS
 
 add_library(spider_core)
 target_sources(spider_core PRIVATE ${SPIDER_CORE_SOURCES})
-target_sources(
-    spider_core
-    PUBLIC
-        FILE_SET spider_core_headers
-        TYPE HEADERS
-        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/..
-        FILES ${SPIDER_CORE_HEADERS}
-)
+target_sources(spider_core PUBLIC ${SPIDER_CORE_HEADERS})
 target_link_libraries(
     spider_core
     PUBLIC
@@ -157,14 +150,8 @@ set(SPIDER_CLIENT_SHARED_HEADERS
 
 add_library(spider_client)
 target_sources(spider_client PRIVATE ${SPIDER_CLIENT_SHARED_SOURCES})
-target_sources(
-    spider_client
-    PUBLIC
-        FILE_SET spider_client_shared_headers
-        TYPE HEADERS
-        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/..
-        FILES ${SPIDER_CLIENT_SHARED_HEADERS}
-)
+target_sources(spider_client PUBLIC ${SPIDER_CLIENT_SHARED_HEADERS})
+target_include_directories(spider_client PUBLIC ..)
 target_link_libraries(
     spider_client
     PUBLIC

--- a/src/spider/CMakeLists.txt
+++ b/src/spider/CMakeLists.txt
@@ -151,7 +151,7 @@ set(SPIDER_CLIENT_SHARED_HEADERS
 add_library(spider_client)
 target_sources(spider_client PRIVATE ${SPIDER_CLIENT_SHARED_SOURCES})
 target_sources(spider_client PUBLIC ${SPIDER_CLIENT_SHARED_HEADERS})
-target_include_directories(spider_client PUBLIC ..)
+target_include_directories(spider_client PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
 target_link_libraries(
     spider_client
     PUBLIC


### PR DESCRIPTION
# Description
#46 uses `FILE_SET` to specify the public headers. CMake adds support for `FILE_SET` in `target_sources` in version 3.23. The default cmake on ubuntu jammy is still 3.22.1, so we need to replace `FILE_SET` with good old `target_include_directories` for backward compatibility.
Change unit test workflow to run on both ubuntu jammy and noble.

# Validation performed
- [x] GitHub workflows pass
- [x] Unit tests pass in dev container
- [x] Integration tests pass in dev container


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Chores**
  - Updated GitHub Actions workflow to run unit tests on multiple Ubuntu versions.
  - Simplified CMake configuration for header file management in the Spider project.

- **CI/CD**
  - Enhanced test coverage by running tests on Ubuntu 22.04 and 24.04.

These changes improve our testing infrastructure and build configuration, ensuring better compatibility and maintainability of the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->