### PR TITLE
feat: Cache ready tasks query results in scheduler

### DIFF
--- a/src/spider/CMakeLists.txt
+++ b/src/spider/CMakeLists.txt
@@ -110,13 +110,15 @@ set(SPIDER_SCHEDULER_SOURCES
     scheduler/SchedulerMessage.hpp
     scheduler/SchedulerServer.cpp
     scheduler/SchedulerServer.hpp
+    scheduler/SchedulerTaskCache.cpp
+    scheduler/SchedulerTaskCache.hpp
+    scheduler/scheduler.cpp
     utils/StopToken.hpp
     CACHE INTERNAL
     "spider scheduler source files"
 )
 add_executable(spider_scheduler)
 target_sources(spider_scheduler PRIVATE ${SPIDER_SCHEDULER_SOURCES})
-target_sources(spider_scheduler PRIVATE scheduler/scheduler.cpp)
 target_link_libraries(spider_scheduler PRIVATE spider_core)
 target_link_libraries(
     spider_scheduler

--- a/src/spider/CMakeLists.txt
+++ b/src/spider/CMakeLists.txt
@@ -112,13 +112,13 @@ set(SPIDER_SCHEDULER_SOURCES
     scheduler/SchedulerServer.hpp
     scheduler/SchedulerTaskCache.cpp
     scheduler/SchedulerTaskCache.hpp
-    scheduler/scheduler.cpp
     utils/StopToken.hpp
     CACHE INTERNAL
     "spider scheduler source files"
 )
 add_executable(spider_scheduler)
 target_sources(spider_scheduler PRIVATE ${SPIDER_SCHEDULER_SOURCES})
+target_sources(spider_scheduler PRIVATE scheduler/scheduler.cpp)
 target_link_libraries(spider_scheduler PRIVATE spider_core)
 target_link_libraries(
     spider_scheduler

--- a/src/spider/scheduler/FifoPolicy.cpp
+++ b/src/spider/scheduler/FifoPolicy.cpp
@@ -69,7 +69,6 @@ FifoPolicy::FifoPolicy(
           m_task_cache{
                   metadata_store,
                   data_store,
-                  100,
                   [&](std::vector<core::Task>& tasks,
                       boost::uuids::uuid const& worker_id,
                       std::string const& worker_addr) -> std::optional<boost::uuids::uuid> {

--- a/src/spider/scheduler/FifoPolicy.cpp
+++ b/src/spider/scheduler/FifoPolicy.cpp
@@ -6,6 +6,7 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #include <boost/uuid/uuid.hpp>

--- a/src/spider/scheduler/FifoPolicy.cpp
+++ b/src/spider/scheduler/FifoPolicy.cpp
@@ -18,6 +18,7 @@
 #include "../core/Task.hpp"
 #include "../storage/DataStorage.hpp"
 #include "../storage/MetadataStorage.hpp"
+#include "SchedulerTaskCache.hpp"
 
 namespace {
 
@@ -59,28 +60,40 @@ auto task_locality_satisfied(
 
 namespace spider::scheduler {
 
-auto FifoPolicy::schedule_next(
-        std::shared_ptr<core::MetadataStorage> metadata_store,
-        std::shared_ptr<core::DataStorage> data_store,
-        boost::uuids::uuid const /*worker_id*/,
-        std::string const& worker_addr
-) -> std::optional<std::tuple<boost::uuids::uuid, boost::uuids::uuid>> {
-    std::vector<core::Task> ready_tasks;
-    metadata_store->get_ready_tasks(&ready_tasks);
+FifoPolicy::FifoPolicy(
+        std::shared_ptr<core::MetadataStorage> const& metadata_store,
+        std::shared_ptr<core::DataStorage> const& data_store
+)
+        : m_metadata_store{metadata_store},
+          m_data_store{data_store},
+          m_task_cache{
+                  metadata_store,
+                  data_store,
+                  100,
+                  [&](std::vector<core::Task>& tasks,
+                      boost::uuids::uuid const& worker_id,
+                      std::string const& worker_addr) -> std::optional<boost::uuids::uuid> {
+                      return get_next_task(tasks, worker_id, worker_addr);
+                  }
+          } {}
 
-    std::erase_if(ready_tasks, [data_store, worker_addr](core::Task const& task) -> bool {
-        return !task_locality_satisfied(data_store, task, worker_addr);
+auto FifoPolicy::get_next_task(
+        std::vector<core::Task>& tasks,
+        boost::uuids::uuid const& worker_id,
+        std::string const& worker_addr
+) -> std::optional<boost::uuids::uuid> {
+    std::erase_if(tasks, [this, worker_addr](core::Task const& task) -> bool {
+        return !task_locality_satisfied(m_data_store, task, worker_addr);
     });
 
-    if (ready_tasks.empty()) {
+    if (tasks.empty()) {
         return std::nullopt;
     }
 
     auto const earliest_task = std::ranges::min_element(
-            ready_tasks,
+            tasks,
             {},
-            [this,
-             metadata_store](core::Task const& task) -> std::chrono::system_clock::time_point {
+            [this](core::Task const& task) -> std::chrono::system_clock::time_point {
                 boost::uuids::uuid const task_id = task.get_id();
                 boost::uuids::uuid job_id;
                 std::optional<boost::uuids::uuid> const optional_job_id
@@ -88,7 +101,7 @@ auto FifoPolicy::schedule_next(
                 if (optional_job_id.has_value()) {
                     job_id = optional_job_id.value();
                 } else {
-                    if (false == metadata_store->get_task_job_id(task_id, &job_id).success()) {
+                    if (false == m_metadata_store->get_task_job_id(task_id, &job_id).success()) {
                         throw std::runtime_error(fmt::format(
                                 "Task with id {} not exists.",
                                 boost::uuids::to_string(task_id)
@@ -104,7 +117,7 @@ auto FifoPolicy::schedule_next(
                 }
 
                 core::JobMetadata job_metadata;
-                if (false == metadata_store->get_job_metadata(job_id, &job_metadata).success()) {
+                if (false == m_metadata_store->get_job_metadata(job_id, &job_metadata).success()) {
                     throw std::runtime_error(fmt::format(
                             "Job with id {} not exists.",
                             boost::uuids::to_string(job_id)
@@ -116,6 +129,11 @@ auto FifoPolicy::schedule_next(
     );
 
     return earliest_task->get_id();
+}
+
+auto FifoPolicy::schedule_next(boost::uuids::uuid const worker_id, std::string const& worker_addr)
+        -> std::optional<boost::uuids::uuid> {
+    return m_task_cache.get_ready_task(worker_id, worker_addr);
 }
 
 auto FifoPolicy::cleanup() -> void {

--- a/src/spider/scheduler/FifoPolicy.cpp
+++ b/src/spider/scheduler/FifoPolicy.cpp
@@ -6,7 +6,6 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
-#include <tuple>
 #include <vector>
 
 #include <boost/uuid/uuid.hpp>
@@ -78,7 +77,7 @@ FifoPolicy::FifoPolicy(
 
 auto FifoPolicy::get_next_task(
         std::vector<core::Task>& tasks,
-        boost::uuids::uuid const& worker_id,
+        boost::uuids::uuid const& /*worker_id*/,
         std::string const& worker_addr
 ) -> std::optional<boost::uuids::uuid> {
     std::erase_if(tasks, [this, worker_addr](core::Task const& task) -> bool {

--- a/src/spider/scheduler/FifoPolicy.cpp
+++ b/src/spider/scheduler/FifoPolicy.cpp
@@ -63,7 +63,7 @@ auto FifoPolicy::schedule_next(
         std::shared_ptr<core::DataStorage> data_store,
         boost::uuids::uuid const /*worker_id*/,
         std::string const& worker_addr
-) -> std::optional<boost::uuids::uuid> {
+) -> std::optional<std::tuple<boost::uuids::uuid, boost::uuids::uuid>> {
     std::vector<core::Task> ready_tasks;
     metadata_store->get_ready_tasks(&ready_tasks);
 

--- a/src/spider/scheduler/FifoPolicy.hpp
+++ b/src/spider/scheduler/FifoPolicy.hpp
@@ -5,7 +5,7 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <tuple>
+#include <vector>
 
 #include <boost/uuid/uuid.hpp>
 
@@ -13,20 +13,33 @@
 #include "../storage/MetadataStorage.hpp"
 #include "../utils/TimedCache.hpp"
 #include "SchedulerPolicy.hpp"
+#include "SchedulerTaskCache.hpp"
 
 namespace spider::scheduler {
 
 class FifoPolicy final : public SchedulerPolicy {
 public:
-    auto schedule_next(
-            std::shared_ptr<core::MetadataStorage> metadata_store,
-            std::shared_ptr<core::DataStorage> data_store,
-            boost::uuids::uuid worker_id,
-            std::string const& worker_addr
-    ) -> std::optional<std::tuple<boost::uuids::uuid, boost::uuids::uuid>> override;
+    FifoPolicy(
+            std::shared_ptr<core::MetadataStorage> const& metadata_store,
+            std::shared_ptr<core::DataStorage> const& data_store
+    );
+
+    auto schedule_next(boost::uuids::uuid worker_id, std::string const& worker_addr)
+            -> std::optional<boost::uuids::uuid> override;
     auto cleanup() -> void override;
 
 private:
+    auto get_next_task(
+            std::vector<core::Task>& tasks,
+            boost::uuids::uuid const& worker_id,
+            std::string const& worker_addr
+    ) -> std::optional<boost::uuids::uuid>;
+
+    std::shared_ptr<core::MetadataStorage> m_metadata_store;
+    std::shared_ptr<core::DataStorage> m_data_store;
+
+    SchedulerTaskCache m_task_cache;
+
     core::TimedCache<boost::uuids::uuid, boost::uuids::uuid> m_task_job_cache;
     core::TimedCache<boost::uuids::uuid, std::chrono::system_clock::time_point> m_job_time_cache;
 };

--- a/src/spider/scheduler/FifoPolicy.hpp
+++ b/src/spider/scheduler/FifoPolicy.hpp
@@ -9,6 +9,7 @@
 
 #include <boost/uuid/uuid.hpp>
 
+#include "../core/Task.hpp"
 #include "../storage/DataStorage.hpp"
 #include "../storage/MetadataStorage.hpp"
 #include "../utils/TimedCache.hpp"

--- a/src/spider/scheduler/FifoPolicy.hpp
+++ b/src/spider/scheduler/FifoPolicy.hpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <tuple>
 
 #include <boost/uuid/uuid.hpp>
 
@@ -22,7 +23,7 @@ public:
             std::shared_ptr<core::DataStorage> data_store,
             boost::uuids::uuid worker_id,
             std::string const& worker_addr
-    ) -> std::optional<boost::uuids::uuid> override;
+    ) -> std::optional<std::tuple<boost::uuids::uuid, boost::uuids::uuid>> override;
     auto cleanup() -> void override;
 
 private:

--- a/src/spider/scheduler/SchedulerMessage.hpp
+++ b/src/spider/scheduler/SchedulerMessage.hpp
@@ -3,6 +3,7 @@
 
 #include <optional>
 #include <string>
+#include <tuple>
 #include <utility>
 
 #include <boost/uuid/uuid.hpp>
@@ -54,17 +55,28 @@ class ScheduleTaskResponse {
 public:
     ScheduleTaskResponse() = default;
 
-    explicit ScheduleTaskResponse(boost::uuids::uuid const task_id) : m_task_id{task_id} {}
+    ScheduleTaskResponse(
+            boost::uuids::uuid const task_id,
+            boost::uuids::uuid const task_instance_id
+    )
+            : m_task_ids{std::make_tuple(task_id, task_instance_id)} {}
 
-    [[nodiscard]] auto has_task_id() const -> bool { return m_task_id.has_value(); }
+    explicit ScheduleTaskResponse(std::tuple<boost::uuids::uuid, boost::uuids::uuid> const& task_ids
+    )
+            : m_task_ids{task_ids} {}
+
+    [[nodiscard]] auto has_task_id() const -> bool { return m_task_ids.has_value(); }
 
     // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    [[nodiscard]] auto get_task_id() const -> boost::uuids::uuid { return m_task_id.value(); }
+    [[nodiscard]] auto get_task_ids(
+    ) const -> std::tuple<boost::uuids::uuid, boost::uuids::uuid> const& {
+        return m_task_ids.value();
+    }
 
-    MSGPACK_DEFINE_ARRAY(m_task_id);
+    MSGPACK_DEFINE_ARRAY(m_task_ids);
 
 private:
-    std::optional<boost::uuids::uuid> m_task_id = std::nullopt;
+    std::optional<std::tuple<boost::uuids::uuid, boost::uuids::uuid>> m_task_ids = std::nullopt;
 };
 
 }  // namespace spider::scheduler

--- a/src/spider/scheduler/SchedulerMessage.hpp
+++ b/src/spider/scheduler/SchedulerMessage.hpp
@@ -67,9 +67,9 @@ public:
 
     [[nodiscard]] auto has_task_id() const -> bool { return m_task_ids.has_value(); }
 
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     [[nodiscard]] auto get_task_ids(
     ) const -> std::tuple<boost::uuids::uuid, boost::uuids::uuid> const& {
+        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
         return m_task_ids.value();
     }
 

--- a/src/spider/scheduler/SchedulerPolicy.hpp
+++ b/src/spider/scheduler/SchedulerPolicy.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <tuple>
 
 #include <boost/uuid/uuid.hpp>
 
@@ -25,7 +26,7 @@ public:
             std::shared_ptr<core::DataStorage> data_store,
             boost::uuids::uuid worker_id,
             std::string const& worker_addr
-    ) -> std::optional<boost::uuids::uuid> = 0;
+    ) -> std::optional<std::tuple<boost::uuids::uuid, boost::uuids::uuid>> = 0;
 
     virtual auto cleanup() -> void = 0;
 };

--- a/src/spider/scheduler/SchedulerPolicy.hpp
+++ b/src/spider/scheduler/SchedulerPolicy.hpp
@@ -1,7 +1,6 @@
 #ifndef SPIDER_SCHEDULER_SCHEDULERPOLICY_HPP
 #define SPIDER_SCHEDULER_SCHEDULERPOLICY_HPP
 
-#include <memory>
 #include <optional>
 #include <string>
 

--- a/src/spider/scheduler/SchedulerPolicy.hpp
+++ b/src/spider/scheduler/SchedulerPolicy.hpp
@@ -4,12 +4,8 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <tuple>
 
 #include <boost/uuid/uuid.hpp>
-
-#include "../storage/DataStorage.hpp"
-#include "../storage/MetadataStorage.hpp"
 
 namespace spider::scheduler {
 class SchedulerPolicy {
@@ -21,12 +17,8 @@ public:
     auto operator=(SchedulerPolicy&&) -> SchedulerPolicy& = default;
     virtual ~SchedulerPolicy() = default;
 
-    virtual auto schedule_next(
-            std::shared_ptr<core::MetadataStorage> metadata_store,
-            std::shared_ptr<core::DataStorage> data_store,
-            boost::uuids::uuid worker_id,
-            std::string const& worker_addr
-    ) -> std::optional<std::tuple<boost::uuids::uuid, boost::uuids::uuid>> = 0;
+    virtual auto schedule_next(boost::uuids::uuid worker_id, std::string const& worker_addr)
+            -> std::optional<boost::uuids::uuid> = 0;
 
     virtual auto cleanup() -> void = 0;
 };

--- a/src/spider/scheduler/SchedulerServer.cpp
+++ b/src/spider/scheduler/SchedulerServer.cpp
@@ -5,7 +5,6 @@
 #include <optional>
 #include <stdexcept>
 #include <thread>
-#include <tuple>
 #include <utility>
 
 #include <boost/uuid/uuid.hpp>
@@ -13,6 +12,7 @@
 #include <spdlog/spdlog.h>
 
 #include "../core/Error.hpp"
+#include "../core/Task.hpp"
 #include "../io/BoostAsio.hpp"  // IWYU pragma: keep
 #include "../io/MsgPack.hpp"  // IWYU pragma: keep
 #include "../io/msgpack_message.hpp"
@@ -156,7 +156,7 @@ auto SchedulerServer::process_message(boost::asio::ip::tcp::socket socket
             = m_policy->schedule_next(request.get_worker_id(), request.get_worker_addr());
     ScheduleTaskResponse response{};
     if (task_id.has_value()) {
-        core::TaskInstance instance{task_id.value()};
+        core::TaskInstance const instance{task_id.value()};
         core::StorageErr const err = m_metadata_store->create_task_instance(instance);
         if (err.success()) {
             response = ScheduleTaskResponse{task_id.value(), instance.id};

--- a/src/spider/scheduler/SchedulerServer.cpp
+++ b/src/spider/scheduler/SchedulerServer.cpp
@@ -151,15 +151,16 @@ auto SchedulerServer::process_message(boost::asio::ip::tcp::socket socket
         }
     }
 
-    std::optional<boost::uuids::uuid> const task_id = m_policy->schedule_next(
-            m_metadata_store,
-            m_data_store,
-            request.get_worker_id(),
-            request.get_worker_addr()
-    );
+    std::optional<std::tuple<boost::uuids::uuid, boost::uuids::uuid>> const task_ids
+            = m_policy->schedule_next(
+                    m_metadata_store,
+                    m_data_store,
+                    request.get_worker_id(),
+                    request.get_worker_addr()
+            );
     ScheduleTaskResponse response{};
-    if (task_id.has_value()) {
-        response = ScheduleTaskResponse{task_id.value()};
+    if (task_ids.has_value()) {
+        response = ScheduleTaskResponse{task_ids.value()};
     }
     msgpack::sbuffer response_buffer;
     msgpack::pack(response_buffer, response);

--- a/src/spider/scheduler/SchedulerServer.cpp
+++ b/src/spider/scheduler/SchedulerServer.cpp
@@ -5,6 +5,7 @@
 #include <optional>
 #include <stdexcept>
 #include <thread>
+#include <tuple>
 #include <utility>
 
 #include <boost/uuid/uuid.hpp>

--- a/src/spider/scheduler/SchedulerTaskCache.cpp
+++ b/src/spider/scheduler/SchedulerTaskCache.cpp
@@ -81,8 +81,13 @@ auto SchedulerTaskCache::should_fetch_tasks() -> bool {
 void SchedulerTaskCache::fetch_ready_tasks() {
     m_tasks.clear();
     std::vector<core::Task> tasks;
-    m_metadata_store->get_ready_tasks(&tasks);
+    m_metadata_store->get_ready_tasks(&tasks, m_num_tasks);
     for (core::Task const& task : tasks) {
+        m_tasks.emplace(std::make_pair(task.get_id(), task));
+    }
+    std::vector<std::tuple<core::TaskInstance, core::Task>> task_instances;
+    m_metadata_store->get_task_timeout(&task_instances);
+    for (auto const& [task_instance, task] : task_instances) {
         m_tasks.emplace(std::make_pair(task.get_id(), task));
     }
 

--- a/src/spider/scheduler/SchedulerTaskCache.cpp
+++ b/src/spider/scheduler/SchedulerTaskCache.cpp
@@ -81,7 +81,7 @@ auto SchedulerTaskCache::should_fetch_tasks() -> bool {
 void SchedulerTaskCache::fetch_ready_tasks() {
     m_tasks.clear();
     std::vector<core::Task> tasks;
-    m_metadata_store->get_ready_tasks(&tasks, m_num_tasks);
+    m_metadata_store->get_ready_tasks(&tasks);
     for (core::Task const& task : tasks) {
         m_tasks.emplace(std::make_pair(task.get_id(), task));
     }

--- a/src/spider/scheduler/SchedulerTaskCache.cpp
+++ b/src/spider/scheduler/SchedulerTaskCache.cpp
@@ -1,1 +1,85 @@
 #include "SchedulerTaskCache.hpp"
+
+#include <chrono>
+#include <functional>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <boost/uuid/uuid.hpp>
+
+#include "../core/Task.hpp"
+
+namespace spider::core {
+
+namespace {
+constexpr int cUpdateCount = 100;
+constexpr int cUpdateInterval = 5;  // 10 ms
+}  // namespace
+
+auto SchedulerTaskCache::get_ready_task(
+        boost::uuids::uuid const& worker_id,
+        std::string const& worker_addr
+) -> std::optional<boost::uuids::uuid> {
+    bool const updated = should_fetch_tasks();
+    if (updated) {
+        fetch_ready_tasks();
+    }
+
+    std::optional<Task> task = pop_next_task(worker_id, worker_addr);
+    if (task.has_value()) {
+        m_update_count++;
+        return task.value().get_id();
+    }
+    if (updated) {
+        m_update_count++;
+        return std::nullopt;
+    }
+    fetch_ready_tasks();
+    task = pop_next_task(worker_id, worker_addr);
+    m_update_count++;
+    if (task.has_value()) {
+        return task.value().get_id();
+    }
+
+    return std::nullopt;
+}
+
+auto SchedulerTaskCache::pop_next_task(
+        boost::uuids::uuid const& worker_id,
+        std::string const& worker_addr
+) -> std::optional<Task> {
+    std::vector<Task> tasks;
+    tasks.reserve(m_tasks.size());
+    for (auto const& task : m_tasks) {
+        tasks.push_back(task.second);
+    }
+    std::optional<boost::uuids::uuid> const task_id = std::invoke(
+            m_get_next_task_function,
+            std::ref(tasks),
+            std::cref(worker_id),
+            std::cref(worker_addr)
+    );
+    if (!task_id.has_value()) {
+        return std::nullopt;
+    }
+
+    Task task = m_tasks.at(task_id.value());
+    m_tasks.erase(task_id.value());
+    return task;
+}
+
+auto SchedulerTaskCache::should_fetch_tasks() -> bool {
+    std::chrono::steady_clock::time_point const now = std::chrono::steady_clock::now();
+    if (m_last_update + std::chrono::milliseconds(cUpdateInterval) < now) {
+        return true;
+    }
+    return m_update_count > cUpdateCount;
+}
+
+void SchedulerTaskCache::fetch_ready_tasks() {
+    m_update_count = 0;
+    m_last_update = std::chrono::steady_clock::now();
+}
+
+}  // namespace spider::core

--- a/src/spider/scheduler/SchedulerTaskCache.cpp
+++ b/src/spider/scheduler/SchedulerTaskCache.cpp
@@ -1,0 +1,1 @@
+#include "SchedulerTaskCache.hpp"

--- a/src/spider/scheduler/SchedulerTaskCache.cpp
+++ b/src/spider/scheduler/SchedulerTaskCache.cpp
@@ -4,6 +4,7 @@
 #include <functional>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <boost/uuid/uuid.hpp>
@@ -78,6 +79,13 @@ auto SchedulerTaskCache::should_fetch_tasks() -> bool {
 }
 
 void SchedulerTaskCache::fetch_ready_tasks() {
+    m_tasks.clear();
+    std::vector<Task> tasks;
+    m_metadata_store->get_ready_tasks(&tasks);
+    for (Task const& task : tasks) {
+        m_tasks.emplace(std::make_pair(task.get_id(), task));
+    }
+
     m_update_count = 0;
     m_last_update = std::chrono::steady_clock::now();
 }

--- a/src/spider/scheduler/SchedulerTaskCache.cpp
+++ b/src/spider/scheduler/SchedulerTaskCache.cpp
@@ -11,7 +11,7 @@
 
 #include "../core/Task.hpp"
 
-namespace spider::core {
+namespace spider::scheduler {
 
 namespace {
 constexpr int cUpdateCount = 100;
@@ -27,7 +27,7 @@ auto SchedulerTaskCache::get_ready_task(
         fetch_ready_tasks();
     }
 
-    std::optional<Task> task = pop_next_task(worker_id, worker_addr);
+    std::optional<core::Task> task = pop_next_task(worker_id, worker_addr);
     if (task.has_value()) {
         m_update_count++;
         return task.value().get_id();
@@ -49,8 +49,8 @@ auto SchedulerTaskCache::get_ready_task(
 auto SchedulerTaskCache::pop_next_task(
         boost::uuids::uuid const& worker_id,
         std::string const& worker_addr
-) -> std::optional<Task> {
-    std::vector<Task> tasks;
+) -> std::optional<core::Task> {
+    std::vector<core::Task> tasks;
     tasks.reserve(m_tasks.size());
     for (auto const& task : m_tasks) {
         tasks.push_back(task.second);
@@ -65,7 +65,7 @@ auto SchedulerTaskCache::pop_next_task(
         return std::nullopt;
     }
 
-    Task task = m_tasks.at(task_id.value());
+    core::Task task = m_tasks.at(task_id.value());
     m_tasks.erase(task_id.value());
     return task;
 }
@@ -80,9 +80,9 @@ auto SchedulerTaskCache::should_fetch_tasks() -> bool {
 
 void SchedulerTaskCache::fetch_ready_tasks() {
     m_tasks.clear();
-    std::vector<Task> tasks;
+    std::vector<core::Task> tasks;
     m_metadata_store->get_ready_tasks(&tasks);
-    for (Task const& task : tasks) {
+    for (core::Task const& task : tasks) {
         m_tasks.emplace(std::make_pair(task.get_id(), task));
     }
 
@@ -90,4 +90,4 @@ void SchedulerTaskCache::fetch_ready_tasks() {
     m_last_update = std::chrono::steady_clock::now();
 }
 
-}  // namespace spider::core
+}  // namespace spider::scheduler

--- a/src/spider/scheduler/SchedulerTaskCache.cpp
+++ b/src/spider/scheduler/SchedulerTaskCache.cpp
@@ -4,6 +4,7 @@
 #include <functional>
 #include <optional>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 

--- a/src/spider/scheduler/SchedulerTaskCache.cpp
+++ b/src/spider/scheduler/SchedulerTaskCache.cpp
@@ -16,7 +16,7 @@ namespace spider::scheduler {
 
 namespace {
 constexpr int cUpdateCount = 100;
-constexpr int cUpdateInterval = 5;  // 10 ms
+constexpr int cUpdateInterval = 5;  // 5 ms
 }  // namespace
 
 auto SchedulerTaskCache::get_ready_task(

--- a/src/spider/scheduler/SchedulerTaskCache.hpp
+++ b/src/spider/scheduler/SchedulerTaskCache.hpp
@@ -1,0 +1,27 @@
+#ifndef SPIDER_SCHEDULER_SCHEDULERTASKCACHE_HPP
+#define SPIDER_SCHEDULER_SCHEDULERTASKCACHE_HPP
+
+#include <memory>
+
+#include "../storage/DataStorage.hpp"
+#include "../storage/MetadataStorage.hpp"
+
+namespace spider::core {
+
+class SchedulerTaskCache {
+public:
+    SchedulerTaskCache(
+            std::shared_ptr<MetadataStorage> const& metadata_store,
+            std::shared_ptr<DataStorage> const& data_store
+    )
+            : m_metadata_store{metadata_store},
+              m_data_store{data_store} {}
+
+private:
+    std::shared_ptr<MetadataStorage> m_metadata_store;
+    std::shared_ptr<DataStorage> m_data_store;
+};
+
+}  // namespace spider::core
+
+#endif  // SPIDER_SCHEDULER_SCHEDULERTASKCACHE_HPP

--- a/src/spider/scheduler/SchedulerTaskCache.hpp
+++ b/src/spider/scheduler/SchedulerTaskCache.hpp
@@ -1,8 +1,18 @@
 #ifndef SPIDER_SCHEDULER_SCHEDULERTASKCACHE_HPP
 #define SPIDER_SCHEDULER_SCHEDULERTASKCACHE_HPP
 
+#include <chrono>
+#include <cstddef>
+#include <functional>
 #include <memory>
+#include <optional>
+#include <string>
+#include <vector>
 
+#include <absl/container/flat_hash_map.h>
+#include <boost/uuid/uuid.hpp>
+
+#include "../core/Task.hpp"
 #include "../storage/DataStorage.hpp"
 #include "../storage/MetadataStorage.hpp"
 
@@ -12,14 +22,45 @@ class SchedulerTaskCache {
 public:
     SchedulerTaskCache(
             std::shared_ptr<MetadataStorage> const& metadata_store,
-            std::shared_ptr<DataStorage> const& data_store
+            std::shared_ptr<DataStorage> const& data_store,
+            size_t const num_tasks,
+            std::function<std::optional<boost::uuids::uuid>(
+                    std::vector<Task>& tasks,
+                    boost::uuids::uuid const& worker_id,
+                    std::string const& worker_addr
+            )> const& get_next_task_function
     )
             : m_metadata_store{metadata_store},
-              m_data_store{data_store} {}
+              m_data_store{data_store},
+              m_num_tasks{num_tasks},
+              m_get_next_task_function{get_next_task_function} {}
+
+    auto get_ready_task(boost::uuids::uuid const& worker_id, std::string const& worker_addr)
+            -> std::optional<boost::uuids::uuid>;
 
 private:
+    auto should_fetch_tasks() -> bool;
+
+    void fetch_ready_tasks();
+
+    auto pop_next_task(boost::uuids::uuid const& worker_id, std::string const& worker_addr)
+            -> std::optional<Task>;
+
     std::shared_ptr<MetadataStorage> m_metadata_store;
     std::shared_ptr<DataStorage> m_data_store;
+
+    absl::flat_hash_map<boost::uuids::uuid, Task> m_tasks;
+    std::chrono::steady_clock::time_point m_last_update;
+    size_t m_update_count = 0;
+
+    size_t m_num_tasks;
+
+    std::function<std::optional<boost::uuids::uuid>(
+            std::vector<Task>& tasks,
+            boost::uuids::uuid const& worker_id,
+            std::string const& worker_addr
+    )>
+            m_get_next_task_function;
 };
 
 }  // namespace spider::core

--- a/src/spider/scheduler/SchedulerTaskCache.hpp
+++ b/src/spider/scheduler/SchedulerTaskCache.hpp
@@ -23,7 +23,6 @@ public:
     SchedulerTaskCache(
             std::shared_ptr<core::MetadataStorage> const& metadata_store,
             std::shared_ptr<core::DataStorage> const& data_store,
-            size_t const num_tasks,
             std::function<std::optional<boost::uuids::uuid>(
                     std::vector<core::Task>& tasks,
                     boost::uuids::uuid const& worker_id,
@@ -32,7 +31,6 @@ public:
     )
             : m_metadata_store{metadata_store},
               m_data_store{data_store},
-              m_num_tasks{num_tasks},
               m_get_next_task_function{get_next_task_function} {}
 
     auto get_ready_task(boost::uuids::uuid const& worker_id, std::string const& worker_addr)
@@ -53,8 +51,6 @@ private:
     absl::flat_hash_map<boost::uuids::uuid, core::Task, std::hash<boost::uuids::uuid>> m_tasks;
     std::chrono::steady_clock::time_point m_last_update;
     size_t m_update_count = 0;
-
-    size_t m_num_tasks;
 
     std::function<std::optional<boost::uuids::uuid>(
             std::vector<core::Task>& tasks,

--- a/src/spider/scheduler/SchedulerTaskCache.hpp
+++ b/src/spider/scheduler/SchedulerTaskCache.hpp
@@ -49,7 +49,8 @@ private:
     std::shared_ptr<MetadataStorage> m_metadata_store;
     std::shared_ptr<DataStorage> m_data_store;
 
-    absl::flat_hash_map<boost::uuids::uuid, Task> m_tasks;
+    // NOLINTNEXTLINE(misc-include-cleaner)
+    absl::flat_hash_map<boost::uuids::uuid, Task, std::hash<boost::uuids::uuid>> m_tasks;
     std::chrono::steady_clock::time_point m_last_update;
     size_t m_update_count = 0;
 

--- a/src/spider/scheduler/SchedulerTaskCache.hpp
+++ b/src/spider/scheduler/SchedulerTaskCache.hpp
@@ -16,16 +16,16 @@
 #include "../storage/DataStorage.hpp"
 #include "../storage/MetadataStorage.hpp"
 
-namespace spider::core {
+namespace spider::scheduler {
 
 class SchedulerTaskCache {
 public:
     SchedulerTaskCache(
-            std::shared_ptr<MetadataStorage> const& metadata_store,
-            std::shared_ptr<DataStorage> const& data_store,
+            std::shared_ptr<core::MetadataStorage> const& metadata_store,
+            std::shared_ptr<core::DataStorage> const& data_store,
             size_t const num_tasks,
             std::function<std::optional<boost::uuids::uuid>(
-                    std::vector<Task>& tasks,
+                    std::vector<core::Task>& tasks,
                     boost::uuids::uuid const& worker_id,
                     std::string const& worker_addr
             )> const& get_next_task_function
@@ -44,26 +44,26 @@ private:
     void fetch_ready_tasks();
 
     auto pop_next_task(boost::uuids::uuid const& worker_id, std::string const& worker_addr)
-            -> std::optional<Task>;
+            -> std::optional<core::Task>;
 
-    std::shared_ptr<MetadataStorage> m_metadata_store;
-    std::shared_ptr<DataStorage> m_data_store;
+    std::shared_ptr<core::MetadataStorage> m_metadata_store;
+    std::shared_ptr<core::DataStorage> m_data_store;
 
     // NOLINTNEXTLINE(misc-include-cleaner)
-    absl::flat_hash_map<boost::uuids::uuid, Task, std::hash<boost::uuids::uuid>> m_tasks;
+    absl::flat_hash_map<boost::uuids::uuid, core::Task, std::hash<boost::uuids::uuid>> m_tasks;
     std::chrono::steady_clock::time_point m_last_update;
     size_t m_update_count = 0;
 
     size_t m_num_tasks;
 
     std::function<std::optional<boost::uuids::uuid>(
-            std::vector<Task>& tasks,
+            std::vector<core::Task>& tasks,
             boost::uuids::uuid const& worker_id,
             std::string const& worker_addr
     )>
             m_get_next_task_function;
 };
 
-}  // namespace spider::core
+}  // namespace spider::scheduler
 
 #endif  // SPIDER_SCHEDULER_SCHEDULERTASKCACHE_HPP

--- a/src/spider/scheduler/scheduler.cpp
+++ b/src/spider/scheduler/scheduler.cpp
@@ -189,7 +189,7 @@ auto main(int argc, char** argv) -> int {
     // Start scheduler server
     spider::core::StopToken stop_token;
     std::shared_ptr<spider::scheduler::SchedulerPolicy> const policy
-            = std::make_shared<spider::scheduler::FifoPolicy>();
+            = std::make_shared<spider::scheduler::FifoPolicy>(metadata_store, data_store);
     spider::scheduler::SchedulerServer server{port, policy, metadata_store, data_store, stop_token};
 
     // Register scheduler with storage

--- a/src/spider/storage/MetadataStorage.hpp
+++ b/src/spider/storage/MetadataStorage.hpp
@@ -51,7 +51,6 @@ public:
     virtual auto get_task_job_id(boost::uuids::uuid id, boost::uuids::uuid* job_id) -> StorageErr
                                                                                        = 0;
     virtual auto get_ready_tasks(std::vector<Task>* tasks) -> StorageErr = 0;
-    virtual auto get_ready_tasks(std::vector<Task>* tasks, size_t limit) -> StorageErr = 0;
     virtual auto set_task_state(boost::uuids::uuid id, TaskState state) -> StorageErr = 0;
     virtual auto set_task_running(boost::uuids::uuid id) -> StorageErr = 0;
     virtual auto add_task_instance(TaskInstance const& instance) -> StorageErr = 0;

--- a/src/spider/storage/MetadataStorage.hpp
+++ b/src/spider/storage/MetadataStorage.hpp
@@ -2,6 +2,7 @@
 #define SPIDER_STORAGE_METADATASTORAGE_HPP
 
 #include <string>
+#include <tuple>
 #include <vector>
 
 #include <boost/uuid/uuid.hpp>
@@ -50,6 +51,7 @@ public:
     virtual auto get_task_job_id(boost::uuids::uuid id, boost::uuids::uuid* job_id) -> StorageErr
                                                                                        = 0;
     virtual auto get_ready_tasks(std::vector<Task>* tasks) -> StorageErr = 0;
+    virtual auto get_ready_tasks(std::vector<Task>* tasks, size_t limit) -> StorageErr = 0;
     virtual auto set_task_state(boost::uuids::uuid id, TaskState state) -> StorageErr = 0;
     virtual auto set_task_running(boost::uuids::uuid id) -> StorageErr = 0;
     virtual auto add_task_instance(TaskInstance const& instance) -> StorageErr = 0;
@@ -57,7 +59,8 @@ public:
             -> StorageErr = 0;
     virtual auto task_fail(TaskInstance const& instance, std::string const& error) -> StorageErr
                                                                                       = 0;
-    virtual auto get_task_timeout(std::vector<TaskInstance>* tasks) -> StorageErr = 0;
+    virtual auto get_task_timeout(std::vector<std::tuple<TaskInstance, Task>>* tasks) -> StorageErr
+                                                                                         = 0;
     virtual auto get_child_tasks(boost::uuids::uuid id, std::vector<Task>* children) -> StorageErr
                                                                                         = 0;
     virtual auto get_parent_tasks(boost::uuids::uuid id, std::vector<Task>* tasks) -> StorageErr

--- a/src/spider/storage/MetadataStorage.hpp
+++ b/src/spider/storage/MetadataStorage.hpp
@@ -55,6 +55,8 @@ public:
     virtual auto set_task_state(boost::uuids::uuid id, TaskState state) -> StorageErr = 0;
     virtual auto set_task_running(boost::uuids::uuid id) -> StorageErr = 0;
     virtual auto add_task_instance(TaskInstance const& instance) -> StorageErr = 0;
+    // Set task state and add new task instance if task is ready or all instances timed out
+    virtual auto create_task_instance(TaskInstance const& instance) -> StorageErr = 0;
     virtual auto task_finish(TaskInstance const& instance, std::vector<TaskOutput> const& outputs)
             -> StorageErr = 0;
     virtual auto task_fail(TaskInstance const& instance, std::string const& error) -> StorageErr

--- a/src/spider/storage/MySqlStorage.cpp
+++ b/src/spider/storage/MySqlStorage.cpp
@@ -72,6 +72,7 @@ char const* const cCreateJobTable = R"(CREATE TABLE IF NOT EXISTS jobs (
     `client_id` BINARY(16) NOT NULL,
     `creation_time` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     KEY (`client_id`) USING BTREE,
+    INDEX (`creation_time`),
     PRIMARY KEY (`id`)
 ))";
 
@@ -1220,7 +1221,7 @@ auto MySqlMetadataStorage::get_ready_tasks(std::vector<Task>* tasks) -> StorageE
     return StorageErr{};
 }
 
-auto MySqlMetadataStorage::get_ready_tasks(std::vector<Task>* tasks, size_t cos limit)
+auto MySqlMetadataStorage::get_ready_tasks(std::vector<Task>* tasks, size_t const limit)
         -> StorageErr {
     std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
     if (std::holds_alternative<StorageErr>(conn_result)) {

--- a/src/spider/storage/MySqlStorage.cpp
+++ b/src/spider/storage/MySqlStorage.cpp
@@ -1333,6 +1333,7 @@ auto MySqlMetadataStorage::create_task_instance(TaskInstance const& instance) ->
                 conn->prepareStatement("UPDATE `tasks` SET `state` = 'running' WHERE `id` = ?")
         );
         running_statement->setBytes(1, &id_bytes);
+        running_statement->executeUpdate();
         // Insert task instance
         std::unique_ptr<sql::PreparedStatement> const instance_statement(conn->prepareStatement(
                 "INSERT INTO `task_instances` (`id`, `task_id`, `start_time`) VALUES(?, ?, "
@@ -1341,7 +1342,7 @@ auto MySqlMetadataStorage::create_task_instance(TaskInstance const& instance) ->
         sql::bytes instance_id_bytes = uuid_get_bytes(instance.id);
         instance_statement->setBytes(1, &instance_id_bytes);
         instance_statement->setBytes(2, &id_bytes);
-        running_statement->executeUpdate();
+        instance_statement->executeUpdate();
     } catch (sql::SQLException& e) {
         conn->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};

--- a/src/spider/storage/MySqlStorage.hpp
+++ b/src/spider/storage/MySqlStorage.hpp
@@ -55,7 +55,6 @@ public:
     auto get_task(boost::uuids::uuid id, Task* task) -> StorageErr override;
     auto get_task_job_id(boost::uuids::uuid id, boost::uuids::uuid* job_id) -> StorageErr override;
     auto get_ready_tasks(std::vector<Task>* tasks) -> StorageErr override;
-    auto get_ready_tasks(std::vector<Task>* tasks, size_t limit) -> StorageErr override;
     auto set_task_state(boost::uuids::uuid id, TaskState state) -> StorageErr override;
     auto set_task_running(boost::uuids::uuid id) -> StorageErr override;
     auto add_task_instance(TaskInstance const& instance) -> StorageErr override;

--- a/src/spider/storage/MySqlStorage.hpp
+++ b/src/spider/storage/MySqlStorage.hpp
@@ -59,6 +59,7 @@ public:
     auto set_task_state(boost::uuids::uuid id, TaskState state) -> StorageErr override;
     auto set_task_running(boost::uuids::uuid id) -> StorageErr override;
     auto add_task_instance(TaskInstance const& instance) -> StorageErr override;
+    auto create_task_instance(TaskInstance const& instance) -> StorageErr override;
     auto task_finish(TaskInstance const& instance, std::vector<TaskOutput> const& outputs)
             -> StorageErr override;
     auto task_fail(TaskInstance const& instance, std::string const& error) -> StorageErr override;

--- a/src/spider/storage/MySqlStorage.hpp
+++ b/src/spider/storage/MySqlStorage.hpp
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -54,13 +55,15 @@ public:
     auto get_task(boost::uuids::uuid id, Task* task) -> StorageErr override;
     auto get_task_job_id(boost::uuids::uuid id, boost::uuids::uuid* job_id) -> StorageErr override;
     auto get_ready_tasks(std::vector<Task>* tasks) -> StorageErr override;
+    auto get_ready_tasks(std::vector<Task>* tasks, size_t limit) -> StorageErr override;
     auto set_task_state(boost::uuids::uuid id, TaskState state) -> StorageErr override;
     auto set_task_running(boost::uuids::uuid id) -> StorageErr override;
     auto add_task_instance(TaskInstance const& instance) -> StorageErr override;
     auto task_finish(TaskInstance const& instance, std::vector<TaskOutput> const& outputs)
             -> StorageErr override;
     auto task_fail(TaskInstance const& instance, std::string const& error) -> StorageErr override;
-    auto get_task_timeout(std::vector<TaskInstance>* tasks) -> StorageErr override;
+    auto get_task_timeout(std::vector<std::tuple<TaskInstance, Task>>* tasks
+    ) -> StorageErr override;
     auto get_child_tasks(boost::uuids::uuid id, std::vector<Task>* children) -> StorageErr override;
     auto get_parent_tasks(boost::uuids::uuid id, std::vector<Task>* tasks) -> StorageErr override;
     auto update_heartbeat(boost::uuids::uuid id) -> StorageErr override;

--- a/src/spider/worker/WorkerClient.cpp
+++ b/src/spider/worker/WorkerClient.cpp
@@ -7,6 +7,7 @@
 #include <random>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -34,7 +35,7 @@ WorkerClient::WorkerClient(
           m_metadata_store(std::move(metadata_store)) {}
 
 auto WorkerClient::get_next_task(std::optional<boost::uuids::uuid> const& fail_task_id
-) -> std::optional<boost::uuids::uuid> {
+) -> std::optional<std::tuple<boost::uuids::uuid, boost::uuids::uuid>> {
     // Get schedulers
     std::vector<core::Scheduler> schedulers;
     if (!m_metadata_store->get_active_scheduler(&schedulers).success()) {
@@ -94,7 +95,7 @@ auto WorkerClient::get_next_task(std::optional<boost::uuids::uuid> const& fail_t
         if (!response.has_task_id()) {
             return std::nullopt;
         }
-        return response.get_task_id();
+        return response.get_task_ids();
     } catch (boost::system::system_error const& e) {
         return std::nullopt;
     } catch (std::runtime_error const& e) {

--- a/src/spider/worker/WorkerClient.hpp
+++ b/src/spider/worker/WorkerClient.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <tuple>
 
 #include <boost/uuid/uuid.hpp>
 
@@ -29,7 +30,7 @@ public:
     );
 
     auto get_next_task(std::optional<boost::uuids::uuid> const& fail_task_id
-    ) -> std::optional<boost::uuids::uuid>;
+    ) -> std::optional<std::tuple<boost::uuids::uuid, boost::uuids::uuid>>;
 
 private:
     boost::uuids::uuid m_worker_id;

--- a/src/spider/worker/worker.cpp
+++ b/src/spider/worker/worker.cpp
@@ -217,7 +217,7 @@ auto task_loop(
     while (!stop_token.stop_requested()) {
         boost::asio::io_context context;
         auto const [task_id, task_instance_id] = fetch_task(client, fail_task_id);
-        spider::core::TaskInstance instance{task_id, task_instance_id};
+        spider::core::TaskInstance const instance{task_id, task_instance_id};
         spdlog::debug("Fetched task {}", boost::uuids::to_string(task_id));
         fail_task_id = std::nullopt;
         // Fetch task detail from metadata storage

--- a/src/spider/worker/worker.cpp
+++ b/src/spider/worker/worker.cpp
@@ -217,7 +217,7 @@ auto task_loop(
     while (!stop_token.stop_requested()) {
         boost::asio::io_context context;
         auto const [task_id, task_instance_id] = fetch_task(client, fail_task_id);
-        spider::core::TaskInstance const instance{task_id, task_instance_id};
+        spider::core::TaskInstance const instance{task_instance_id, task_id};
         spdlog::debug("Fetched task {}", boost::uuids::to_string(task_id));
         fail_task_id = std::nullopt;
         // Fetch task detail from metadata storage

--- a/src/spider/worker/worker.cpp
+++ b/src/spider/worker/worker.cpp
@@ -8,6 +8,7 @@
 #include <stdexcept>
 #include <string>
 #include <thread>
+#include <tuple>
 #include <vector>
 
 #include <absl/container/flat_hash_map.h>
@@ -124,13 +125,13 @@ constexpr int cFetchTaskTimeout = 100;
 auto fetch_task(
         spider::worker::WorkerClient& client,
         std::optional<boost::uuids::uuid> fail_task_id
-) -> boost::uuids::uuid {
+) -> std::tuple<boost::uuids::uuid, boost::uuids::uuid> {
     spdlog::debug("Fetching task");
     while (true) {
-        std::optional<boost::uuids::uuid> const optional_task_id
+        std::optional<std::tuple<boost::uuids::uuid, boost::uuids::uuid>> const optional_task_ids
                 = client.get_next_task(fail_task_id);
-        if (optional_task_id.has_value()) {
-            return optional_task_id.value();
+        if (optional_task_ids.has_value()) {
+            return optional_task_ids.value();
         }
         // If the first request succeeds, later requests should not include the failed task id
         fail_task_id = std::nullopt;
@@ -215,7 +216,8 @@ auto task_loop(
     std::optional<boost::uuids::uuid> fail_task_id = std::nullopt;
     while (!stop_token.stop_requested()) {
         boost::asio::io_context context;
-        boost::uuids::uuid const task_id = fetch_task(client, fail_task_id);
+        auto const [task_id, task_instance_id] = fetch_task(client, fail_task_id);
+        spider::core::TaskInstance instance{task_id, task_instance_id};
         spdlog::debug("Fetched task {}", boost::uuids::to_string(task_id));
         fail_task_id = std::nullopt;
         // Fetch task detail from metadata storage
@@ -223,20 +225,6 @@ auto task_loop(
         spider::core::StorageErr err = metadata_store->get_task(task_id, &task);
         if (!err.success()) {
             spdlog::error("Failed to fetch task detail: {}", err.description);
-            continue;
-        }
-
-        // Update task status to running
-        err = metadata_store->set_task_running(task_id);
-        if (!err.success()) {
-            spdlog::debug("Failed to update task status to running: {}", err.description);
-            continue;
-        }
-        spider::core::TaskInstance const instance{task_id};
-        spdlog::debug("Adding task instance");
-        err = metadata_store->add_task_instance(instance);
-        if (!err.success()) {
-            spdlog::error("Failed to add task instance: {}", err.description);
             continue;
         }
 

--- a/tests/scheduler/test-SchedulerPolicy.cpp
+++ b/tests/scheduler/test-SchedulerPolicy.cpp
@@ -56,11 +56,11 @@ TEMPLATE_LIST_TEST_CASE(
     boost::uuids::uuid const job_id_2 = gen();
     REQUIRE(metadata_store->add_job(job_id_2, client_id, graph_2).success());
 
-    spider::scheduler::FifoPolicy policy;
+    spider::scheduler::FifoPolicy policy{metadata_store, data_store};
 
     // Scheduler the earlier task
     std::optional<boost::uuids::uuid> const optional_task_id
-            = policy.schedule_next(metadata_store, data_store, gen(), "");
+            = policy.schedule_next(gen(), "");
     REQUIRE(optional_task_id.has_value());
     if (optional_task_id.has_value()) {
         boost::uuids::uuid const& task_id = optional_task_id.value();
@@ -103,12 +103,12 @@ TEMPLATE_LIST_TEST_CASE(
     graph.add_output_task(task.get_id());
     REQUIRE(metadata_store->add_job(job_id, client_id, graph).success());
 
-    spider::scheduler::FifoPolicy policy;
+    spider::scheduler::FifoPolicy policy{metadata_store, data_store};
     // Schedule with wrong address
-    REQUIRE_FALSE(policy.schedule_next(metadata_store, data_store, gen(), "").has_value());
+    REQUIRE_FALSE(policy.schedule_next(gen(), "").has_value());
     // Schedule with correct address
     std::optional<boost::uuids::uuid> const optional_task_id
-            = policy.schedule_next(metadata_store, data_store, gen(), "127.0.0.1");
+            = policy.schedule_next(gen(), "127.0.0.1");
     REQUIRE(optional_task_id.has_value());
     if (optional_task_id.has_value()) {
         boost::uuids::uuid const& task_id = optional_task_id.value();
@@ -150,10 +150,10 @@ TEMPLATE_LIST_TEST_CASE(
     graph.add_output_task(task.get_id());
     REQUIRE(metadata_store->add_job(job_id, client_id, graph).success());
 
-    spider::scheduler::FifoPolicy policy;
+    spider::scheduler::FifoPolicy policy{metadata_store, data_store};
     // Schedule with wrong address
     std::optional<boost::uuids::uuid> const optional_task_id
-            = policy.schedule_next(metadata_store, data_store, gen(), "");
+            = policy.schedule_next(gen(), "");
     REQUIRE(optional_task_id.has_value());
     if (optional_task_id.has_value()) {
         boost::uuids::uuid const& task_id = optional_task_id.value();

--- a/tests/scheduler/test-SchedulerPolicy.cpp
+++ b/tests/scheduler/test-SchedulerPolicy.cpp
@@ -59,8 +59,7 @@ TEMPLATE_LIST_TEST_CASE(
     spider::scheduler::FifoPolicy policy{metadata_store, data_store};
 
     // Scheduler the earlier task
-    std::optional<boost::uuids::uuid> const optional_task_id
-            = policy.schedule_next(gen(), "");
+    std::optional<boost::uuids::uuid> const optional_task_id = policy.schedule_next(gen(), "");
     REQUIRE(optional_task_id.has_value());
     if (optional_task_id.has_value()) {
         boost::uuids::uuid const& task_id = optional_task_id.value();
@@ -152,8 +151,7 @@ TEMPLATE_LIST_TEST_CASE(
 
     spider::scheduler::FifoPolicy policy{metadata_store, data_store};
     // Schedule with wrong address
-    std::optional<boost::uuids::uuid> const optional_task_id
-            = policy.schedule_next(gen(), "");
+    std::optional<boost::uuids::uuid> const optional_task_id = policy.schedule_next(gen(), "");
     REQUIRE(optional_task_id.has_value());
     if (optional_task_id.has_value()) {
         boost::uuids::uuid const& task_id = optional_task_id.value();

--- a/tests/scheduler/test-SchedulerServer.cpp
+++ b/tests/scheduler/test-SchedulerServer.cpp
@@ -46,7 +46,7 @@ TEMPLATE_LIST_TEST_CASE(
     std::shared_ptr<spider::core::DataStorage> const data_store = std::move(std::get<1>(storages));
 
     std::shared_ptr<spider::scheduler::SchedulerPolicy> const policy
-            = std::make_shared<spider::scheduler::FifoPolicy>();
+            = std::make_shared<spider::scheduler::FifoPolicy>(metadata_store, data_store);
 
     constexpr unsigned short cPort = 6021;
     spider::core::StopToken stop_token;
@@ -100,7 +100,7 @@ TEMPLATE_LIST_TEST_CASE(
         spider::scheduler::ScheduleTaskResponse const res
                 = object.as<spider::scheduler::ScheduleTaskResponse>();
         REQUIRE(res.has_task_id());
-        REQUIRE(res.get_task_id() == parent_task.get_id());
+        REQUIRE(std::get<0>(res.get_task_ids()) == parent_task.get_id());
     }
     socket.close();
     server.stop();


### PR DESCRIPTION
# Description
Scheduler fetches all ready tasks from storage on each schedule task request, which is inefficient. Now scheduler caches the tasks queried from storage for a short period or number of schedule requests before another storage query.


# Validation performed
- [x] GitHub workflows pass
- [x] Unit tests pass in dev container
- [x] Integration tests pass in dev container


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a task caching mechanism for improved scheduler performance.
  - Enhanced task scheduling with more flexible task instance management.

- **Improvements**
  - Updated task scheduling policy to support more complex task retrieval.
  - Improved metadata and data storage interactions.
  - Refined task timeout and instance handling.

- **Changes**
  - Modified task ID management to support multiple task identifiers.
  - Updated method signatures across scheduler and worker components.
  - Streamlined task scheduling logic, reducing the number of parameters in method calls.

- **Bug Fixes**
  - Improved error handling in task instance creation.
  - Enhanced task locality checking mechanisms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->