### PR TITLE
build: Add dependency between worker and task_executor

### DIFF
--- a/src/spider/CMakeLists.txt
+++ b/src/spider/CMakeLists.txt
@@ -58,21 +58,6 @@ set(SPIDER_WORKER_SOURCES
     "spider worker source files"
 )
 
-add_executable(spider_worker)
-target_sources(spider_worker PRIVATE ${SPIDER_WORKER_SOURCES})
-target_sources(spider_worker PRIVATE worker/worker.cpp)
-target_link_libraries(spider_worker PRIVATE spider_core)
-target_link_libraries(
-    spider_worker
-    PRIVATE
-        Boost::headers
-        Boost::filesystem
-        Boost::process
-        Boost::program_options
-        Boost::system
-        spdlog::spdlog
-)
-
 set(SPIDER_TASK_EXECUTOR_SOURCES
     worker/DllLoader.cpp
     worker/DllLoader.hpp
@@ -99,6 +84,22 @@ target_link_libraries(
         Boost::system
         spdlog::spdlog
 )
+
+add_executable(spider_worker)
+target_sources(spider_worker PRIVATE ${SPIDER_WORKER_SOURCES})
+target_sources(spider_worker PRIVATE worker/worker.cpp)
+target_link_libraries(spider_worker PRIVATE spider_core)
+target_link_libraries(
+    spider_worker
+    PRIVATE
+        Boost::headers
+        Boost::filesystem
+        Boost::process
+        Boost::program_options
+        Boost::system
+        spdlog::spdlog
+)
+add_dependencies(spider_worker spider_task_executor)
 
 set(SPIDER_SCHEDULER_SOURCES
     scheduler/SchedulerPolicy.hpp


### PR DESCRIPTION
# Description
As title. Fixes #50.


# Validation performed
- [x] GitHub workflows pass
- [x] Unit tests pass in dev container
- [x] Integration tests pass in dev container


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated build configuration for `spider_worker` executable
	- Added build dependency on `spider_task_executor`
	- Maintained existing source files and link libraries for the executable

The changes ensure proper build sequencing and dependency management for the `spider_worker` component without modifying its core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->