### PR TITLE
fix: Remove binary decode in integration test after using VARBINARY in storage (#60)

### DIFF
--- a/tests/integration/test_scheduler_worker.py
+++ b/tests/integration/test_scheduler_worker.py
@@ -222,17 +222,17 @@ class TestSchedulerWorker:
         assert state == "success"
         outputs = get_task_outputs(storage, parent_1.id)
         assert len(outputs) == 1
-        assert outputs[0].value == msgpack.packb(3).decode("utf-8")
+        assert outputs[0].value == msgpack.packb(3)
         state = get_task_state(storage, parent_2.id)
         assert state == "success"
         outputs = get_task_outputs(storage, parent_2.id)
         assert len(outputs) == 1
-        assert outputs[0].value == msgpack.packb(7).decode("utf-8")
+        assert outputs[0].value == msgpack.packb(7)
         state = get_task_state(storage, child.id)
         assert state == "success"
         outputs = get_task_outputs(storage, child.id)
         assert len(outputs) == 1
-        assert outputs[0].value == msgpack.packb(10).decode("utf-8")
+        assert outputs[0].value == msgpack.packb(10)
 
     def test_job_failure(self, scheduler_worker, storage, fail_job):
         task = fail_job
@@ -249,7 +249,7 @@ class TestSchedulerWorker:
         assert state == "success"
         outputs = get_task_outputs(storage, task.id)
         assert len(outputs) == 1
-        assert outputs[0].value == msgpack.packb(2).decode("utf-8")
+        assert outputs[0].value == msgpack.packb(2)
 
     def test_random_fail_job(self, scheduler_worker, storage, random_fail_job):
         task = random_fail_job


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description

#60 uses `VARBINARY` instead of `VARCHAR` in storage. Python connector returns binary instead of string, thus the integration tests should not decode the binary string when checking the results.



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* [ ] GitHub workflows pass
* [x] Unit tests pass in dev container
* [x] Integration tests pass in dev container



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Refined output validations in tests by removing redundant transformations for clearer comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->