### PR TITLE
chore(docs): Update quick-start docs to recommend gcc-11+ and clang-14+

### DIFF
--- a/docs/src/user-docs/guides-quick-start.md
+++ b/docs/src/user-docs/guides-quick-start.md
@@ -24,7 +24,7 @@ In the rest of this guide:
 In the guide below, you'll need:
 
 * CMake 3.22.1+
-* GCC 10+ or Clang 7+
+* GCC 11+ or Clang 14+
 * [Docker] 20.10+
   * If you're not running as root, ensure `docker` can be run
     [without superuser privileges][docker-non-root].


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

This PR updates the quick start docs for spider to recommend gcc-11+ and clang-14+. Spider uses std::bit_cast, which is only supported as of gcc-11+ and clang-14+ per this [compiler support reference](https://en.cppreference.com/w/cpp/compiler_support/20).

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* Validated that docs can still be built succesfully


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the quick start guide to reflect increased minimum compiler requirements (now GCC 11+ and Clang 14+), ensuring that user environments are in line with current standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->