### PR TITLE
fix: Move function definitions from headers to sources

### DIFF
--- a/src/spider/worker/FunctionManager.cpp
+++ b/src/spider/worker/FunctionManager.cpp
@@ -102,6 +102,11 @@ auto response_get_result_buffers(msgpack::sbuffer const& buffer
     // NOLINTEND(cppcoreguidelines-pro-type-union-access,cppcoreguidelines-pro-bounds-pointer-arithmetic)
 }
 
+auto FunctionManager::get_instance() -> FunctionManager& {
+    static FunctionManager instance;
+    return instance;
+}
+
 auto FunctionManager::get_function(std::string const& name) const -> Function const* {
     if (auto const func_iter = m_function_map.find(name); func_iter != m_function_map.end()) {
         return &(func_iter->second);

--- a/src/spider/worker/FunctionManager.hpp
+++ b/src/spider/worker/FunctionManager.hpp
@@ -343,10 +343,7 @@ public:
 
     auto operator=(FunctionManager&&) -> FunctionManager& = delete;
 
-    static auto get_instance() -> FunctionManager& {
-        static FunctionManager instance;
-        return instance;
-    }
+    static auto get_instance() -> FunctionManager&;
 
     template <class F>
     auto register_function(std::string const& name, F f) -> bool {

--- a/src/spider/worker/FunctionNameManager.cpp
+++ b/src/spider/worker/FunctionNameManager.cpp
@@ -7,6 +7,11 @@
 
 namespace spider::core {
 
+auto FunctionNameManager::get_instance() -> FunctionNameManager& {
+    static FunctionNameManager instance;
+    return instance;
+}
+
 auto FunctionNameManager::get_function_name(void const* ptr) const -> std::optional<std::string> {
     if (auto const& it = m_name_map.find(ptr); it != m_name_map.end()) {
         return it->second;

--- a/src/spider/worker/FunctionNameManager.hpp
+++ b/src/spider/worker/FunctionNameManager.hpp
@@ -30,10 +30,7 @@ public:
 
     auto operator=(FunctionNameManager&&) -> FunctionNameManager& = delete;
 
-    static auto get_instance() -> FunctionNameManager& {
-        static FunctionNameManager instance;
-        return instance;
-    }
+    static auto get_instance() -> FunctionNameManager&;
 
     template <typename F>
     auto register_function(std::string const& name, F function_pointer) -> bool {


### PR DESCRIPTION
# Description
`FunctionNameManager.cpp` only includes one function that is not called inside a task library, and thus symbols are optimized out when building task library outside of project. Move some function definitions into source file solves this issue.
Fixes #54.


# Validation performed
- [x] GitHub workflows pass
- [x] Unit tests pass in dev container
- [x] Integration pass in dev container
- [x] Quick start example works in dev container


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced singleton access methods for `FunctionManager` and `FunctionNameManager`
  - Added module-level function aliases for retrieving singleton instances

- **Refactor**
  - Updated method signatures for singleton instance retrieval
  - Restructured singleton pattern implementation across multiple files

The changes enhance the accessibility and management of core system components with improved singleton access mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->