### PR TITLE
fix: Add storage connection in storage interface

### DIFF
--- a/src/spider/CMakeLists.txt
+++ b/src/spider/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SPIDER_CORE_HEADERS
     utils/LruCache.hpp
     storage/MetadataStorage.hpp
     storage/DataStorage.hpp
+    storage/StorageConnection.hpp
     storage/MySqlConnection.hpp
     storage/MySqlStorage.hpp
     worker/FunctionManager.hpp

--- a/src/spider/client/Data.hpp
+++ b/src/spider/client/Data.hpp
@@ -14,6 +14,7 @@
 #include "../io/MsgPack.hpp"  // IWYU pragma: keep
 #include "../io/Serializer.hpp"
 #include "../storage/DataStorage.hpp"
+#include "../storage/MySqlConnection.hpp"
 #include "Exception.hpp"
 
 namespace spider {
@@ -64,7 +65,13 @@ public:
     void set_locality(std::vector<std::string> const& nodes, bool hard) {
         m_impl->set_locality(nodes);
         m_impl->set_hard_locality(hard);
-        m_data_store->set_data_locality(*m_impl);
+        std::variant<core::MySqlConnection, core::StorageErr> conn_result
+                = core::MySqlConnection::create(m_data_store->get_url());
+        if (std::holds_alternative<core::StorageErr>(conn_result)) {
+            throw ConnectionException(std::get<core::StorageErr>(conn_result).description);
+        }
+        core::MySqlConnection& conn = std::get<core::MySqlConnection>(conn_result);
+        m_data_store->set_data_locality(conn, *m_impl);
     }
 
     class Builder {
@@ -108,16 +115,22 @@ public:
             auto data = std::make_unique<core::Data>(std::string{buffer.data(), buffer.size()});
             data->set_locality(m_nodes);
             data->set_hard_locality(m_hard_locality);
+            std::variant<core::MySqlConnection, core::StorageErr> conn_result
+                    = core::MySqlConnection::create(m_data_store->get_url());
+            if (std::holds_alternative<core::StorageErr>(conn_result)) {
+                throw ConnectionException(std::get<core::StorageErr>(conn_result).description);
+            }
+            core::MySqlConnection& conn = std::get<core::MySqlConnection>(conn_result);
             core::StorageErr err;
             switch (m_data_source) {
                 case DataSource::Driver:
-                    err = m_data_store->add_driver_data(m_source_id, *data);
+                    err = m_data_store->add_driver_data(conn, m_source_id, *data);
                     if (!err.success()) {
                         throw ConnectionException(err.description);
                     }
                     break;
                 case DataSource::TaskContext:
-                    err = m_data_store->add_task_data(m_source_id, *data);
+                    err = m_data_store->add_task_data(conn, m_source_id, *data);
                     if (!err.success()) {
                         throw ConnectionException(err.description);
                     }

--- a/src/spider/client/Driver.cpp
+++ b/src/spider/client/Driver.cpp
@@ -26,7 +26,14 @@ Driver::Driver(std::string const& storage_url) {
     m_metadata_storage = std::make_shared<core::MySqlMetadataStorage>(storage_url);
     m_data_storage = std::make_shared<core::MySqlDataStorage>(storage_url);
 
-    core::StorageErr const err = m_metadata_storage->add_driver(core::Driver{m_id});
+    std::variant<core::MySqlConnection, core::StorageErr> conn_result
+            = core::MySqlConnection::create(storage_url);
+    if (std::holds_alternative<core::StorageErr>(conn_result)) {
+        throw ConnectionException(std::get<core::StorageErr>(conn_result).description);
+    }
+    core::MySqlConnection& conn = std::get<core::MySqlConnection>(conn_result);
+
+    core::StorageErr const err = m_metadata_storage->add_driver(conn, core::Driver{m_id});
     if (!err.success()) {
         if (core::StorageErrType::DuplicateKeyErr == err.type) {
             throw DriverIdInUseException(m_id);
@@ -39,7 +46,14 @@ Driver::Driver(std::string const& storage_url) {
     m_heartbeat_thread = std::jthread([this](std::stop_token stoken) {
         while (!stoken.stop_requested()) {
             std::this_thread::sleep_for(std::chrono::seconds(1));
-            core::StorageErr const err = m_metadata_storage->update_heartbeat(m_id);
+            std::variant<core::MySqlConnection, core::StorageErr> conn_result
+                    = core::MySqlConnection::create(m_metadata_storage->get_url());
+            if (std::holds_alternative<core::StorageErr>(conn_result)) {
+                throw ConnectionException(std::get<core::StorageErr>(conn_result).description);
+            }
+            core::MySqlConnection& conn = std::get<core::MySqlConnection>(conn_result);
+
+            core::StorageErr const err = m_metadata_storage->update_heartbeat(conn, m_id);
             if (!err.success()) {
                 throw ConnectionException(err.description);
             }
@@ -50,8 +64,14 @@ Driver::Driver(std::string const& storage_url) {
 Driver::Driver(std::string const& storage_url, boost::uuids::uuid const id) : m_id{id} {
     m_metadata_storage = std::make_shared<core::MySqlMetadataStorage>(storage_url);
     m_data_storage = std::make_shared<core::MySqlDataStorage>(storage_url);
+    std::variant<core::MySqlConnection, core::StorageErr> conn_result
+            = core::MySqlConnection::create(storage_url);
+    if (std::holds_alternative<core::StorageErr>(conn_result)) {
+        throw ConnectionException(std::get<core::StorageErr>(conn_result).description);
+    }
+    core::MySqlConnection& conn = std::get<core::MySqlConnection>(conn_result);
 
-    core::StorageErr const err = m_metadata_storage->add_driver(core::Driver{m_id});
+    core::StorageErr const err = m_metadata_storage->add_driver(conn, core::Driver{m_id});
     if (!err.success()) {
         if (core::StorageErrType::DuplicateKeyErr == err.type) {
             throw DriverIdInUseException(m_id);
@@ -64,7 +84,14 @@ Driver::Driver(std::string const& storage_url, boost::uuids::uuid const id) : m_
     m_heartbeat_thread = std::jthread([this](std::stop_token stoken) {
         while (!stoken.stop_requested()) {
             std::this_thread::sleep_for(std::chrono::seconds(1));
-            core::StorageErr const err = m_metadata_storage->update_heartbeat(m_id);
+            std::variant<core::MySqlConnection, core::StorageErr> conn_result
+                    = core::MySqlConnection::create(m_metadata_storage->get_url());
+            if (std::holds_alternative<core::StorageErr>(conn_result)) {
+                throw ConnectionException(std::get<core::StorageErr>(conn_result).description);
+            }
+            core::MySqlConnection& conn = std::get<core::MySqlConnection>(conn_result);
+
+            core::StorageErr const err = m_metadata_storage->update_heartbeat(conn, m_id);
             if (!err.success()) {
                 throw ConnectionException(err.description);
             }
@@ -74,15 +101,30 @@ Driver::Driver(std::string const& storage_url, boost::uuids::uuid const id) : m_
 
 auto Driver::kv_store_insert(std::string const& key, std::string const& value) -> void {
     core::KeyValueData const kv_data{key, value, m_id};
-    core::StorageErr const err = m_data_storage->add_client_kv_data(kv_data);
+
+    std::variant<core::MySqlConnection, core::StorageErr> conn_result
+            = core::MySqlConnection::create(m_data_storage->get_url());
+    if (std::holds_alternative<core::StorageErr>(conn_result)) {
+        throw ConnectionException(std::get<core::StorageErr>(conn_result).description);
+    }
+    core::MySqlConnection& conn = std::get<core::MySqlConnection>(conn_result);
+
+    core::StorageErr const err = m_data_storage->add_client_kv_data(conn, kv_data);
     if (!err.success()) {
         throw ConnectionException(err.description);
     }
 }
 
 auto Driver::kv_store_get(std::string const& key) -> std::optional<std::string> {
+    std::variant<core::MySqlConnection, core::StorageErr> conn_result
+            = core::MySqlConnection::create(m_data_storage->get_url());
+    if (std::holds_alternative<core::StorageErr>(conn_result)) {
+        throw ConnectionException(std::get<core::StorageErr>(conn_result).description);
+    }
+    core::MySqlConnection& conn = std::get<core::MySqlConnection>(conn_result);
+
     std::string value;
-    core::StorageErr const err = m_data_storage->get_client_kv_data(m_id, key, &value);
+    core::StorageErr const err = m_data_storage->get_client_kv_data(conn, m_id, key, &value);
     if (!err.success()) {
         if (core::StorageErrType::KeyNotFoundErr == err.type) {
             return std::nullopt;

--- a/src/spider/client/Driver.hpp
+++ b/src/spider/client/Driver.hpp
@@ -175,8 +175,8 @@ public:
         graph.add_output_task(new_task.get_id());
         std::variant<core::MySqlConnection, core::StorageErr> conn_result
                 = core::MySqlConnection::create(m_metadata_storage->get_url());
-        if (std::holds_alternative<spider::core::StorageErr>(conn_result)) {
-            throw ConnectionException(std::get<spider::core::StorageErr>(conn_result).description);
+        if (std::holds_alternative<core::StorageErr>(conn_result)) {
+            throw ConnectionException(std::get<core::StorageErr>(conn_result).description);
         }
         core::MySqlConnection& conn = std::get<core::MySqlConnection>(conn_result);
         core::StorageErr err = m_metadata_storage->add_job(conn, job_id, m_id, graph);
@@ -222,8 +222,14 @@ public:
         graph.m_impl->reset_ids();
         boost::uuids::random_generator gen;
         boost::uuids::uuid const job_id = gen();
+        std::variant<core::MySqlConnection, core::StorageErr> conn_result
+                = core::MySqlConnection::create(m_metadata_storage->get_url());
+        if (std::holds_alternative<core::StorageErr>(conn_result)) {
+            throw ConnectionException(std::get<core::StorageErr>(conn_result).description);
+        }
+        core::MySqlConnection& conn = std::get<core::MySqlConnection>(conn_result);
         core::StorageErr const err
-                = m_metadata_storage->add_job(job_id, m_id, graph.m_impl->get_graph());
+                = m_metadata_storage->add_job(conn, job_id, m_id, graph.m_impl->get_graph());
         if (!err.success()) {
             throw ConnectionException(fmt::format("Failed to start job: {}", err.description));
         }

--- a/src/spider/client/Driver.hpp
+++ b/src/spider/client/Driver.hpp
@@ -173,7 +173,13 @@ public:
         graph.add_task(new_task);
         graph.add_input_task(new_task.get_id());
         graph.add_output_task(new_task.get_id());
-        core::StorageErr err = m_metadata_storage->add_job(job_id, m_id, graph);
+        std::variant<core::MySqlConnection, core::StorageErr> conn_result
+                = core::MySqlConnection::create(m_metadata_storage->get_url());
+        if (std::holds_alternative<spider::core::StorageErr>(conn_result)) {
+            throw ConnectionException(std::get<spider::core::StorageErr>(conn_result).description);
+        }
+        core::MySqlConnection& conn = std::get<core::MySqlConnection>(conn_result);
+        core::StorageErr err = m_metadata_storage->add_job(conn, job_id, m_id, graph);
         if (!err.success()) {
             throw ConnectionException(fmt::format("Failed to start job: {}", err.description));
         }
@@ -235,7 +241,14 @@ public:
      */
     auto get_jobs() -> std::vector<boost::uuids::uuid> {
         std::vector<boost::uuids::uuid> job_ids;
-        core::StorageErr const err = m_metadata_storage->get_jobs_by_client_id(m_id, &job_ids);
+        std::variant<core::MySqlConnection, core::StorageErr> conn_result
+                = core::MySqlConnection::create(m_metadata_storage->get_url());
+        if (std::holds_alternative<spider::core::StorageErr>(conn_result)) {
+            throw ConnectionException(std::get<spider::core::StorageErr>(conn_result).description);
+        }
+        core::MySqlConnection& conn = std::get<core::MySqlConnection>(conn_result);
+        core::StorageErr const err
+                = m_metadata_storage->get_jobs_by_client_id(conn, m_id, &job_ids);
         if (!err.success()) {
             throw ConnectionException("Failed to get jobs.");
         }

--- a/src/spider/client/TaskContext.cpp
+++ b/src/spider/client/TaskContext.cpp
@@ -17,8 +17,15 @@ auto TaskContext::get_id() const -> boost::uuids::uuid {
 }
 
 auto TaskContext::kv_store_get(std::string const& key) -> std::optional<std::string> {
+    std::variant<core::MySqlConnection, core::StorageErr> conn_result
+            = core::MySqlConnection::create(m_data_store->get_url());
+    if (std::holds_alternative<core::StorageErr>(conn_result)) {
+        throw ConnectionException(std::get<core::StorageErr>(conn_result).description);
+    }
+    core::MySqlConnection& conn = std::get<core::MySqlConnection>(conn_result);
+
     std::string value;
-    core::StorageErr const err = m_data_store->get_task_kv_data(m_task_id, key, &value);
+    core::StorageErr const err = m_data_store->get_task_kv_data(conn, m_task_id, key, &value);
     if (!err.success()) {
         if (core::StorageErrType::KeyNotFoundErr == err.type) {
             return std::nullopt;
@@ -29,16 +36,30 @@ auto TaskContext::kv_store_get(std::string const& key) -> std::optional<std::str
 }
 
 auto TaskContext::kv_store_insert(std::string const& key, std::string const& value) -> void {
+    std::variant<core::MySqlConnection, core::StorageErr> conn_result
+            = core::MySqlConnection::create(m_data_store->get_url());
+    if (std::holds_alternative<core::StorageErr>(conn_result)) {
+        throw ConnectionException(std::get<core::StorageErr>(conn_result).description);
+    }
+    core::MySqlConnection& conn = std::get<core::MySqlConnection>(conn_result);
+
     core::KeyValueData const kv_data{key, value, m_task_id};
-    core::StorageErr const err = m_data_store->add_task_kv_data(kv_data);
+    core::StorageErr const err = m_data_store->add_task_kv_data(conn, kv_data);
     if (!err.success()) {
         throw ConnectionException(err.description);
     }
 }
 
 auto TaskContext::get_jobs() -> std::vector<boost::uuids::uuid> {
+    std::variant<core::MySqlConnection, core::StorageErr> conn_result
+            = core::MySqlConnection::create(m_metadata_store->get_url());
+    if (std::holds_alternative<core::StorageErr>(conn_result)) {
+        throw ConnectionException(std::get<core::StorageErr>(conn_result).description);
+    }
+    core::MySqlConnection& conn = std::get<core::MySqlConnection>(conn_result);
+
     std::vector<boost::uuids::uuid> job_ids;
-    core::StorageErr const err = m_metadata_store->get_jobs_by_client_id(m_task_id, &job_ids);
+    core::StorageErr const err = m_metadata_store->get_jobs_by_client_id(conn, m_task_id, &job_ids);
     if (!err.success()) {
         throw ConnectionException("Failed to get jobs.");
     }

--- a/src/spider/client/TaskContext.hpp
+++ b/src/spider/client/TaskContext.hpp
@@ -121,8 +121,8 @@ public:
      * @throw spider::ConnectionException
      */
     template <TaskIo ReturnType, TaskIo... Params, TaskIo... Inputs>
-    auto start(TaskFunction<ReturnType, Params...> const& task, Inputs&&... inputs)
-            -> Job<ReturnType> {
+    auto
+    start(TaskFunction<ReturnType, Params...> const& task, Inputs&&... inputs) -> Job<ReturnType> {
         // Check input type
         static_assert(
                 sizeof...(Inputs) == sizeof...(Params),
@@ -178,8 +178,8 @@ public:
      * @throw spider::ConnectionException
      */
     template <TaskIo ReturnType, TaskIo... Params, TaskIo... Inputs>
-    auto start(TaskGraph<ReturnType, Params...> const& graph, Inputs&&... inputs)
-            -> Job<ReturnType> {
+    auto
+    start(TaskGraph<ReturnType, Params...> const& graph, Inputs&&... inputs) -> Job<ReturnType> {
         // Check input type
         static_assert(
                 sizeof...(Inputs) == sizeof...(Params),

--- a/src/spider/scheduler/FifoPolicy.cpp
+++ b/src/spider/scheduler/FifoPolicy.cpp
@@ -23,6 +23,7 @@ namespace {
 
 auto task_locality_satisfied(
         std::shared_ptr<spider::core::DataStorage> const& data_store,
+        spider::core::StorageConnection& conn,
         spider::core::Task const& task,
         std::string const& addr
 ) -> bool {
@@ -36,7 +37,7 @@ auto task_locality_satisfied(
         }
         boost::uuids::uuid const data_id = optional_data_id.value();
         spider::core::Data data;
-        if (false == data_store->get_data(data_id, &data).success()) {
+        if (false == data_store->get_data(conn, data_id, &data).success()) {
             throw std::runtime_error(
                     fmt::format("Data with id {} not exists.", boost::uuids::to_string((data_id)))
             );
@@ -61,13 +62,16 @@ namespace spider::scheduler {
 
 FifoPolicy::FifoPolicy(
         std::shared_ptr<core::MetadataStorage> const& metadata_store,
-        std::shared_ptr<core::DataStorage> const& data_store
+        std::shared_ptr<core::DataStorage> const& data_store,
+        core::StorageConnection& conn
 )
         : m_metadata_store{metadata_store},
           m_data_store{data_store},
+          m_conn{conn},
           m_task_cache{
                   metadata_store,
                   data_store,
+                  conn,
                   [&](std::vector<core::Task>& tasks,
                       boost::uuids::uuid const& worker_id,
                       std::string const& worker_addr) -> std::optional<boost::uuids::uuid> {
@@ -81,7 +85,7 @@ auto FifoPolicy::get_next_task(
         std::string const& worker_addr
 ) -> std::optional<boost::uuids::uuid> {
     std::erase_if(tasks, [this, worker_addr](core::Task const& task) -> bool {
-        return !task_locality_satisfied(m_data_store, task, worker_addr);
+        return !task_locality_satisfied(m_data_store, m_conn, task, worker_addr);
     });
 
     if (tasks.empty()) {
@@ -99,7 +103,8 @@ auto FifoPolicy::get_next_task(
                 if (optional_job_id.has_value()) {
                     job_id = optional_job_id.value();
                 } else {
-                    if (false == m_metadata_store->get_task_job_id(task_id, &job_id).success()) {
+                    if (false
+                        == m_metadata_store->get_task_job_id(m_conn, task_id, &job_id).success()) {
                         throw std::runtime_error(fmt::format(
                                 "Task with id {} not exists.",
                                 boost::uuids::to_string(task_id)
@@ -115,7 +120,9 @@ auto FifoPolicy::get_next_task(
                 }
 
                 core::JobMetadata job_metadata;
-                if (false == m_metadata_store->get_job_metadata(job_id, &job_metadata).success()) {
+                if (false
+                    == m_metadata_store->get_job_metadata(m_conn, job_id, &job_metadata).success())
+                {
                     throw std::runtime_error(fmt::format(
                             "Job with id {} not exists.",
                             boost::uuids::to_string(job_id)

--- a/src/spider/scheduler/FifoPolicy.hpp
+++ b/src/spider/scheduler/FifoPolicy.hpp
@@ -12,6 +12,7 @@
 #include "../core/Task.hpp"
 #include "../storage/DataStorage.hpp"
 #include "../storage/MetadataStorage.hpp"
+#include "../storage/StorageConnection.hpp"
 #include "../utils/LruCache.hpp"
 #include "SchedulerPolicy.hpp"
 #include "SchedulerTaskCache.hpp"
@@ -22,7 +23,9 @@ class FifoPolicy final : public SchedulerPolicy {
 public:
     FifoPolicy(
             std::shared_ptr<core::MetadataStorage> const& metadata_store,
-            std::shared_ptr<core::DataStorage> const& data_store
+            std::shared_ptr<core::DataStorage> const& data_store,
+            core::StorageConnection& conn
+
     );
 
     auto schedule_next(boost::uuids::uuid worker_id, std::string const& worker_addr)
@@ -37,6 +40,7 @@ private:
 
     std::shared_ptr<core::MetadataStorage> m_metadata_store;
     std::shared_ptr<core::DataStorage> m_data_store;
+    core::StorageConnection& m_conn;
 
     SchedulerTaskCache m_task_cache;
 

--- a/src/spider/scheduler/SchedulerServer.cpp
+++ b/src/spider/scheduler/SchedulerServer.cpp
@@ -19,6 +19,7 @@
 #include "../io/Serializer.hpp"  // IWYU pragma: keep
 #include "../storage/DataStorage.hpp"
 #include "../storage/MetadataStorage.hpp"
+#include "../storage/StorageConnection.hpp"
 #include "../utils/StopToken.hpp"
 #include "SchedulerMessage.hpp"
 #include "SchedulerPolicy.hpp"
@@ -30,12 +31,14 @@ SchedulerServer::SchedulerServer(
         std::shared_ptr<SchedulerPolicy> policy,
         std::shared_ptr<core::MetadataStorage> metadata_store,
         std::shared_ptr<core::DataStorage> data_store,
+        core::StorageConnection& conn,
         core::StopToken& stop_token
 )
         : m_port{port},
           m_policy{std::move(policy)},
           m_metadata_store{std::move(metadata_store)},
           m_data_store{std::move(data_store)},
+          m_conn{conn},
           m_stop_token{stop_token} {
     boost::asio::co_spawn(m_context, receive_message(), boost::asio::detached);
     std::lock_guard const lock{m_mutex};
@@ -136,7 +139,8 @@ auto SchedulerServer::process_message(boost::asio::ip::tcp::socket socket
     // Reset the whole job if the task fails
     if (request.has_task_id()) {
         boost::uuids::uuid job_id;
-        core::StorageErr err = m_metadata_store->get_task_job_id(request.get_task_id(), &job_id);
+        core::StorageErr err
+                = m_metadata_store->get_task_job_id(m_conn, request.get_task_id(), &job_id);
         // It is possible the job is deleted, so we don't need to reset it
         if (!err.success()) {
             spdlog::error(
@@ -144,7 +148,7 @@ auto SchedulerServer::process_message(boost::asio::ip::tcp::socket socket
                     boost::uuids::to_string(request.get_task_id())
             );
         } else {
-            err = m_metadata_store->reset_job(job_id);
+            err = m_metadata_store->reset_job(m_conn, job_id);
             if (!err.success()) {
                 spdlog::error("Cannot reset job {}", boost::uuids::to_string(job_id));
                 co_return;
@@ -157,7 +161,7 @@ auto SchedulerServer::process_message(boost::asio::ip::tcp::socket socket
     ScheduleTaskResponse response{};
     if (task_id.has_value()) {
         core::TaskInstance const instance{task_id.value()};
-        core::StorageErr const err = m_metadata_store->create_task_instance(instance);
+        core::StorageErr const err = m_metadata_store->create_task_instance(m_conn, instance);
         if (err.success()) {
             response = ScheduleTaskResponse{task_id.value(), instance.id};
         } else {

--- a/src/spider/scheduler/SchedulerServer.hpp
+++ b/src/spider/scheduler/SchedulerServer.hpp
@@ -8,6 +8,7 @@
 #include "../io/BoostAsio.hpp"  // IWYU pragma: keep
 #include "../storage/DataStorage.hpp"
 #include "../storage/MetadataStorage.hpp"
+#include "../storage/StorageConnection.hpp"
 #include "../utils/StopToken.hpp"
 #include "SchedulerPolicy.hpp"
 
@@ -27,6 +28,7 @@ public:
             std::shared_ptr<SchedulerPolicy> policy,
             std::shared_ptr<core::MetadataStorage> metadata_store,
             std::shared_ptr<core::DataStorage> data_store,
+            core::StorageConnection& conn,
             core::StopToken& stop_token
     );
 
@@ -44,6 +46,7 @@ private:
     std::shared_ptr<SchedulerPolicy> m_policy;
     std::shared_ptr<core::MetadataStorage> m_metadata_store;
     std::shared_ptr<core::DataStorage> m_data_store;
+    core::StorageConnection& m_conn;
 
     boost::asio::io_context m_context;
 

--- a/src/spider/scheduler/SchedulerTaskCache.cpp
+++ b/src/spider/scheduler/SchedulerTaskCache.cpp
@@ -82,12 +82,12 @@ auto SchedulerTaskCache::should_fetch_tasks() -> bool {
 void SchedulerTaskCache::fetch_ready_tasks() {
     m_tasks.clear();
     std::vector<core::Task> tasks;
-    m_metadata_store->get_ready_tasks(&tasks);
+    m_metadata_store->get_ready_tasks(m_conn, &tasks);
     for (core::Task const& task : tasks) {
         m_tasks.emplace(std::make_pair(task.get_id(), task));
     }
     std::vector<std::tuple<core::TaskInstance, core::Task>> task_instances;
-    m_metadata_store->get_task_timeout(&task_instances);
+    m_metadata_store->get_task_timeout(m_conn, &task_instances);
     for (auto const& [task_instance, task] : task_instances) {
         m_tasks.emplace(std::make_pair(task.get_id(), task));
     }

--- a/src/spider/scheduler/SchedulerTaskCache.hpp
+++ b/src/spider/scheduler/SchedulerTaskCache.hpp
@@ -15,6 +15,7 @@
 #include "../core/Task.hpp"
 #include "../storage/DataStorage.hpp"
 #include "../storage/MetadataStorage.hpp"
+#include "../storage/StorageConnection.hpp"
 
 namespace spider::scheduler {
 
@@ -23,6 +24,7 @@ public:
     SchedulerTaskCache(
             std::shared_ptr<core::MetadataStorage> const& metadata_store,
             std::shared_ptr<core::DataStorage> const& data_store,
+            core::StorageConnection& conn,
             std::function<std::optional<boost::uuids::uuid>(
                     std::vector<core::Task>& tasks,
                     boost::uuids::uuid const& worker_id,
@@ -31,6 +33,7 @@ public:
     )
             : m_metadata_store{metadata_store},
               m_data_store{data_store},
+              m_conn{conn},
               m_get_next_task_function{get_next_task_function} {}
 
     auto get_ready_task(boost::uuids::uuid const& worker_id, std::string const& worker_addr)
@@ -46,6 +49,7 @@ private:
 
     std::shared_ptr<core::MetadataStorage> m_metadata_store;
     std::shared_ptr<core::DataStorage> m_data_store;
+    core::StorageConnection& m_conn;
 
     // NOLINTNEXTLINE(misc-include-cleaner)
     absl::flat_hash_map<boost::uuids::uuid, core::Task, std::hash<boost::uuids::uuid>> m_tasks;

--- a/src/spider/scheduler/scheduler.cpp
+++ b/src/spider/scheduler/scheduler.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <system_error>
 #include <thread>
+#include <variant>
 
 #include <boost/any/bad_any_cast.hpp>
 #include <boost/program_options/errors.hpp>
@@ -23,7 +24,9 @@
 #include "../io/BoostAsio.hpp"  // IWYU pragma: keep
 #include "../storage/DataStorage.hpp"
 #include "../storage/MetadataStorage.hpp"
+#include "../storage/MySqlConnection.hpp"
 #include "../storage/MySqlStorage.hpp"
+#include "../storage/StorageConnection.hpp"
 #include "../utils/StopToken.hpp"
 #include "FifoPolicy.hpp"
 #include "SchedulerPolicy.hpp"
@@ -69,6 +72,7 @@ auto parse_args(int const argc, char** argv) -> boost::program_options::variable
 
 auto heartbeat_loop(
         std::shared_ptr<spider::core::MetadataStorage> const& metadata_store,
+        std::string const& storage_url,
         spider::core::Scheduler const& scheduler,
         spider::core::StopToken& stop_token
 ) -> void {
@@ -76,7 +80,19 @@ auto heartbeat_loop(
     while (!stop_token.stop_requested()) {
         std::this_thread::sleep_for(std::chrono::seconds(1));
         spdlog::debug("Updating heartbeat");
-        spider::core::StorageErr const err = metadata_store->update_heartbeat(scheduler.get_id());
+        std::variant<spider::core::MySqlConnection, spider::core::StorageErr> conn_result
+                = spider::core::MySqlConnection::create(storage_url);
+        if (std::holds_alternative<spider::core::StorageErr>(conn_result)) {
+            spdlog::error(
+                    "Failed to connection to storage: {}",
+                    std::get<spider::core::StorageErr>(conn_result).description
+            );
+            fail_count++;
+            continue;
+        }
+        spider::core::MySqlConnection& conn = std::get<spider::core::MySqlConnection>(conn_result);
+        spider::core::StorageErr const err
+                = metadata_store->update_heartbeat(conn, scheduler.get_id());
         if (!err.success()) {
             spdlog::error("Failed to update scheduler heartbeat: {}", err.description);
             fail_count++;
@@ -93,21 +109,32 @@ auto heartbeat_loop(
 auto cleanup_loop(
         std::shared_ptr<spider::core::MetadataStorage> const& metadata_store,
         std::shared_ptr<spider::core::DataStorage> const& data_store,
+        std::string const& storage_url,
         spider::core::Scheduler const& scheduler,
         spider::core::StopToken& stop_token
 ) -> void {
     while (!stop_token.stop_requested()) {
         std::this_thread::sleep_for(std::chrono::seconds(cCleanupInterval));
         spdlog::debug("Starting cleanup");
+        std::variant<spider::core::MySqlConnection, spider::core::StorageErr> conn_result
+                = spider::core::MySqlConnection::create(storage_url);
+        if (std::holds_alternative<spider::core::StorageErr>(conn_result)) {
+            spdlog::error(
+                    "Failed to connection to storage: {}",
+                    std::get<spider::core::StorageErr>(conn_result).description
+            );
+            continue;
+        }
+        spider::core::MySqlConnection& conn = std::get<spider::core::MySqlConnection>(conn_result);
         spider::core::StorageErr err
-                = metadata_store->set_scheduler_state(scheduler.get_id(), "gc");
+                = metadata_store->set_scheduler_state(conn, scheduler.get_id(), "gc");
         if (!err.success()) {
             spdlog::error("Failed to set scheduler state to gc: {}", err.description);
             continue;
         }
-        data_store->remove_dangling_data();
+        data_store->remove_dangling_data(conn);
         for (size_t i = 0; i < cRetryCount; ++i) {
-            err = metadata_store->set_scheduler_state(scheduler.get_id(), "normal");
+            err = metadata_store->set_scheduler_state(conn, scheduler.get_id(), "normal");
             if (!err.success()) {
                 spdlog::error("Failed to set scheduler state to normal: {}", err.description);
                 if (i >= cRetryCount - 1) {
@@ -161,17 +188,27 @@ auto main(int argc, char** argv) -> int {
 
     // Create storages
     std::shared_ptr<spider::core::MetadataStorage> const metadata_store
-            = std::make_shared<spider::core::MySqlMetadataStorage>(storage_url);
+            = std::make_shared<spider::core::MySqlMetadataStorage>();
     std::shared_ptr<spider::core::DataStorage> const data_store
-            = std::make_shared<spider::core::MySqlDataStorage>(storage_url);
+            = std::make_shared<spider::core::MySqlDataStorage>();
 
     // Initialize storages
-    spider::core::StorageErr err = metadata_store->initialize();
+    std::variant<spider::core::MySqlConnection, spider::core::StorageErr> conn_result
+            = spider::core::MySqlConnection::create(storage_url);
+    if (std::holds_alternative<spider::core::StorageErr>(conn_result)) {
+        spdlog::error(
+                "Failed to connection to storage: {}",
+                std::get<spider::core::StorageErr>(conn_result).description
+        );
+    }
+    spider::core::MySqlConnection& conn = std::get<spider::core::MySqlConnection>(conn_result);
+
+    spider::core::StorageErr err = metadata_store->initialize(conn);
     if (!err.success()) {
         spdlog::error("Failed to initialize metadata storage: {}", err.description);
         return cStorageErr;
     }
-    err = data_store->initialize();
+    err = data_store->initialize(conn);
     if (!err.success()) {
         spdlog::error("Failed to initialize data storage: {}", err.description);
         return cStorageErr;
@@ -189,7 +226,7 @@ auto main(int argc, char** argv) -> int {
 
     // Register scheduler with storage
     spider::core::Scheduler const scheduler{scheduler_id, scheduler_addr, port};
-    err = metadata_store->add_scheduler(scheduler);
+    err = metadata_store->add_scheduler(conn, scheduler);
     if (!err.success()) {
         spdlog::error("Failed to register scheduler with storage server: {}", err.description);
         return cStorageErr;
@@ -200,6 +237,7 @@ auto main(int argc, char** argv) -> int {
         std::thread heartbeat_thread{
                 heartbeat_loop,
                 std::cref(metadata_store),
+                std::cref(storage_url),
                 std::ref(scheduler),
                 std::ref(stop_token),
         };
@@ -209,6 +247,7 @@ auto main(int argc, char** argv) -> int {
                 cleanup_loop,
                 std::cref(metadata_store),
                 std::cref(data_store),
+                std::cref(storage_url),
                 std::cref(scheduler),
                 std::ref(stop_token)
         };

--- a/src/spider/scheduler/scheduler.cpp
+++ b/src/spider/scheduler/scheduler.cpp
@@ -220,7 +220,8 @@ auto main(int argc, char** argv) -> int {
     spider::core::StopToken stop_token;
     std::shared_ptr<spider::scheduler::SchedulerPolicy> const policy
             = std::make_shared<spider::scheduler::FifoPolicy>(metadata_store, data_store, conn);
-    spider::scheduler::SchedulerServer server{port, policy, metadata_store, data_store, conn, stop_token};
+    spider::scheduler::SchedulerServer
+            server{port, policy, metadata_store, data_store, conn, stop_token};
 
     // Register scheduler with storage
     spider::core::Scheduler const scheduler{scheduler_id, scheduler_addr, port};

--- a/src/spider/storage/DataStorage.hpp
+++ b/src/spider/storage/DataStorage.hpp
@@ -75,7 +75,7 @@ public:
             std::string* value
     ) -> StorageErr = 0;
 
-    virtual auto get_url() const -> std::string const& = 0
+    virtual auto get_url() const -> std::string const& = 0;
 };
 }  // namespace spider::core
 

--- a/src/spider/storage/DataStorage.hpp
+++ b/src/spider/storage/DataStorage.hpp
@@ -8,6 +8,7 @@
 #include "../core/Data.hpp"
 #include "../core/Error.hpp"
 #include "../core/KeyValueData.hpp"
+#include "StorageConnection.hpp"
 
 namespace spider::core {
 class DataStorage {
@@ -19,31 +20,56 @@ public:
     auto operator=(DataStorage&&) -> DataStorage& = delete;
     virtual ~DataStorage() = default;
 
-    virtual auto initialize() -> StorageErr = 0;
+    virtual auto initialize(StorageConnection& conn) -> StorageErr = 0;
 
-    virtual auto add_driver_data(boost::uuids::uuid driver_id, Data const& data) -> StorageErr = 0;
-    virtual auto add_task_data(boost::uuids::uuid task_id, Data const& data) -> StorageErr = 0;
-    virtual auto get_data(boost::uuids::uuid id, Data* data) -> StorageErr = 0;
-    virtual auto set_data_locality(Data const& data) -> StorageErr = 0;
-    virtual auto remove_data(boost::uuids::uuid id) -> StorageErr = 0;
-    virtual auto add_task_reference(boost::uuids::uuid id, boost::uuids::uuid task_id) -> StorageErr
+    virtual auto add_driver_data(
+            StorageConnection& conn,
+            boost::uuids::uuid driver_id,
+            Data const& data
+    ) -> StorageErr = 0;
+    virtual auto add_task_data(
+            StorageConnection& conn,
+            boost::uuids::uuid task_id,
+            Data const& data
+    ) -> StorageErr = 0;
+    virtual auto get_data(StorageConnection& conn, boost::uuids::uuid id, Data* data) -> StorageErr
+                                                                                         = 0;
+    virtual auto set_data_locality(StorageConnection& conn, Data const& data) -> StorageErr = 0;
+    virtual auto remove_data(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr = 0;
+    virtual auto add_task_reference(
+            StorageConnection& conn,
+            boost::uuids::uuid id,
+            boost::uuids::uuid task_id
+    ) -> StorageErr = 0;
+    virtual auto remove_task_reference(
+            StorageConnection& conn,
+            boost::uuids::uuid id,
+            boost::uuids::uuid task_id
+    ) -> StorageErr = 0;
+    virtual auto add_driver_reference(
+            StorageConnection& conn,
+            boost::uuids::uuid id,
+            boost::uuids::uuid driver_id
+    ) -> StorageErr = 0;
+    virtual auto remove_driver_reference(
+            StorageConnection& conn,
+            boost::uuids::uuid id,
+            boost::uuids::uuid driver_id
+    ) -> StorageErr = 0;
+    virtual auto remove_dangling_data(StorageConnection& conn) -> StorageErr = 0;
+
+    virtual auto add_client_kv_data(StorageConnection& conn, KeyValueData const& data) -> StorageErr
                                                                                           = 0;
-    virtual auto
-    remove_task_reference(boost::uuids::uuid id, boost::uuids::uuid task_id) -> StorageErr = 0;
-    virtual auto
-    add_driver_reference(boost::uuids::uuid id, boost::uuids::uuid driver_id) -> StorageErr = 0;
-    virtual auto
-    remove_driver_reference(boost::uuids::uuid id, boost::uuids::uuid driver_id) -> StorageErr = 0;
-    virtual auto remove_dangling_data() -> StorageErr = 0;
-
-    virtual auto add_client_kv_data(KeyValueData const& data) -> StorageErr = 0;
-    virtual auto add_task_kv_data(KeyValueData const& data) -> StorageErr = 0;
+    virtual auto add_task_kv_data(StorageConnection& conn, KeyValueData const& data) -> StorageErr
+                                                                                        = 0;
     virtual auto get_client_kv_data(
+            StorageConnection& conn,
             boost::uuids::uuid const& client_id,
             std::string const& key,
             std::string* value
     ) -> StorageErr = 0;
     virtual auto get_task_kv_data(
+            StorageConnection& conn,
             boost::uuids::uuid const& task_id,
             std::string const& key,
             std::string* value

--- a/src/spider/storage/DataStorage.hpp
+++ b/src/spider/storage/DataStorage.hpp
@@ -74,6 +74,8 @@ public:
             std::string const& key,
             std::string* value
     ) -> StorageErr = 0;
+
+    virtual auto get_url() const -> std::string const& = 0
 };
 }  // namespace spider::core
 

--- a/src/spider/storage/MetadataStorage.hpp
+++ b/src/spider/storage/MetadataStorage.hpp
@@ -23,58 +23,109 @@ public:
     auto operator=(MetadataStorage&&) -> MetadataStorage& = delete;
     virtual ~MetadataStorage() = default;
 
-    virtual auto initialize() -> StorageErr = 0;
+    virtual auto initialize(StorageConnection& conn) -> StorageErr = 0;
 
-    virtual auto add_driver(Driver const& driver) -> StorageErr = 0;
-    virtual auto add_scheduler(Scheduler const& scheduler) -> StorageErr = 0;
-    virtual auto get_active_scheduler(std::vector<Scheduler>* schedulers) -> StorageErr = 0;
+    virtual auto add_driver(StorageConnection& conn, Driver const& driver) -> StorageErr = 0;
+    virtual auto add_scheduler(StorageConnection& conn, Scheduler const& scheduler) -> StorageErr
+                                                                                       = 0;
+    virtual auto get_active_scheduler(StorageConnection& conn, std::vector<Scheduler>* schedulers)
+            -> StorageErr = 0;
 
-    virtual auto
-    add_job(boost::uuids::uuid job_id, boost::uuids::uuid client_id, TaskGraph const& task_graph
+    virtual auto add_job(
+            StorageConnection& conn,
+            boost::uuids::uuid job_id,
+            boost::uuids::uuid client_id,
+            TaskGraph const& task_graph
     ) -> StorageErr = 0;
-    virtual auto get_job_metadata(boost::uuids::uuid id, JobMetadata* job) -> StorageErr = 0;
-    virtual auto get_job_complete(boost::uuids::uuid id, bool* complete) -> StorageErr = 0;
-    virtual auto get_job_status(boost::uuids::uuid id, JobStatus* status) -> StorageErr = 0;
+    virtual auto get_job_metadata(StorageConnection& conn, boost::uuids::uuid id, JobMetadata* job)
+            -> StorageErr = 0;
+    virtual auto get_job_complete(StorageConnection& conn, boost::uuids::uuid id, bool* complete)
+            -> StorageErr = 0;
+    virtual auto get_job_status(StorageConnection& conn, boost::uuids::uuid id, JobStatus* status)
+            -> StorageErr = 0;
     virtual auto get_job_output_tasks(
+            StorageConnection& conn,
             boost::uuids::uuid id,
             std::vector<boost::uuids::uuid>* task_ids
     ) -> StorageErr = 0;
-    virtual auto get_task_graph(boost::uuids::uuid id, TaskGraph* task_graph) -> StorageErr = 0;
+    virtual auto get_task_graph(
+            StorageConnection& conn,
+            boost::uuids::uuid id,
+            TaskGraph* task_graph
+    ) -> StorageErr = 0;
     virtual auto get_jobs_by_client_id(
+            StorageConnection& conn,
             boost::uuids::uuid client_id,
             std::vector<boost::uuids::uuid>* job_ids
     ) -> StorageErr = 0;
-    virtual auto remove_job(boost::uuids::uuid id) -> StorageErr = 0;
-    virtual auto reset_job(boost::uuids::uuid id) -> StorageErr = 0;
-    virtual auto add_child(boost::uuids::uuid parent_id, Task const& child) -> StorageErr = 0;
-    virtual auto get_task(boost::uuids::uuid id, Task* task) -> StorageErr = 0;
-    virtual auto get_task_job_id(boost::uuids::uuid id, boost::uuids::uuid* job_id) -> StorageErr
-                                                                                       = 0;
-    virtual auto get_ready_tasks(std::vector<Task>* tasks) -> StorageErr = 0;
-    virtual auto set_task_state(boost::uuids::uuid id, TaskState state) -> StorageErr = 0;
-    virtual auto set_task_running(boost::uuids::uuid id) -> StorageErr = 0;
-    virtual auto add_task_instance(TaskInstance const& instance) -> StorageErr = 0;
-    // Set task state and add new task instance if task is ready or all instances timed out
-    virtual auto create_task_instance(TaskInstance const& instance) -> StorageErr = 0;
-    virtual auto task_finish(TaskInstance const& instance, std::vector<TaskOutput> const& outputs)
+    virtual auto remove_job(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr = 0;
+    virtual auto reset_job(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr = 0;
+    virtual auto add_child(StorageConnection& conn, boost::uuids::uuid parent_id, Task const& child)
             -> StorageErr = 0;
-    virtual auto task_fail(TaskInstance const& instance, std::string const& error) -> StorageErr
-                                                                                      = 0;
-    virtual auto get_task_timeout(std::vector<std::tuple<TaskInstance, Task>>* tasks) -> StorageErr
+    virtual auto get_task(StorageConnection& conn, boost::uuids::uuid id, Task* task) -> StorageErr
                                                                                          = 0;
-    virtual auto get_child_tasks(boost::uuids::uuid id, std::vector<Task>* children) -> StorageErr
-                                                                                        = 0;
-    virtual auto get_parent_tasks(boost::uuids::uuid id, std::vector<Task>* tasks) -> StorageErr
-                                                                                      = 0;
+    virtual auto get_task_job_id(
+            StorageConnection& conn,
+            boost::uuids::uuid id,
+            boost::uuids::uuid* job_id
+    ) -> StorageErr = 0;
+    virtual auto get_ready_tasks(StorageConnection& conn, std::vector<Task>* tasks) -> StorageErr
+                                                                                       = 0;
+    virtual auto set_task_state(StorageConnection& conn, boost::uuids::uuid id, TaskState state)
+            -> StorageErr = 0;
+    virtual auto set_task_running(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr = 0;
+    virtual auto
+    add_task_instance(StorageConnection& conn, TaskInstance const& instance) -> StorageErr = 0;
+    // Set task state and add new task instance if task is ready or all instances timed out
+    virtual auto
+    create_task_instance(StorageConnection& conn, TaskInstance const& instance) -> StorageErr = 0;
+    virtual auto task_finish(
+            StorageConnection& conn,
+            TaskInstance const& instance,
+            std::vector<TaskOutput> const& outputs
+    ) -> StorageErr = 0;
+    virtual auto task_fail(
+            StorageConnection& conn,
+            TaskInstance const& instance,
+            std::string const& error
+    ) -> StorageErr = 0;
+    virtual auto get_task_timeout(
+            StorageConnection& conn,
+            std::vector<std::tuple<TaskInstance, Task>>* tasks
+    ) -> StorageErr = 0;
+    virtual auto get_child_tasks(
+            StorageConnection& conn,
+            boost::uuids::uuid id,
+            std::vector<Task>* children
+    ) -> StorageErr = 0;
+    virtual auto get_parent_tasks(
+            StorageConnection& conn,
+            boost::uuids::uuid id,
+            std::vector<Task>* tasks
+    ) -> StorageErr = 0;
 
-    virtual auto update_heartbeat(boost::uuids::uuid id) -> StorageErr = 0;
-    virtual auto
-    heartbeat_timeout(double timeout, std::vector<boost::uuids::uuid>* ids) -> StorageErr = 0;
-    virtual auto get_scheduler_state(boost::uuids::uuid id, std::string* state) -> StorageErr = 0;
-    virtual auto
-    get_scheduler_addr(boost::uuids::uuid id, std::string* addr, int* port) -> StorageErr = 0;
-    virtual auto set_scheduler_state(boost::uuids::uuid id, std::string const& state) -> StorageErr
-                                                                                         = 0;
+    virtual auto update_heartbeat(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr = 0;
+    virtual auto heartbeat_timeout(
+            StorageConnection& conn,
+            double timeout,
+            std::vector<boost::uuids::uuid>* ids
+    ) -> StorageErr = 0;
+    virtual auto get_scheduler_state(
+            StorageConnection& conn,
+            boost::uuids::uuid id,
+            std::string* state
+    ) -> StorageErr = 0;
+    virtual auto get_scheduler_addr(
+            StorageConnection& conn,
+            boost::uuids::uuid id,
+            std::string* addr,
+            int* port
+    ) -> StorageErr = 0;
+    virtual auto set_scheduler_state(
+            StorageConnection& conn,
+            boost::uuids::uuid id,
+            std::string const& state
+    ) -> StorageErr = 0;
 };
 
 }  // namespace spider::core

--- a/src/spider/storage/MetadataStorage.hpp
+++ b/src/spider/storage/MetadataStorage.hpp
@@ -126,6 +126,8 @@ public:
             boost::uuids::uuid id,
             std::string const& state
     ) -> StorageErr = 0;
+
+    virtual auto get_url() const -> std::string const& = 0;
 };
 
 }  // namespace spider::core

--- a/src/spider/storage/MetadataStorage.hpp
+++ b/src/spider/storage/MetadataStorage.hpp
@@ -12,6 +12,7 @@
 #include "../core/JobMetadata.hpp"
 #include "../core/Task.hpp"
 #include "../core/TaskGraph.hpp"
+#include "StorageConnection.hpp"
 
 namespace spider::core {
 class MetadataStorage {

--- a/src/spider/storage/MySqlConnection.hpp
+++ b/src/spider/storage/MySqlConnection.hpp
@@ -25,7 +25,7 @@ public:
     MySqlConnection(MySqlConnection&&) = default;
     auto operator=(MySqlConnection&&) -> MySqlConnection& = default;
 
-    ~MySqlConnection() override;
+    ~MySqlConnection();
 
     auto operator*() const -> sql::Connection&;
     auto operator->() const -> sql::Connection*;

--- a/src/spider/storage/MySqlConnection.hpp
+++ b/src/spider/storage/MySqlConnection.hpp
@@ -9,11 +9,12 @@
 #include <mariadb/conncpp/Connection.hpp>
 
 #include "../core/Error.hpp"
+#include "StorageConnection.hpp"
 
 namespace spider::core {
 
 // RAII class for MySQL connection
-class MySqlConnection {
+class MySqlConnection : public StorageConnection {
 public:
     static auto create(std::string const& url) -> std::variant<MySqlConnection, StorageErr>;
 
@@ -24,7 +25,7 @@ public:
     MySqlConnection(MySqlConnection&&) = default;
     auto operator=(MySqlConnection&&) -> MySqlConnection& = default;
 
-    ~MySqlConnection();
+    ~MySqlConnection() override;
 
     auto operator*() const -> sql::Connection&;
     auto operator->() const -> sql::Connection*;

--- a/src/spider/storage/MySqlStorage.cpp
+++ b/src/spider/storage/MySqlStorage.cpp
@@ -37,6 +37,7 @@
 #include "../core/Task.hpp"
 #include "../core/TaskGraph.hpp"
 #include "MySqlConnection.hpp"
+#include "StorageConnection.hpp"
 
 // mariadb-connector-cpp does not define SQL errcode. Just include some useful ones.
 enum MariadbErr : uint16_t {
@@ -284,90 +285,84 @@ auto string_to_task_state(std::string const& state) -> spider::core::TaskState {
 }
 }  // namespace
 
-auto MySqlMetadataStorage::initialize() -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlMetadataStorage::initialize(StorageConnection& conn) -> StorageErr {
     try {
         for (char const* create_table_str : cCreateStorage) {
-            std::unique_ptr<sql::Statement> statement(conn->createStatement());
+            std::unique_ptr<sql::Statement> statement(
+                    static_cast<MySqlConnection&>(conn)->createStatement()
+            );
             statement->executeUpdate(create_table_str);
         }
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
 
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlMetadataStorage::add_driver(Driver const& driver) -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlMetadataStorage::add_driver(StorageConnection& conn, Driver const& driver) -> StorageErr {
     try {
         std::unique_ptr<sql::PreparedStatement> statement(
-                conn->prepareStatement("INSERT INTO `drivers` (`id`) VALUES (?)")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "INSERT INTO `drivers` (`id`) VALUES (?)"
+                )
         );
         sql::bytes id_bytes = uuid_get_bytes(driver.get_id());
         statement->setBytes(1, &id_bytes);
         statement->executeUpdate();
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         if (e.getErrorCode() == ErDupKey || e.getErrorCode() == ErDupEntry) {
             return StorageErr{StorageErrType::DuplicateKeyErr, e.what()};
         }
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlMetadataStorage::add_scheduler(Scheduler const& scheduler) -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlMetadataStorage::add_scheduler(StorageConnection& conn, Scheduler const& scheduler)
+        -> StorageErr {
     try {
         std::unique_ptr<sql::PreparedStatement> driver_statement(
-                conn->prepareStatement("INSERT INTO `drivers` (`id`) VALUES (?)")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "INSERT INTO `drivers` (`id`) VALUES (?)"
+                )
         );
         sql::bytes id_bytes = uuid_get_bytes(scheduler.get_id());
         driver_statement->setBytes(1, &id_bytes);
         driver_statement->executeUpdate();
-        std::unique_ptr<sql::PreparedStatement> scheduler_statement(conn->prepareStatement(
-                "INSERT INTO `schedulers` (`id`, `address`, `port`, `state`) "
-                "VALUES (?, ?, ?, 'normal')"
-        ));
+        std::unique_ptr<sql::PreparedStatement> scheduler_statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "INSERT INTO `schedulers` (`id`, `address`, `port`, `state`) VALUES (?, ?, "
+                        "?, 'normal')"
+                )
+        );
         scheduler_statement->setBytes(1, &id_bytes);
         scheduler_statement->setString(2, scheduler.get_addr());
         scheduler_statement->setInt(3, scheduler.get_port());
         scheduler_statement->executeUpdate();
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         if (e.getErrorCode() == ErDupKey || e.getErrorCode() == ErDupEntry) {
             return StorageErr{StorageErrType::DuplicateKeyErr, e.what()};
         }
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlMetadataStorage::get_active_scheduler(std::vector<Scheduler>* schedulers) -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlMetadataStorage::get_active_scheduler(
+        StorageConnection& conn,
+        std::vector<Scheduler>* schedulers
+) -> StorageErr {
     try {
-        std::unique_ptr<sql::Statement> statement(conn->createStatement());
+        std::unique_ptr<sql::Statement> statement(
+                static_cast<MySqlConnection&>(conn)->createStatement()
+        );
         std::unique_ptr<sql::ResultSet> res(statement->executeQuery(
                 "SELECT `schedulers`.`id`, `address`, `port` FROM `schedulers` JOIN `drivers` ON "
                 "`schedulers`.`id` = `drivers`.`id` WHERE `state` = 'normal'"
@@ -379,10 +374,10 @@ auto MySqlMetadataStorage::get_active_scheduler(std::vector<Scheduler>* schedule
             schedulers->emplace_back(id, addr, port);
         }
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
@@ -464,21 +459,19 @@ void MySqlMetadataStorage::add_task(MySqlConnection& conn, sql::bytes job_id, Ta
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 auto MySqlMetadataStorage::add_job(
+        StorageConnection& conn,
         boost::uuids::uuid job_id,
         boost::uuids::uuid client_id,
         TaskGraph const& task_graph
 ) -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
     try {
         sql::bytes job_id_bytes = uuid_get_bytes(job_id);
         sql::bytes client_id_bytes = uuid_get_bytes(client_id);
         {
             std::unique_ptr<sql::PreparedStatement> statement{
-                    conn->prepareStatement("INSERT INTO `jobs` (`id`, `client_id`) VALUES (?, ?)")
+                    static_cast<MySqlConnection&>(conn)->prepareStatement(
+                            "INSERT INTO `jobs` (`id`, `client_id`) VALUES (?, ?)"
+                    )
             };
             statement->setBytes(1, &job_id_bytes);
             statement->setBytes(2, &client_id_bytes);
@@ -496,14 +489,14 @@ auto MySqlMetadataStorage::add_job(
         for (boost::uuids::uuid const task_id : heads) {
             std::optional<Task const*> const task_option = task_graph.get_task(task_id);
             if (!task_option.has_value()) {
-                conn->rollback();
+                static_cast<MySqlConnection&>(conn)->rollback();
                 return StorageErr{
                         StorageErrType::KeyNotFoundErr,
                         "Task graph inconsistent: head task not found"
                 };
             }
             Task const* task = task_option.value();
-            add_task(conn, job_id_bytes, *task);
+            add_task(static_cast<MySqlConnection&>(conn), job_id_bytes, *task);
             for (boost::uuids::uuid const id : task_graph.get_child_tasks(task_id)) {
                 std::vector<boost::uuids::uuid> const parents = task_graph.get_parent_tasks(id);
                 if (std::ranges::all_of(parents, [&](boost::uuids::uuid const& parent) {
@@ -522,11 +515,11 @@ auto MySqlMetadataStorage::add_job(
                 heads.insert(task_id);
                 std::optional<Task const*> const task_option = task_graph.get_task(task_id);
                 if (!task_option.has_value()) {
-                    conn->rollback();
+                    static_cast<MySqlConnection&>(conn)->rollback();
                     return StorageErr{StorageErrType::KeyNotFoundErr, "Task graph inconsistent"};
                 }
                 Task const* task = task_option.value();
-                add_task(conn, job_id_bytes, *task);
+                add_task(static_cast<MySqlConnection&>(conn), job_id_bytes, *task);
                 for (boost::uuids::uuid const id : task_graph.get_child_tasks(task_id)) {
                     std::vector<boost::uuids::uuid> const parents = task_graph.get_parent_tasks(id);
                     if (std::ranges::all_of(parents, [&](boost::uuids::uuid const& parent) {
@@ -543,9 +536,11 @@ auto MySqlMetadataStorage::add_job(
         for (std::pair<boost::uuids::uuid, boost::uuids::uuid> const& pair :
              task_graph.get_dependencies())
         {
-            std::unique_ptr<sql::PreparedStatement> dep_statement{conn->prepareStatement(
-                    "INSERT INTO `task_dependencies` (parent, child) VALUES (?, ?)"
-            )};
+            std::unique_ptr<sql::PreparedStatement> dep_statement{
+                    static_cast<MySqlConnection&>(conn)->prepareStatement(
+                            "INSERT INTO `task_dependencies` (parent, child) VALUES (?, ?)"
+                    )
+            };
             sql::bytes parent_id_bytes = uuid_get_bytes(pair.first);
             sql::bytes child_id_bytes = uuid_get_bytes(pair.second);
             dep_statement->setBytes(1, &parent_id_bytes);
@@ -555,9 +550,12 @@ auto MySqlMetadataStorage::add_job(
 
         // Add input tasks
         for (size_t i = 0; i < input_task_ids.size(); i++) {
-            std::unique_ptr<sql::PreparedStatement> input_statement{conn->prepareStatement(
-                    "INSERT INTO `input_tasks` (`job_id`, `task_id`, `position`) VALUES (?, ?, ?)"
-            )};
+            std::unique_ptr<sql::PreparedStatement> input_statement{
+                    static_cast<MySqlConnection&>(conn)->prepareStatement(
+                            "INSERT INTO `input_tasks` (`job_id`, `task_id`, `position`) VALUES "
+                            "(?, ?, ?)"
+                    )
+            };
             input_statement->setBytes(1, &job_id_bytes);
             sql::bytes task_id_bytes = uuid_get_bytes(input_task_ids[i]);
             input_statement->setBytes(2, &task_id_bytes);
@@ -567,9 +565,12 @@ auto MySqlMetadataStorage::add_job(
         // Add output tasks
         std::vector<boost::uuids::uuid> const& output_task_ids = task_graph.get_output_tasks();
         for (size_t i = 0; i < output_task_ids.size(); i++) {
-            std::unique_ptr<sql::PreparedStatement> output_statement{conn->prepareStatement(
-                    "INSERT INTO `output_tasks` (`job_id`, `task_id`, `position`) VALUES (?, ?, ?)"
-            )};
+            std::unique_ptr<sql::PreparedStatement> output_statement{
+                    static_cast<MySqlConnection&>(conn)->prepareStatement(
+                            "INSERT INTO `output_tasks` (`job_id`, `task_id`, `position`) VALUES "
+                            "(?, ?, ?)"
+                    )
+            };
             output_statement->setBytes(1, &job_id_bytes);
             sql::bytes task_id_bytes = uuid_get_bytes(output_task_ids[i]);
             output_statement->setBytes(2, &task_id_bytes);
@@ -580,7 +581,9 @@ auto MySqlMetadataStorage::add_job(
         // Mark head tasks as ready
         for (boost::uuids::uuid const& task_id : task_graph.get_input_tasks()) {
             std::unique_ptr<sql::PreparedStatement> statement(
-                    conn->prepareStatement("UPDATE `tasks` SET `state` = 'ready' WHERE `id` = ?")
+                    static_cast<MySqlConnection&>(conn)->prepareStatement(
+                            "UPDATE `tasks` SET `state` = 'ready' WHERE `id` = ?"
+                    )
             );
             sql::bytes task_id_bytes = uuid_get_bytes(task_id);
             statement->setBytes(1, &task_id_bytes);
@@ -588,13 +591,13 @@ auto MySqlMetadataStorage::add_job(
         }
 
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         if (e.getErrorCode() == ErDupKey || e.getErrorCode() == ErDupEntry) {
             return StorageErr{StorageErrType::DuplicateKeyErr, e.what()};
         }
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
@@ -704,8 +707,7 @@ auto MySqlMetadataStorage::fetch_full_task(
     // Get task inputs
     std::unique_ptr<sql::PreparedStatement> input_statement{conn->prepareStatement(
             "SELECT `task_id`, `position`, `type`, `output_task_id`, `output_task_position`, "
-            "`value`, `data_id` FROM `task_inputs` "
-            "WHERE `task_id` = ? ORDER BY `position`"
+            "`value`, `data_id` FROM `task_inputs` WHERE `task_id` = ? ORDER BY `position`"
     )};
     input_statement->setBytes(1, &id_bytes);
     std::unique_ptr<sql::ResultSet> const input_res{input_statement->executeQuery()};
@@ -714,10 +716,10 @@ auto MySqlMetadataStorage::fetch_full_task(
     }
 
     // Get task outputs
-    std::unique_ptr<sql::PreparedStatement> output_statement{conn->prepareStatement(
-            "SELECT `task_id`, `position`, `type`, `value`, `data_id` FROM `task_outputs` WHERE "
-            "`task_id` = ? ORDER BY `position`"
-    )};
+    std::unique_ptr<sql::PreparedStatement> output_statement{
+            conn->prepareStatement("SELECT `task_id`, `position`, `type`, `value`, `data_id` FROM "
+                                   "`task_outputs` WHERE `task_id` = ? ORDER BY `position`")
+    };
     output_statement->setBytes(1, &id_bytes);
     std::unique_ptr<sql::ResultSet> const output_res{output_statement->executeQuery()};
     while (output_res->next()) {
@@ -726,24 +728,24 @@ auto MySqlMetadataStorage::fetch_full_task(
     return task;
 }
 
-auto MySqlMetadataStorage::get_task_graph(boost::uuids::uuid id, TaskGraph* task_graph)
-        -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlMetadataStorage::get_task_graph(
+        StorageConnection& conn,
+        boost::uuids::uuid id,
+        TaskGraph* task_graph
+) -> StorageErr {
     try {
         // Get all tasks
         std::unique_ptr<sql::PreparedStatement> task_statement(
-                conn->prepareStatement("SELECT `id`, `func_name`, `state`, `timeout` "
-                                       "FROM `tasks` WHERE `job_id` = ?")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `id`, `func_name`, `state`, `timeout` FROM `tasks` WHERE `job_id` "
+                        "= ?"
+                )
         );
         sql::bytes id_bytes = uuid_get_bytes(id);
         task_statement->setBytes(1, &id_bytes);
         std::unique_ptr<sql::ResultSet> const task_res(task_statement->executeQuery());
         if (task_res->rowsCount() == 0) {
-            conn->commit();
+            static_cast<MySqlConnection&>(conn)->commit();
             return StorageErr{
                     StorageErrType::KeyNotFoundErr,
                     fmt::format("no task graph with id {}", boost::uuids::to_string(id))
@@ -755,47 +757,48 @@ auto MySqlMetadataStorage::get_task_graph(boost::uuids::uuid id, TaskGraph* task
         }
 
         // Get inputs
-        std::unique_ptr<sql::PreparedStatement> input_statement(conn->prepareStatement(
-                "SELECT `t1`.`task_id`, `t1`.`position`, `t1`.`type`, `t1`.`output_task_id`, "
-                "`t1`.`output_task_position`, `t1`.`value`, `t1`.`data_id` FROM `task_inputs` AS "
-                "`t1` JOIN "
-                "`tasks` "
-                "ON `t1`.`task_id` = `tasks`.`id` WHERE `tasks`.`job_id` = ? ORDER BY "
-                "`t1`.`task_id`, "
-                "`t1`.`position`"
-        ));
+        std::unique_ptr<sql::PreparedStatement> input_statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `t1`.`task_id`, `t1`.`position`, `t1`.`type`, "
+                        "`t1`.`output_task_id`, `t1`.`output_task_position`, `t1`.`value`, "
+                        "`t1`.`data_id` FROM `task_inputs` AS `t1` JOIN `tasks` ON `t1`.`task_id` "
+                        "= `tasks`.`id` WHERE `tasks`.`job_id` = ? ORDER BY `t1`.`task_id`, "
+                        "`t1`.`position`"
+                )
+        );
         input_statement->setBytes(1, &id_bytes);
         std::unique_ptr<sql::ResultSet> const input_res(input_statement->executeQuery());
         while (input_res->next()) {
             if (!fetch_task_graph_task_input(task_graph, input_res)) {
-                conn->rollback();
+                static_cast<MySqlConnection&>(conn)->rollback();
                 return StorageErr{StorageErrType::KeyNotFoundErr, "Task storage inconsistent"};
             }
         }
 
         // Get outputs
         std::unique_ptr<sql::PreparedStatement> output_statement(
-                conn->prepareStatement("SELECT `t1`.`task_id`, `t1`.`position`, `t1`.`type`, "
-                                       "`t1`.`value`, `t1`.`data_id` FROM "
-                                       "`task_outputs` "
-                                       "AS `t1` JOIN `tasks` ON `t1`.`task_id` = `tasks`.`id` "
-                                       "WHERE `tasks`.`job_id` = ? ORDER BY "
-                                       "`t1`.`task_id`, `t1`.`position`")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `t1`.`task_id`, `t1`.`position`, `t1`.`type`, `t1`.`value`, "
+                        "`t1`.`data_id` FROM `task_outputs` AS `t1` JOIN `tasks` ON `t1`.`task_id` "
+                        "= `tasks`.`id` WHERE `tasks`.`job_id` = ? ORDER BY `t1`.`task_id`, "
+                        "`t1`.`position`"
+                )
         );
         output_statement->setBytes(1, &id_bytes);
         std::unique_ptr<sql::ResultSet> const output_res(output_statement->executeQuery());
         while (output_res->next()) {
             if (!fetch_task_graph_task_output(task_graph, output_res)) {
-                conn->rollback();
+                static_cast<MySqlConnection&>(conn)->rollback();
                 return StorageErr{StorageErrType::KeyNotFoundErr, "Task storage inconsistent"};
             }
         }
 
         // Get dependencies
         std::unique_ptr<sql::PreparedStatement> dep_statement(
-                conn->prepareStatement("SELECT `t1`.`parent`, `t1`.`child` FROM "
-                                       "`task_dependencies` AS `t1` JOIN `tasks` ON "
-                                       "`t1`.`parent` = `tasks`.`id` WHERE `tasks`.`job_id` = ?")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `t1`.`parent`, `t1`.`child` FROM `task_dependencies` AS `t1` JOIN "
+                        "`tasks` ON `t1`.`parent` = `tasks`.`id` WHERE `tasks`.`job_id` = ?"
+                )
         );
         dep_statement->setBytes(1, &id_bytes);
         std::unique_ptr<sql::ResultSet> const dep_res(dep_statement->executeQuery());
@@ -808,8 +811,10 @@ auto MySqlMetadataStorage::get_task_graph(boost::uuids::uuid id, TaskGraph* task
 
         // Get input tasks
         std::unique_ptr<sql::PreparedStatement> input_task_statement(
-                conn->prepareStatement("SELECT `task_id`, `position` FROM `input_tasks` WHERE "
-                                       "`job_id` = ? ORDER BY `position`")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `task_id`, `position` FROM `input_tasks` WHERE `job_id` = ? ORDER "
+                        "BY `position`"
+                )
         );
         input_task_statement->setBytes(1, &id_bytes);
         std::unique_ptr<sql::ResultSet> const input_task_res(input_task_statement->executeQuery());
@@ -818,8 +823,10 @@ auto MySqlMetadataStorage::get_task_graph(boost::uuids::uuid id, TaskGraph* task
         }
         // Get output tasks
         std::unique_ptr<sql::PreparedStatement> output_task_statement(
-                conn->prepareStatement("SELECT `task_id`, `position` FROM `output_tasks` WHERE "
-                                       "`job_id` = ? ORDER BY `position`")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `task_id`, `position` FROM `output_tasks` WHERE `job_id` = ? ORDER "
+                        "BY `position`"
+                )
         );
         output_task_statement->setBytes(1, &id_bytes);
         std::unique_ptr<sql::ResultSet> const output_task_res(output_task_statement->executeQuery()
@@ -829,13 +836,13 @@ auto MySqlMetadataStorage::get_task_graph(boost::uuids::uuid id, TaskGraph* task
         }
 
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         if (e.getErrorCode() == ErKeyNotFound) {
             return StorageErr{StorageErrType::KeyNotFoundErr, e.what()};
         }
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 }  // namespace spider::core
@@ -857,21 +864,22 @@ auto parse_timestamp(std::string const& timestamp
 
 namespace spider::core {
 
-auto MySqlMetadataStorage::get_job_metadata(boost::uuids::uuid id, JobMetadata* job) -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlMetadataStorage::get_job_metadata(
+        StorageConnection& conn,
+        boost::uuids::uuid id,
+        JobMetadata* job
+) -> StorageErr {
     try {
-        std::unique_ptr<sql::PreparedStatement> statement{conn->prepareStatement(
-                "SELECT `client_id`, `creation_time` FROM `jobs` WHERE `id` = ?"
-        )};
+        std::unique_ptr<sql::PreparedStatement> statement{
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `client_id`, `creation_time` FROM `jobs` WHERE `id` = ?"
+                )
+        };
         sql::bytes id_bytes = uuid_get_bytes(id);
         statement->setBytes(1, &id_bytes);
         std::unique_ptr<sql::ResultSet> const res{statement->executeQuery()};
         if (0 == res->rowsCount()) {
-            conn->commit();
+            static_cast<MySqlConnection&>(conn)->commit();
             return StorageErr{
                     StorageErrType::KeyNotFoundErr,
                     fmt::format("No job with id {} ", boost::uuids::to_string(id))
@@ -882,7 +890,7 @@ auto MySqlMetadataStorage::get_job_metadata(boost::uuids::uuid id, JobMetadata* 
         std::optional<std::chrono::system_clock::time_point> const optional_creation_time
                 = parse_timestamp(get_sql_string(res->getString("creation_time")));
         if (false == optional_creation_time.has_value()) {
-            conn->rollback();
+            static_cast<MySqlConnection&>(conn)->rollback();
             return StorageErr{
                     StorageErrType::OtherErr,
                     fmt::format(
@@ -893,100 +901,103 @@ auto MySqlMetadataStorage::get_job_metadata(boost::uuids::uuid id, JobMetadata* 
         }
         *job = JobMetadata{id, client_id, optional_creation_time.value()};
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlMetadataStorage::get_job_complete(boost::uuids::uuid const id, bool* complete)
-        -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlMetadataStorage::get_job_complete(
+        StorageConnection& conn,
+        boost::uuids::uuid const id,
+        bool* complete
+) -> StorageErr {
     try {
         std::unique_ptr<sql::PreparedStatement> const statement{
-                conn->prepareStatement("SELECT `state` FROM `tasks` WHERE `job_id` = ? AND "
-                                       "`state` NOT IN ('success', 'cancel', 'fail') ")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `state` FROM `tasks` WHERE `job_id` = ? AND `state` NOT IN "
+                        "('success', 'cancel', 'fail') "
+                )
         };
         sql::bytes id_bytes = uuid_get_bytes(id);
         statement->setBytes(1, &id_bytes);
         std::unique_ptr<sql::ResultSet> const res{statement->executeQuery()};
         *complete = 0 == res->rowsCount();
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlMetadataStorage::get_job_status(boost::uuids::uuid const id, JobStatus* status)
-        -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlMetadataStorage::get_job_status(
+        StorageConnection& conn,
+        boost::uuids::uuid const id,
+        JobStatus* status
+) -> StorageErr {
     try {
         std::unique_ptr<sql::PreparedStatement> const running_statement{
-                conn->prepareStatement("SELECT `state` FROM `tasks` WHERE `job_id` = ? AND "
-                                       "`state` NOT IN ('success', 'cancel', 'fail') ")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `state` FROM `tasks` WHERE `job_id` = ? AND `state` NOT IN "
+                        "('success', 'cancel', 'fail')"
+                )
         };
         sql::bytes id_bytes = uuid_get_bytes(id);
         running_statement->setBytes(1, &id_bytes);
         std::unique_ptr<sql::ResultSet> const running_res{running_statement->executeQuery()};
         if (running_res->rowsCount() > 0) {
             *status = JobStatus::Running;
-            conn->commit();
+            static_cast<MySqlConnection&>(conn)->commit();
             return StorageErr{};
         }
-        std::unique_ptr<sql::PreparedStatement> failed_statement{conn->prepareStatement(
-                "SELECT `state` FROM `tasks` WHERE `job_id` = ? AND `state` = 'fail'"
-        )};
+        std::unique_ptr<sql::PreparedStatement> failed_statement{
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `state` FROM `tasks` WHERE `job_id` = ? AND `state` = 'fail'"
+                )
+        };
         failed_statement->setBytes(1, &id_bytes);
         std::unique_ptr<sql::ResultSet> const failed_res{failed_statement->executeQuery()};
         if (failed_res->rowsCount() > 0) {
             *status = JobStatus::Failed;
-            conn->commit();
+            static_cast<MySqlConnection&>(conn)->commit();
             return StorageErr{};
         }
-        std::unique_ptr<sql::PreparedStatement> canceled_statement{conn->prepareStatement(
-                "SELECT `state` FROM `tasks` WHERE `job_id` = ? AND `state` = 'cancel'"
-        )};
+        std::unique_ptr<sql::PreparedStatement> canceled_statement{
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `state` FROM `tasks` WHERE `job_id` = ? AND `state` = 'cancel'"
+                )
+        };
         canceled_statement->setBytes(1, &id_bytes);
         std::unique_ptr<sql::ResultSet> const canceled_res{canceled_statement->executeQuery()};
         if (canceled_res->rowsCount() > 0) {
             *status = JobStatus::Cancelled;
-            conn->commit();
+            static_cast<MySqlConnection&>(conn)->commit();
             return StorageErr{};
         }
         *status = JobStatus::Succeeded;
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
 auto MySqlMetadataStorage::get_job_output_tasks(
+        StorageConnection& conn,
         boost::uuids::uuid const id,
         std::vector<boost::uuids::uuid>* task_ids
 ) -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
     try {
         task_ids->clear();
-        std::unique_ptr<sql::PreparedStatement> statement{conn->prepareStatement(
-                "SELECT `task_id` FROM `output_tasks` WHERE `job_id` = ? ORDER BY `position`"
-        )};
+        std::unique_ptr<sql::PreparedStatement> statement{
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `task_id` FROM `output_tasks` WHERE `job_id` = ? ORDER BY "
+                        "`position`"
+                )
+        };
         sql::bytes id_bytes = uuid_get_bytes(id);
         statement->setBytes(1, &id_bytes);
         std::unique_ptr<sql::ResultSet> const res{statement->executeQuery()};
@@ -994,25 +1005,23 @@ auto MySqlMetadataStorage::get_job_output_tasks(
             task_ids->emplace_back(read_id(res->getBinaryStream(1)));
         }
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
 auto MySqlMetadataStorage::get_jobs_by_client_id(
+        StorageConnection& conn,
         boost::uuids::uuid client_id,
         std::vector<boost::uuids::uuid>* job_ids
 ) -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
     try {
         std::unique_ptr<sql::PreparedStatement> statement{
-                conn->prepareStatement("SELECT `id` FROM `jobs` WHERE `client_id` = ?")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `id` FROM `jobs` WHERE `client_id` = ?"
+                )
         };
         sql::bytes client_id_bytes = uuid_get_bytes(client_id);
         statement->setBytes(1, &client_id_bytes);
@@ -1021,168 +1030,170 @@ auto MySqlMetadataStorage::get_jobs_by_client_id(
             job_ids->emplace_back(read_id(res->getBinaryStream(1)));
         }
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlMetadataStorage::remove_job(boost::uuids::uuid id) -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlMetadataStorage::remove_job(StorageConnection& conn, boost::uuids::uuid id)
+        -> StorageErr {
     try {
         std::unique_ptr<sql::PreparedStatement> statement(
-                conn->prepareStatement("DELETE FROM `jobs` WHERE `id` = ?")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "DELETE FROM `jobs` WHERE `id` = ?"
+                )
         );
         sql::bytes id_bytes = uuid_get_bytes(id);
         statement->setBytes(1, &id_bytes);
         statement->executeUpdate();
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlMetadataStorage::reset_job(boost::uuids::uuid const id) -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlMetadataStorage::reset_job(StorageConnection& conn, boost::uuids::uuid const id)
+        -> StorageErr {
     try {
         // Check for retry count on all tasks
-        std::unique_ptr<sql::PreparedStatement> retry_statement(conn->prepareStatement(
-                "SELECT `id` FROM `tasks` WHERE `job_id` = ? AND `retry` >= `max_retry`"
-        ));
+        std::unique_ptr<sql::PreparedStatement> retry_statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `id` FROM `tasks` WHERE `job_id` = ? AND `retry` >= `max_retry`"
+                )
+        );
         sql::bytes job_id_bytes = uuid_get_bytes(id);
         retry_statement->setBytes(1, &job_id_bytes);
         std::unique_ptr<sql::ResultSet> const res(retry_statement->executeQuery());
         if (res->rowsCount() > 0) {
-            conn->commit();
+            static_cast<MySqlConnection&>(conn)->commit();
             return StorageErr{StorageErrType::Success, "Some tasks have reached max retry count"};
         }
         // Increment the retry count for all tasks
-        std::unique_ptr<sql::PreparedStatement> increment_statement(conn->prepareStatement(
-                "UPDATE `tasks` SET `retry` = `retry` + 1 WHERE `job_id` = ?"
-        ));
+        std::unique_ptr<sql::PreparedStatement> increment_statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "UPDATE `tasks` SET `retry` = `retry` + 1 WHERE `job_id` = ?"
+                )
+        );
         increment_statement->setBytes(1, &job_id_bytes);
         increment_statement->executeUpdate();
         // Reset states for all tasks. Head tasks should be ready and other tasks should be pending
-        std::unique_ptr<sql::PreparedStatement> state_statement(conn->prepareStatement(
-                "UPDATE `tasks` SET `state` = IF(`id` NOT IN (SELECT `task_id` FROM `task_inputs` "
-                "WHERE `task_id` IN (SELECT `id` FROM `tasks` WHERE `job_id` = ?) AND "
-                "`output_task_id` IS NOT NULL), 'ready', 'pending') WHERE job_id = ?"
-        ));
+        std::unique_ptr<sql::PreparedStatement> state_statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "UPDATE `tasks` SET `state` = IF(`id` NOT IN (SELECT `task_id` FROM "
+                        "`task_inputs` WHERE `task_id` IN (SELECT `id` FROM `tasks` WHERE `job_id` "
+                        "= ?) AND `output_task_id` IS NOT NULL), 'ready', 'pending') WHERE job_id "
+                        "= ?"
+                )
+        );
         state_statement->setBytes(1, &job_id_bytes);
         state_statement->setBytes(2, &job_id_bytes);
         state_statement->executeUpdate();
         // Clear outputs for all tasks
-        std::unique_ptr<sql::PreparedStatement> output_statement(conn->prepareStatement(
-                "UPDATE `task_outputs` SET `value` = NULL, `data_id` = NULL "
-                "WHERE `task_id` IN (SELECT `id` FROM `tasks` WHERE `job_id` = ?)"
-        ));
+        std::unique_ptr<sql::PreparedStatement> output_statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "UPDATE `task_outputs` SET `value` = NULL, `data_id` = NULL WHERE "
+                        "`task_id` IN (SELECT `id` FROM `tasks` WHERE `job_id` = ?)"
+                )
+        );
         output_statement->setBytes(1, &job_id_bytes);
         output_statement->executeUpdate();
         // Clear inputs for non-head tasks
-        std::unique_ptr<sql::PreparedStatement> input_statement(conn->prepareStatement(
-                "UPDATE `task_inputs` SET `value` = NULL, `data_id` = NULL "
-                "WHERE `task_id` IN (SELECT `id` FROM `tasks` WHERE `job_id` = ?) "
-                "AND `output_task_id` IS NOT NULL"
-        ));
+        std::unique_ptr<sql::PreparedStatement> input_statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "UPDATE `task_inputs` SET `value` = NULL, `data_id` = NULL WHERE `task_id` "
+                        "IN (SELECT `id` FROM `tasks` WHERE `job_id` = ?) AND `output_task_id` IS "
+                        "NOT NULL"
+                )
+        );
         input_statement->setBytes(1, &job_id_bytes);
         input_statement->executeUpdate();
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlMetadataStorage::add_child(boost::uuids::uuid parent_id, Task const& child)
-        -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlMetadataStorage::add_child(
+        StorageConnection& conn,
+        boost::uuids::uuid parent_id,
+        Task const& child
+) -> StorageErr {
     try {
         sql::bytes const job_id = uuid_get_bytes(child.get_id());
-        add_task(conn, job_id, child);
+        add_task(static_cast<MySqlConnection&>(conn), job_id, child);
 
         // Add dependencies
-        std::unique_ptr<sql::PreparedStatement> statement(conn->prepareStatement(
-                "INSERT INTO `task_dependencies` (`parent`, `child`) VALUES (?, ?)"
-        ));
+        std::unique_ptr<sql::PreparedStatement> statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "INSERT INTO `task_dependencies` (`parent`, `child`) VALUES (?, ?)"
+                )
+        );
         sql::bytes parent_id_bytes = uuid_get_bytes(parent_id);
         sql::bytes child_id_bytes = uuid_get_bytes(child.get_id());
         statement->setBytes(1, &parent_id_bytes);
         statement->setBytes(2, &child_id_bytes);
         statement->executeUpdate();
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         if (e.getErrorCode() == ErDupKey || e.getErrorCode() == ErDupEntry) {
             return StorageErr{StorageErrType::DuplicateKeyErr, e.what()};
         }
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlMetadataStorage::get_task(boost::uuids::uuid id, Task* task) -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlMetadataStorage::get_task(StorageConnection& conn, boost::uuids::uuid id, Task* task)
+        -> StorageErr {
     try {
         std::unique_ptr<sql::PreparedStatement> statement(
-                conn->prepareStatement("SELECT `id`, `func_name`, `state`, `timeout` "
-                                       "FROM `tasks` WHERE `id` = ?")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `id`, `func_name`, `state`, `timeout` FROM `tasks` WHERE `id` = ?"
+                )
         );
         sql::bytes id_bytes = uuid_get_bytes(id);
         statement->setBytes(1, &id_bytes);
         std::unique_ptr<sql::ResultSet> const res(statement->executeQuery());
         if (res->rowsCount() == 0) {
-            conn->commit();
+            static_cast<MySqlConnection&>(conn)->commit();
             return StorageErr{
                     StorageErrType::KeyNotFoundErr,
                     fmt::format("no task with id {}", boost::uuids::to_string(id))
             };
         }
         res->next();
-        *task = fetch_full_task(conn, res);
+        *task = fetch_full_task(static_cast<MySqlConnection&>(conn), res);
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlMetadataStorage::get_task_job_id(boost::uuids::uuid id, boost::uuids::uuid* job_id)
-        -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlMetadataStorage::get_task_job_id(
+        StorageConnection& conn,
+        boost::uuids::uuid id,
+        boost::uuids::uuid* job_id
+) -> StorageErr {
     try {
         std::unique_ptr<sql::PreparedStatement> statement(
-                conn->prepareStatement("SELECT `job_id` FROM `tasks` WHERE `id` = ?")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `job_id` FROM `tasks` WHERE `id` = ?"
+                )
         );
         sql::bytes id_bytes = uuid_get_bytes(id);
         statement->setBytes(1, &id_bytes);
         std::unique_ptr<sql::ResultSet> const res(statement->executeQuery());
         if (res->rowsCount() == 0) {
-            conn->commit();
+            static_cast<MySqlConnection&>(conn)->commit();
             return StorageErr{
                     StorageErrType::KeyNotFoundErr,
                     fmt::format("no task with id {}", boost::uuids::to_string(id))
@@ -1191,199 +1202,201 @@ auto MySqlMetadataStorage::get_task_job_id(boost::uuids::uuid id, boost::uuids::
         res->next();
         *job_id = read_id(res->getBinaryStream("job_id"));
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlMetadataStorage::get_ready_tasks(std::vector<Task>* tasks) -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlMetadataStorage::get_ready_tasks(StorageConnection& conn, std::vector<Task>* tasks)
+        -> StorageErr {
     try {
         // Get all ready tasks from job that has not failed or cancelled
-        std::unique_ptr<sql::Statement> statement(conn->createStatement());
+        std::unique_ptr<sql::Statement> statement(
+                static_cast<MySqlConnection&>(conn)->createStatement()
+        );
         std::unique_ptr<sql::ResultSet> res(statement->executeQuery(
                 "SELECT `id`, `func_name`, `state`, `timeout` FROM `tasks` WHERE `state` = 'ready' "
                 "AND `job_id` NOT IN (SELECT `job_id` FROM `tasks` WHERE `state` = 'fail' OR "
                 "`state` = 'cancel')"
         ));
         while (res->next()) {
-            tasks->emplace_back(fetch_full_task(conn, res));
+            tasks->emplace_back(fetch_full_task(static_cast<MySqlConnection&>(conn), res));
         }
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlMetadataStorage::set_task_state(boost::uuids::uuid id, TaskState state) -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlMetadataStorage::set_task_state(
+        StorageConnection& conn,
+        boost::uuids::uuid id,
+        TaskState state
+) -> StorageErr {
     try {
         std::unique_ptr<sql::PreparedStatement> statement(
-                conn->prepareStatement("UPDATE `tasks` SET `state` = ? WHERE `id` = ?")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "UPDATE `tasks` SET `state` = ? WHERE `id` = ?"
+                )
         );
         statement->setString(1, task_state_to_string(state));
         sql::bytes id_bytes = uuid_get_bytes(id);
         statement->setBytes(2, &id_bytes);
         statement->executeUpdate();
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         if (e.getErrorCode() == ErKeyNotFound) {
             return StorageErr{StorageErrType::KeyNotFoundErr, e.what()};
         }
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlMetadataStorage::set_task_running(boost::uuids::uuid id) -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlMetadataStorage::set_task_running(StorageConnection& conn, boost::uuids::uuid id)
+        -> StorageErr {
     try {
-        std::unique_ptr<sql::PreparedStatement> statement(conn->prepareStatement(
-                "UPDATE `tasks` SET `state` = 'running' WHERE `id` = ? AND `state` = 'ready'"
-        ));
+        std::unique_ptr<sql::PreparedStatement> statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "UPDATE `tasks` SET `state` = 'running' WHERE `id` = ? AND `state` = "
+                        "'ready'"
+                )
+        );
         sql::bytes id_bytes = uuid_get_bytes(id);
         statement->setBytes(1, &id_bytes);
         int32_t const update_count = statement->executeUpdate();
         if (update_count == 0) {
-            conn->rollback();
+            static_cast<MySqlConnection&>(conn)->rollback();
             return StorageErr{StorageErrType::KeyNotFoundErr, "Task not ready"};
         }
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlMetadataStorage::add_task_instance(TaskInstance const& instance) -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlMetadataStorage::add_task_instance(StorageConnection& conn, TaskInstance const& instance)
+        -> StorageErr {
     try {
-        std::unique_ptr<sql::PreparedStatement> const statement(conn->prepareStatement(
-                "INSERT INTO `task_instances` (`id`, `task_id`, `start_time`) "
-                "VALUES(?, ?, CURRENT_TIMESTAMP())"
-        ));
+        std::unique_ptr<sql::PreparedStatement> const statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "INSERT INTO `task_instances` (`id`, `task_id`, `start_time`) VALUES(?, ?, "
+                        "CURRENT_TIMESTAMP())"
+                )
+        );
         sql::bytes id_bytes = uuid_get_bytes(instance.id);
         sql::bytes task_id_bytes = uuid_get_bytes(instance.task_id);
         statement->setBytes(1, &id_bytes);
         statement->setBytes(2, &task_id_bytes);
         statement->executeUpdate();
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         if (e.getErrorCode() == ErDupKey || e.getErrorCode() == ErDupEntry) {
             return StorageErr{StorageErrType::DuplicateKeyErr, e.what()};
         }
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlMetadataStorage::create_task_instance(TaskInstance const& instance) -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlMetadataStorage::create_task_instance(
+        StorageConnection& conn,
+        TaskInstance const& instance
+) -> StorageErr {
     try {
         // Check the state of the task
-        std::unique_ptr<sql::PreparedStatement> ready_statement(conn->prepareStatement(
-                "SELECT `state` FROM `tasks` WHERE `id` = ? AND `state` = 'ready'"
-        ));
+        std::unique_ptr<sql::PreparedStatement> ready_statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `state` FROM `tasks` WHERE `id` = ? AND `state` = 'ready'"
+                )
+        );
         sql::bytes id_bytes = uuid_get_bytes(instance.task_id);
         ready_statement->setBytes(1, &id_bytes);
         std::unique_ptr<sql::ResultSet> const ready_res(ready_statement->executeQuery());
         bool const task_ready = ready_res->rowsCount() > 0;
         // Check all task instances have timed out
-        std::unique_ptr<sql::PreparedStatement> not_timeout_statement(conn->prepareStatement(
-                "SELECT `t1`.`id` FROM `task_instances` as `t1` JOIN `tasks` ON `t1`.`task_id` = "
-                "`tasks`.`id` WHERE `t1`.`task_id` = ? AND `tasks`.`timeout` < 0.0001 AND "
-                "TIMESTAMPDIFF(MICROSECOND, `t1`.`start_time`, CURRENT_TIMESTAMP()) < "
-                "`tasks`.`timeout` * 1000"
-        ));
+        std::unique_ptr<sql::PreparedStatement> not_timeout_statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `t1`.`id` FROM `task_instances` as `t1` JOIN `tasks` ON "
+                        "`t1`.`task_id` = `tasks`.`id` WHERE `t1`.`task_id` = ? AND "
+                        "`tasks`.`timeout` < 0.0001 AND TIMESTAMPDIFF(MICROSECOND, "
+                        "`t1`.`start_time`, CURRENT_TIMESTAMP()) < `tasks`.`timeout` * 1000"
+                )
+        );
         not_timeout_statement->setBytes(1, &id_bytes);
         std::unique_ptr<sql::ResultSet> const not_timeout_res(not_timeout_statement->executeQuery()
         );
         bool const all_timeout = not_timeout_res->rowsCount() == 0;
         if (!task_ready && !all_timeout) {
-            conn->rollback();
+            static_cast<MySqlConnection&>(conn)->rollback();
             return StorageErr{StorageErrType::OtherErr, "Task not ready or timed out"};
         }
         // Set the state to running
         std::unique_ptr<sql::PreparedStatement> const running_statement(
-                conn->prepareStatement("UPDATE `tasks` SET `state` = 'running' WHERE `id` = ?")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "UPDATE `tasks` SET `state` = 'running' WHERE `id` = ?"
+                )
         );
         running_statement->setBytes(1, &id_bytes);
         running_statement->executeUpdate();
         // Insert task instance
-        std::unique_ptr<sql::PreparedStatement> const instance_statement(conn->prepareStatement(
-                "INSERT INTO `task_instances` (`id`, `task_id`, `start_time`) VALUES(?, ?, "
-                "CURRENT_TIMESTAMP())"
-        ));
+        std::unique_ptr<sql::PreparedStatement> const instance_statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "INSERT INTO `task_instances` (`id`, `task_id`, `start_time`) VALUES(?, ?, "
+                        "CURRENT_TIMESTAMP())"
+                )
+        );
         sql::bytes instance_id_bytes = uuid_get_bytes(instance.id);
         instance_statement->setBytes(1, &instance_id_bytes);
         instance_statement->setBytes(2, &id_bytes);
         instance_statement->executeUpdate();
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
 
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
 auto MySqlMetadataStorage::task_finish(
+        StorageConnection& conn,
         TaskInstance const& instance,
         std::vector<TaskOutput> const& outputs
 ) -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
     try {
         // Try to submit task instance
-        std::unique_ptr<sql::PreparedStatement> const statement(conn->prepareStatement(
-                "UPDATE `tasks` SET `instance_id` = ?, `state` = 'success' WHERE `id` = ? AND "
-                "`instance_id` is NULL AND `state` = 'running'"
-        ));
+        std::unique_ptr<sql::PreparedStatement> const statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "UPDATE `tasks` SET `instance_id` = ?, `state` = 'success' WHERE `id` = ? "
+                        "AND `instance_id` is NULL AND `state` = 'running'"
+                )
+        );
         sql::bytes id_bytes = uuid_get_bytes(instance.id);
         sql::bytes task_id_bytes = uuid_get_bytes(instance.task_id);
         statement->setBytes(1, &id_bytes);
         statement->setBytes(2, &task_id_bytes);
         int32_t const update_count = statement->executeUpdate();
         if (update_count == 0) {
-            conn->commit();
+            static_cast<MySqlConnection&>(conn)->commit();
             return StorageErr{};
         }
 
         // Update task outputs
-        std::unique_ptr<sql::PreparedStatement> output_statement(conn->prepareStatement(
-                "UPDATE `task_outputs` SET `value` = ?, `data_id` = ? WHERE `task_id` = ? AND "
-                "`position` = ?"
-        ));
+        std::unique_ptr<sql::PreparedStatement> output_statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "UPDATE `task_outputs` SET `value` = ?, `data_id` = ? WHERE `task_id` = ? "
+                        "AND `position` = ?"
+                )
+        );
         for (size_t i = 0; i < outputs.size(); ++i) {
             TaskOutput const& output = outputs[i];
             std::optional<std::string> const& value = output.get_value();
@@ -1405,10 +1418,12 @@ auto MySqlMetadataStorage::task_finish(
         }
 
         // Update task inputs
-        std::unique_ptr<sql::PreparedStatement> input_statement(conn->prepareStatement(
-                "UPDATE `task_inputs` SET `value` = ?, `data_id` = ? WHERE `output_task_id` = ? "
-                "AND `output_task_position` = ?"
-        ));
+        std::unique_ptr<sql::PreparedStatement> input_statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "UPDATE `task_inputs` SET `value` = ?, `data_id` = ? WHERE "
+                        "`output_task_id` = ? AND `output_task_position` = ?"
+                )
+        );
         for (size_t i = 0; i < outputs.size(); ++i) {
             TaskOutput const& output = outputs[i];
             std::optional<std::string> const& value = output.get_value();
@@ -1430,38 +1445,40 @@ auto MySqlMetadataStorage::task_finish(
         }
 
         // Set task states to ready if all inputs are available
-        std::unique_ptr<sql::PreparedStatement> ready_statement(conn->prepareStatement(
-                "UPDATE `tasks` SET `state` = 'ready' WHERE `id` IN (SELECT `task_id` FROM "
-                "`task_inputs` WHERE `output_task_id` = ?) AND `state` = 'pending' AND NOT EXISTS "
-                "(SELECT `task_id` FROM `task_inputs` WHERE `task_id` IN (SELECT `task_id` FROM "
-                "`task_inputs` WHERE `output_task_id` = ?) AND `value` IS NULL AND `data_id` IS "
-                "NULL)"
-        ));
+        std::unique_ptr<sql::PreparedStatement> ready_statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "UPDATE `tasks` SET `state` = 'ready' WHERE `id` IN (SELECT `task_id` FROM "
+                        "`task_inputs` WHERE `output_task_id` = ?) AND `state` = 'pending' AND NOT "
+                        "EXISTS (SELECT `task_id` FROM `task_inputs` WHERE `task_id` IN (SELECT "
+                        "`task_id` FROM `task_inputs` WHERE `output_task_id` = ?) AND `value` IS "
+                        "NULL AND `data_id` IS NULL)"
+                )
+        );
         ready_statement->setBytes(1, &task_id_bytes);
         ready_statement->setBytes(2, &task_id_bytes);
         ready_statement->executeUpdate();
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         if (e.getErrorCode() == ErDupKey || e.getErrorCode() == ErDupEntry) {
             return StorageErr{StorageErrType::DuplicateKeyErr, e.what()};
         }
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlMetadataStorage::task_fail(TaskInstance const& instance, std::string const& /*error*/)
-        -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlMetadataStorage::task_fail(
+        StorageConnection& conn,
+        TaskInstance const& instance,
+        std::string const& /*error*/
+) -> StorageErr {
     try {
         // Remove task instance
         std::unique_ptr<sql::PreparedStatement> const statement(
-                conn->prepareStatement("DELETE FROM `task_instances` WHERE `id` = ?")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "DELETE FROM `task_instances` WHERE `id` = ?"
+                )
         );
         sql::bytes instance_id_bytes = uuid_get_bytes(instance.id);
         statement->setBytes(1, &instance_id_bytes);
@@ -1469,7 +1486,9 @@ auto MySqlMetadataStorage::task_fail(TaskInstance const& instance, std::string c
 
         // Get number of remaining instances
         std::unique_ptr<sql::PreparedStatement> const count_statement(
-                conn->prepareStatement("SELECT COUNT(*) FROM `task_instances` WHERE `task_id` = ?")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT COUNT(*) FROM `task_instances` WHERE `task_id` = ?"
+                )
         );
         sql::bytes task_id_bytes = uuid_get_bytes(instance.task_id);
         count_statement->setBytes(1, &task_id_bytes);
@@ -1479,45 +1498,49 @@ auto MySqlMetadataStorage::task_fail(TaskInstance const& instance, std::string c
         if (count == 0) {
             // Set the task fail if the last task instance fails
             std::unique_ptr<sql::PreparedStatement> const task_statement(
-                    conn->prepareStatement("UPDATE `tasks` SET `state` = 'fail' WHERE `id` = ?")
+                    static_cast<MySqlConnection&>(conn)->prepareStatement(
+                            "UPDATE `tasks` SET `state` = 'fail' WHERE `id` = ?"
+                    )
             );
             task_statement->setBytes(1, &task_id_bytes);
             task_statement->executeUpdate();
         }
     } catch (sql::SQLException& e) {
         spdlog::error("Task fail error: {}", e.what());
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlMetadataStorage::get_task_timeout(std::vector<std::tuple<TaskInstance, Task>>* tasks
+auto MySqlMetadataStorage::get_task_timeout(
+        StorageConnection& conn,
+        std::vector<std::tuple<TaskInstance, Task>>* tasks
 ) -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
     try {
-        std::unique_ptr<sql::Statement> statement(conn->createStatement());
+        std::unique_ptr<sql::Statement> statement(
+                static_cast<MySqlConnection&>(conn)->createStatement()
+        );
         std::unique_ptr<sql::ResultSet> res(statement->executeQuery(
                 "SELECT `t1`.`id`, `t1`.`task_id` FROM `task_instances` as `t1` JOIN `tasks` ON "
-                "`t1`.`task_id` = "
-                "`tasks`.`id` WHERE `tasks`.`timeout` > 0.0001 AND TIMESTAMPDIFF(MICROSECOND, "
-                "`t1`.`start_time`, CURRENT_TIMESTAMP()) > `tasks`.`timeout` * 1000"
+                "`t1`.`task_id` = `tasks`.`id` WHERE `tasks`.`timeout` > 0.0001 AND "
+                "TIMESTAMPDIFF(MICROSECOND, `t1`.`start_time`, CURRENT_TIMESTAMP()) > "
+                "`tasks`.`timeout` * 1000"
         ));
         std::unique_ptr<sql::PreparedStatement> not_timeout_statement(
-                conn->prepareStatement("SELECT FROM `task_instances` as `t1` JOIN `tasks` ON"
-                                       "`t1`.`task_id` = `tasks`.`id` WHERE `t1.task_id` = ? AND "
-                                       "TIMESTAMPDIFF(MICROSECOND, `t1`.`start_time`, "
-                                       "CURRENT_TIMESTAMP()) < `tasks`.`timeout` * 1000")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT FROM `task_instances` as `t1` JOIN `tasks` ON`t1`.`task_id` = "
+                        "`tasks`.`id` WHERE `t1.task_id` = ? AND TIMESTAMPDIFF(MICROSECOND, "
+                        "`t1`.`start_time`, CURRENT_TIMESTAMP()) < `tasks`.`timeout` * 1000"
+                )
         );
 
-        std::unique_ptr<sql::PreparedStatement> task_statement(conn->prepareStatement(
-                "SELECT `id`, `func_name`, `state`, `timeout` FROM `tasks` WHERE `id` = ?"
-        ));
+        std::unique_ptr<sql::PreparedStatement> task_statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `id`, `func_name`, `state`, `timeout` FROM `tasks` WHERE `id` = ?"
+                )
+        );
         while (res->next()) {
             boost::uuids::uuid const task_instance_id = read_id(res->getBinaryStream("id"));
             boost::uuids::uuid const task_id = read_id(res->getBinaryStream("task_id"));
@@ -1533,90 +1556,88 @@ auto MySqlMetadataStorage::get_task_timeout(std::vector<std::tuple<TaskInstance,
             task_statement->setBytes(1, &task_id_bytes);
             std::unique_ptr<sql::ResultSet> task_res(task_statement->executeQuery());
             if (task_res->next()) {
-                Task const task = fetch_full_task(conn, task_res);
+                Task const task = fetch_full_task(static_cast<MySqlConnection&>(conn), task_res);
                 tasks->emplace_back(TaskInstance{task_instance_id, task_id}, task);
             }
         }
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlMetadataStorage::get_child_tasks(boost::uuids::uuid id, std::vector<Task>* children)
-        -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlMetadataStorage::get_child_tasks(
+        StorageConnection& conn,
+        boost::uuids::uuid id,
+        std::vector<Task>* children
+) -> StorageErr {
     try {
-        std::unique_ptr<sql::PreparedStatement> statement(conn->prepareStatement(
-                "SELECT `id`, `func_name`, `state`, `timeout` FROM `tasks` JOIN "
-                "`task_dependencies` "
-                "as `t2` WHERE `tasks`.`id` = `t2`.`child` AND `t2`.`parent` = ?"
-        ));
+        std::unique_ptr<sql::PreparedStatement> statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `id`, `func_name`, `state`, `timeout` FROM `tasks` JOIN "
+                        "`task_dependencies` as `t2` WHERE `tasks`.`id` = `t2`.`child` AND "
+                        "`t2`.`parent` = ?"
+                )
+        );
         sql::bytes id_bytes = uuid_get_bytes(id);
         statement->setBytes(1, &id_bytes);
         std::unique_ptr<sql::ResultSet> res(statement->executeQuery());
         while (res->next()) {
-            children->emplace_back(fetch_full_task(conn, res));
+            children->emplace_back(fetch_full_task(static_cast<MySqlConnection&>(conn), res));
         }
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlMetadataStorage::get_parent_tasks(boost::uuids::uuid id, std::vector<Task>* tasks)
-        -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlMetadataStorage::get_parent_tasks(
+        StorageConnection& conn,
+        boost::uuids::uuid id,
+        std::vector<Task>* tasks
+) -> StorageErr {
     try {
-        std::unique_ptr<sql::PreparedStatement> statement(conn->prepareStatement(
-                "SELECT `id`, `func_name`, `state`, `timeout` FROM `tasks` JOIN "
-                "`task_dependencies` "
-                "as `t2` WHERE `tasks`.`id` = `t2`.`parent` AND `t2`.`child` = ?"
-        ));
+        std::unique_ptr<sql::PreparedStatement> statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `id`, `func_name`, `state`, `timeout` FROM `tasks` JOIN "
+                        "`task_dependencies` as `t2` WHERE `tasks`.`id` = `t2`.`parent` AND "
+                        "`t2`.`child` = ?"
+                )
+        );
         sql::bytes id_bytes = uuid_get_bytes(id);
         statement->setBytes(1, &id_bytes);
         std::unique_ptr<sql::ResultSet> const res(statement->executeQuery());
         while (res->next()) {
-            tasks->emplace_back(fetch_full_task(conn, res));
+            tasks->emplace_back(fetch_full_task(static_cast<MySqlConnection&>(conn), res));
         }
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlMetadataStorage::update_heartbeat(boost::uuids::uuid id) -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlMetadataStorage::update_heartbeat(StorageConnection& conn, boost::uuids::uuid id)
+        -> StorageErr {
     try {
-        std::unique_ptr<sql::PreparedStatement> statement(conn->prepareStatement(
-                "UPDATE `drivers` SET `heartbeat` = CURRENT_TIMESTAMP() WHERE `id` = ?"
-        ));
+        std::unique_ptr<sql::PreparedStatement> statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "UPDATE `drivers` SET `heartbeat` = CURRENT_TIMESTAMP() WHERE `id` = ?"
+                )
+        );
         sql::bytes id_bytes = uuid_get_bytes(id);
         statement->setBytes(1, &id_bytes);
         statement->executeUpdate();
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
@@ -1624,47 +1645,47 @@ namespace {
 constexpr int cMillisecondToMicrosecond = 1000;
 }  // namespace
 
-auto MySqlMetadataStorage::heartbeat_timeout(double timeout, std::vector<boost::uuids::uuid>* ids)
-        -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlMetadataStorage::heartbeat_timeout(
+        StorageConnection& conn,
+        double timeout,
+        std::vector<boost::uuids::uuid>* ids
+) -> StorageErr {
     try {
-        std::unique_ptr<sql::PreparedStatement> statement(conn->prepareStatement(
-                "SELECT `id` FROM `drivers` WHERE TIMESTAMPDIFF(MICROSECOND, "
-                "`heartbeat`, CURRENT_TIMESTAMP()) > ?"
-        ));
+        std::unique_ptr<sql::PreparedStatement> statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `id` FROM `drivers` WHERE TIMESTAMPDIFF(MICROSECOND, `heartbeat`, "
+                        "CURRENT_TIMESTAMP()) > ?"
+                )
+        );
         statement->setDouble(1, timeout * cMillisecondToMicrosecond);
         std::unique_ptr<sql::ResultSet> res(statement->executeQuery());
         while (res->next()) {
             ids->emplace_back(read_id(res->getBinaryStream("id")));
         }
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlMetadataStorage::get_scheduler_state(boost::uuids::uuid id, std::string* state)
-        -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlMetadataStorage::get_scheduler_state(
+        StorageConnection& conn,
+        boost::uuids::uuid id,
+        std::string* state
+) -> StorageErr {
     try {
         std::unique_ptr<sql::PreparedStatement> statement(
-                conn->prepareStatement("SELECT `state` FROM `schedulers` WHERE `id` = ?")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `state` FROM `schedulers` WHERE `id` = ?"
+                )
         );
         sql::bytes id_bytes = uuid_get_bytes(id);
         statement->setBytes(1, &id_bytes);
         std::unique_ptr<sql::ResultSet> res(statement->executeQuery());
         if (res->rowsCount() == 0) {
-            conn->rollback();
+            static_cast<MySqlConnection&>(conn)->rollback();
             return StorageErr{
                     StorageErrType::KeyNotFoundErr,
                     fmt::format("no scheduler with id {}", boost::uuids::to_string(id))
@@ -1673,29 +1694,30 @@ auto MySqlMetadataStorage::get_scheduler_state(boost::uuids::uuid id, std::strin
         res->next();
         *state = get_sql_string(res->getString(1));
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlMetadataStorage::get_scheduler_addr(boost::uuids::uuid id, std::string* addr, int* port)
-        -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlMetadataStorage::get_scheduler_addr(
+        StorageConnection& conn,
+        boost::uuids::uuid id,
+        std::string* addr,
+        int* port
+) -> StorageErr {
     try {
         std::unique_ptr<sql::PreparedStatement> statement(
-                conn->prepareStatement("SELECT `address`, `port` FROM `schedulers` WHERE `id` = ?")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `address`, `port` FROM `schedulers` WHERE `id` = ?"
+                )
         );
         sql::bytes id_bytes = uuid_get_bytes(id);
         statement->setBytes(1, &id_bytes);
         std::unique_ptr<sql::ResultSet> res{statement->executeQuery()};
         if (res->rowsCount() == 0) {
-            conn->rollback();
+            static_cast<MySqlConnection&>(conn)->rollback();
             return StorageErr{
                     StorageErrType::KeyNotFoundErr,
                     fmt::format("no scheduler with id {}", boost::uuids::to_string(id))
@@ -1705,68 +1727,65 @@ auto MySqlMetadataStorage::get_scheduler_addr(boost::uuids::uuid id, std::string
         *addr = get_sql_string(res->getString(1));
         *port = res->getInt(2);
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlMetadataStorage::set_scheduler_state(boost::uuids::uuid id, std::string const& state)
-        -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlMetadataStorage::set_scheduler_state(
+        StorageConnection& conn,
+        boost::uuids::uuid id,
+        std::string const& state
+) -> StorageErr {
     try {
         std::unique_ptr<sql::PreparedStatement> statement(
-                conn->prepareStatement("UPDATE `schedulers` SET `state` = ? WHERE `id` = ?")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "UPDATE `schedulers` SET `state` = ? WHERE `id` = ?"
+                )
         );
         statement->setString(1, state);
         sql::bytes id_bytes = uuid_get_bytes(id);
         statement->setBytes(2, &id_bytes);
         statement->executeUpdate();
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlDataStorage::initialize() -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlDataStorage::initialize(StorageConnection& conn) -> StorageErr {
     try {
         // Need to initialize metadata storage first so that foreign constraint is not voilated
         for (char const* create_table_str : cCreateStorage) {
-            std::unique_ptr<sql::Statement> statement(conn->createStatement());
+            std::unique_ptr<sql::Statement> statement(
+                    static_cast<MySqlConnection&>(conn)->createStatement()
+            );
             statement->executeUpdate(create_table_str);
         }
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
 
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlDataStorage::add_driver_data(boost::uuids::uuid const driver_id, Data const& data)
-        -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlDataStorage::add_driver_data(
+        StorageConnection& conn,
+        boost::uuids::uuid const driver_id,
+        Data const& data
+) -> StorageErr {
     try {
-        std::unique_ptr<sql::PreparedStatement> statement(conn->prepareStatement(
-                "INSERT INTO `data` (`id`, `value`, `hard_locality`) VALUES(?, ?, ?)"
-        ));
+        std::unique_ptr<sql::PreparedStatement> statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "INSERT INTO `data` (`id`, `value`, `hard_locality`) VALUES(?, ?, ?)"
+                )
+        );
         sql::bytes id_bytes = uuid_get_bytes(data.get_id());
         statement->setBytes(1, &id_bytes);
         statement->setString(2, data.get_value());
@@ -1775,42 +1794,46 @@ auto MySqlDataStorage::add_driver_data(boost::uuids::uuid const driver_id, Data 
 
         for (std::string const& addr : data.get_locality()) {
             std::unique_ptr<sql::PreparedStatement> locality_statement(
-                    conn->prepareStatement("INSERT INTO `data_locality` (`id`, "
-                                           "`address`) VALUES (?, ?)")
+                    static_cast<MySqlConnection&>(conn)->prepareStatement(
+                            "INSERT INTO `data_locality` (`id`, "
+                            "`address`) VALUES (?, ?)"
+                    )
             );
             locality_statement->setBytes(1, &id_bytes);
             locality_statement->setString(2, addr);
             locality_statement->executeUpdate();
         }
-        std::unique_ptr<sql::PreparedStatement> driver_ref_statement(conn->prepareStatement(
-                "INSERT INTO `data_ref_driver` (`id`, `driver_id`) VALUES(?, ?)"
-        ));
+        std::unique_ptr<sql::PreparedStatement> driver_ref_statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "INSERT INTO `data_ref_driver` (`id`, `driver_id`) VALUES(?, ?)"
+                )
+        );
         sql::bytes driver_id_bytes = uuid_get_bytes(driver_id);
         driver_ref_statement->setBytes(1, &id_bytes);
         driver_ref_statement->setBytes(2, &driver_id_bytes);
         driver_ref_statement->executeUpdate();
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         if (e.getErrorCode() == ErDupKey || e.getErrorCode() == ErDupEntry) {
             return StorageErr{StorageErrType::DuplicateKeyErr, e.what()};
         }
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlDataStorage::add_task_data(boost::uuids::uuid const task_id, Data const& data)
-        -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlDataStorage::add_task_data(
+        StorageConnection& conn,
+        boost::uuids::uuid const task_id,
+        Data const& data
+) -> StorageErr {
     try {
-        std::unique_ptr<sql::PreparedStatement> statement(conn->prepareStatement(
-                "INSERT INTO `data` (`id`, `value`, `hard_locality`) VALUES(?, ?, ?)"
-        ));
+        std::unique_ptr<sql::PreparedStatement> statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "INSERT INTO `data` (`id`, `value`, `hard_locality`) VALUES(?, ?, ?)"
+                )
+        );
         sql::bytes id_bytes = uuid_get_bytes(data.get_id());
         statement->setBytes(1, &id_bytes);
         statement->setString(2, data.get_value());
@@ -1819,47 +1842,47 @@ auto MySqlDataStorage::add_task_data(boost::uuids::uuid const task_id, Data cons
 
         for (std::string const& addr : data.get_locality()) {
             std::unique_ptr<sql::PreparedStatement> locality_statement(
-                    conn->prepareStatement("INSERT INTO `data_locality` (`id`, "
-                                           "`address`) VALUES (?, ?)")
+                    static_cast<MySqlConnection&>(conn)->prepareStatement(
+                            "INSERT INTO `data_locality` (`id`, `address`) VALUES (?, ?)"
+                    )
             );
             locality_statement->setBytes(1, &id_bytes);
             locality_statement->setString(2, addr);
             locality_statement->executeUpdate();
         }
         std::unique_ptr<sql::PreparedStatement> task_ref_statement(
-                conn->prepareStatement("INSERT INTO `data_ref_task` (`id`, `task_id`) VALUES(?, ?)")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "INSERT INTO `data_ref_task` (`id`, `task_id`) VALUES(?, ?)"
+                )
         );
         sql::bytes task_id_bytes = uuid_get_bytes(task_id);
         task_ref_statement->setBytes(1, &id_bytes);
         task_ref_statement->setBytes(2, &task_id_bytes);
         task_ref_statement->executeUpdate();
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         if (e.getErrorCode() == ErDupKey || e.getErrorCode() == ErDupEntry) {
             return StorageErr{StorageErrType::DuplicateKeyErr, e.what()};
         }
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlDataStorage::get_data(boost::uuids::uuid id, Data* data) -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlDataStorage::get_data(StorageConnection& conn, boost::uuids::uuid id, Data* data)
+        -> StorageErr {
     try {
         std::unique_ptr<sql::PreparedStatement> statement(
-                conn->prepareStatement("SELECT `id`, `value`, `hard_locality` "
-                                       "FROM `data` WHERE `id` = ?")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `id`, `value`, `hard_locality` FROM `data` WHERE `id` = ?"
+                )
         );
         sql::bytes id_bytes = uuid_get_bytes(id);
         statement->setBytes(1, &id_bytes);
         std::unique_ptr<sql::ResultSet> res(statement->executeQuery());
         if (res->rowsCount() == 0) {
-            conn->rollback();
+            static_cast<MySqlConnection&>(conn)->rollback();
             return StorageErr{
                     StorageErrType::KeyNotFoundErr,
                     fmt::format("no data with id {}", boost::uuids::to_string(id))
@@ -1870,7 +1893,9 @@ auto MySqlDataStorage::get_data(boost::uuids::uuid id, Data* data) -> StorageErr
         data->set_hard_locality(res->getBoolean(3));
 
         std::unique_ptr<sql::PreparedStatement> locality_statement(
-                conn->prepareStatement("SELECT `address` FROM `data_locality` WHERE `id` = ?")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `address` FROM `data_locality` WHERE `id` = ?"
+                )
         );
         locality_statement->setBytes(1, &id_bytes);
         std::unique_ptr<sql::ResultSet> const locality_res(locality_statement->executeQuery());
@@ -1882,28 +1907,27 @@ auto MySqlDataStorage::get_data(boost::uuids::uuid id, Data* data) -> StorageErr
             data->set_locality(locality);
         }
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlDataStorage::set_data_locality(Data const& data) -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlDataStorage::set_data_locality(StorageConnection& conn, Data const& data) -> StorageErr {
     try {
         std::unique_ptr<sql::PreparedStatement> const delete_statement(
-                conn->prepareStatement("DELETE FROM `data_locality` WHERE `id` = ?")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "DELETE FROM `data_locality` WHERE `id` = ?"
+                )
         );
         sql::bytes id_bytes = uuid_get_bytes(data.get_id());
         delete_statement->setBytes(1, &id_bytes);
         delete_statement->executeUpdate();
         std::unique_ptr<sql::PreparedStatement> const insert_statement(
-                conn->prepareStatement("INSERT INTO `data_locality` (`id`, `address`) VALUES(?, ?)")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "INSERT INTO `data_locality` (`id`, `address`) VALUES(?, ?)"
+                )
         );
         for (std::string const& addr : data.get_locality()) {
             insert_statement->setBytes(1, &id_bytes);
@@ -1911,51 +1935,49 @@ auto MySqlDataStorage::set_data_locality(Data const& data) -> StorageErr {
             insert_statement->executeUpdate();
         }
         std::unique_ptr<sql::PreparedStatement> const hard_locality_statement(
-                conn->prepareStatement("UPDATE `data` SET `hard_locality` = ? WHERE `id` = ?")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "UPDATE `data` SET `hard_locality` = ? WHERE `id` = ?"
+                )
         );
         hard_locality_statement->setBoolean(1, data.is_hard_locality());
         hard_locality_statement->setBytes(2, &id_bytes);
         hard_locality_statement->executeUpdate();
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlDataStorage::remove_data(boost::uuids::uuid id) -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlDataStorage::remove_data(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr {
     try {
         std::unique_ptr<sql::PreparedStatement> statement(
-                conn->prepareStatement("DELETE FROM `data` WHERE `id` = ?")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "DELETE FROM `data` WHERE `id` = ?"
+                )
         );
         sql::bytes id_bytes = uuid_get_bytes(id);
         statement->setBytes(1, &id_bytes);
         statement->executeUpdate();
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlDataStorage::add_task_reference(boost::uuids::uuid id, boost::uuids::uuid task_id)
-        -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlDataStorage::add_task_reference(
+        StorageConnection& conn,
+        boost::uuids::uuid id,
+        boost::uuids::uuid task_id
+) -> StorageErr {
     try {
         std::unique_ptr<sql::PreparedStatement> statement(
-                conn->prepareStatement("INSERT INTO `data_ref_task` (`id`, "
-                                       "`task_id`) VALUES(?, ?)")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "INSERT INTO `data_ref_task` (`id`, `task_id`) VALUES(?, ?)"
+                )
         );
         sql::bytes id_bytes = uuid_get_bytes(id);
         statement->setBytes(1, &id_bytes);
@@ -1963,27 +1985,26 @@ auto MySqlDataStorage::add_task_reference(boost::uuids::uuid id, boost::uuids::u
         statement->setBytes(2, &task_id_bytes);
         statement->executeUpdate();
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         if (e.getErrorCode() == ErDupKey || e.getErrorCode() == ErDupEntry) {
             return StorageErr{StorageErrType::DuplicateKeyErr, e.what()};
         }
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlDataStorage::remove_task_reference(boost::uuids::uuid id, boost::uuids::uuid task_id)
-        -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlDataStorage::remove_task_reference(
+        StorageConnection& conn,
+        boost::uuids::uuid id,
+        boost::uuids::uuid task_id
+) -> StorageErr {
     try {
         std::unique_ptr<sql::PreparedStatement> statement(
-                conn->prepareStatement("DELETE FROM `data_ref_task` WHERE "
-                                       "`id` = ? AND `task_id` = ?")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "DELETE FROM `data_ref_task` WHERE `id` = ? AND `task_id` = ?"
+                )
         );
         sql::bytes id_bytes = uuid_get_bytes(id);
         statement->setBytes(1, &id_bytes);
@@ -1991,24 +2012,23 @@ auto MySqlDataStorage::remove_task_reference(boost::uuids::uuid id, boost::uuids
         statement->setBytes(2, &task_id_bytes);
         statement->executeUpdate();
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlDataStorage::add_driver_reference(boost::uuids::uuid id, boost::uuids::uuid driver_id)
-        -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlDataStorage::add_driver_reference(
+        StorageConnection& conn,
+        boost::uuids::uuid id,
+        boost::uuids::uuid driver_id
+) -> StorageErr {
     try {
         std::unique_ptr<sql::PreparedStatement> statement(
-                conn->prepareStatement("INSERT INTO `data_ref_driver` (`id`, "
-                                       "`driver_id`) VALUES(?, ?)")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "INSERT INTO `data_ref_driver` (`id`, `driver_id`) VALUES(?, ?)"
+                )
         );
         sql::bytes id_bytes = uuid_get_bytes(id);
         statement->setBytes(1, &id_bytes);
@@ -2016,27 +2036,26 @@ auto MySqlDataStorage::add_driver_reference(boost::uuids::uuid id, boost::uuids:
         statement->setBytes(2, &driver_id_bytes);
         statement->executeUpdate();
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         if (e.getErrorCode() == ErDupKey || e.getErrorCode() == ErDupEntry) {
             return StorageErr{StorageErrType::DuplicateKeyErr, e.what()};
         }
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlDataStorage::remove_driver_reference(boost::uuids::uuid id, boost::uuids::uuid driver_id)
-        -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlDataStorage::remove_driver_reference(
+        StorageConnection& conn,
+        boost::uuids::uuid id,
+        boost::uuids::uuid driver_id
+) -> StorageErr {
     try {
         std::unique_ptr<sql::PreparedStatement> statement(
-                conn->prepareStatement("DELETE FROM `data_ref_driver` "
-                                       "WHERE `id` = ? AND `driver_id` = ?")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "DELETE FROM `data_ref_driver` WHERE `id` = ? AND `driver_id` = ?"
+                )
         );
         sql::bytes id_bytes = uuid_get_bytes(id);
         statement->setBytes(1, &id_bytes);
@@ -2044,105 +2063,97 @@ auto MySqlDataStorage::remove_driver_reference(boost::uuids::uuid id, boost::uui
         statement->setBytes(2, &driver_id_bytes);
         statement->executeUpdate();
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlDataStorage::remove_dangling_data() -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlDataStorage::remove_dangling_data(StorageConnection& conn) -> StorageErr {
     try {
-        std::unique_ptr<sql::Statement> statement{conn->createStatement()};
+        std::unique_ptr<sql::Statement> statement{
+                static_cast<MySqlConnection&>(conn)->createStatement()
+        };
         statement->execute("DELETE FROM `data` WHERE `id` NOT IN (SELECT driver_ref.`id` FROM "
                            "`data_ref_driver` driver_ref) AND `id` NOT IN (SELECT task_ref.`id` "
                            "FROM `data_ref_task` task_ref)");
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlDataStorage::add_client_kv_data(KeyValueData const& data) -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlDataStorage::add_client_kv_data(StorageConnection& conn, KeyValueData const& data)
+        -> StorageErr {
     try {
-        std::unique_ptr<sql::PreparedStatement> statement(conn->prepareStatement(
-                "INSERT INTO `client_kv_data` (`kv_key`, `value`, `client_id`) VALUES(?, ?, ?)"
-        ));
+        std::unique_ptr<sql::PreparedStatement> statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "INSERT INTO `client_kv_data` (`kv_key`, `value`, `client_id`) VALUES(?, "
+                        "?, ?)"
+                )
+        );
         statement->setString(1, data.get_key());
         statement->setString(2, data.get_value());
         sql::bytes id_bytes = uuid_get_bytes(data.get_id());
         statement->setBytes(3, &id_bytes);
         statement->executeUpdate();
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         if (e.getErrorCode() == ErDupKey || e.getErrorCode() == ErDupEntry) {
             return StorageErr{StorageErrType::DuplicateKeyErr, e.what()};
         }
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
-auto MySqlDataStorage::add_task_kv_data(KeyValueData const& data) -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
+auto MySqlDataStorage::add_task_kv_data(StorageConnection& conn, KeyValueData const& data)
+        -> StorageErr {
     try {
-        std::unique_ptr<sql::PreparedStatement> statement(conn->prepareStatement(
-                "INSERT INTO `task_kv_data` (`kv_key`, `value`, `task_id`) VALUES(?, ?, ?)"
-        ));
+        std::unique_ptr<sql::PreparedStatement> statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "INSERT INTO `task_kv_data` (`kv_key`, `value`, `task_id`) VALUES(?, ?, ?)"
+                )
+        );
         statement->setString(1, data.get_key());
         statement->setString(2, data.get_value());
         sql::bytes id_bytes = uuid_get_bytes(data.get_id());
         statement->setBytes(3, &id_bytes);
         statement->executeUpdate();
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         if (e.getErrorCode() == ErDupKey || e.getErrorCode() == ErDupEntry) {
             return StorageErr{StorageErrType::DuplicateKeyErr, e.what()};
         }
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
 auto MySqlDataStorage::get_client_kv_data(
+        StorageConnection& conn,
         boost::uuids::uuid const& client_id,
         std::string const& key,
         std::string* value
 ) -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
     try {
-        std::unique_ptr<sql::PreparedStatement> statement(conn->prepareStatement(
-                "SELECT `value` "
-                "FROM `client_kv_data` WHERE `client_id` = ? AND `kv_key` = ?"
-        ));
+        std::unique_ptr<sql::PreparedStatement> statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `value` FROM `client_kv_data` WHERE `client_id` = ? AND `kv_key` = "
+                        "?"
+                )
+        );
         sql::bytes id_bytes = uuid_get_bytes(client_id);
         statement->setBytes(1, &id_bytes);
         statement->setString(2, key);
         std::unique_ptr<sql::ResultSet> res(statement->executeQuery());
         if (res->rowsCount() == 0) {
-            conn->rollback();
+            static_cast<MySqlConnection&>(conn)->rollback();
             return StorageErr{
                     StorageErrType::KeyNotFoundErr,
                     fmt::format(
@@ -2155,34 +2166,31 @@ auto MySqlDataStorage::get_client_kv_data(
         res->next();
         *value = get_sql_string(res->getString(1));
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
 auto MySqlDataStorage::get_task_kv_data(
+        StorageConnection& conn,
         boost::uuids::uuid const& task_id,
         std::string const& key,
         std::string* value
 ) -> StorageErr {
-    std::variant<MySqlConnection, StorageErr> conn_result = MySqlConnection::create(m_url);
-    if (std::holds_alternative<StorageErr>(conn_result)) {
-        return std::get<StorageErr>(conn_result);
-    }
-    auto& conn = std::get<MySqlConnection>(conn_result);
     try {
         std::unique_ptr<sql::PreparedStatement> statement(
-                conn->prepareStatement("SELECT `value` "
-                                       "FROM `task_kv_data` WHERE `task_id` = ? AND `kv_key` = ?")
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `value` FROM `task_kv_data` WHERE `task_id` = ? AND `kv_key` = ?"
+                )
         );
         sql::bytes id_bytes = uuid_get_bytes(task_id);
         statement->setBytes(1, &id_bytes);
         statement->setString(2, key);
         std::unique_ptr<sql::ResultSet> res(statement->executeQuery());
         if (res->rowsCount() == 0) {
-            conn->rollback();
+            static_cast<MySqlConnection&>(conn)->rollback();
             return StorageErr{
                     StorageErrType::KeyNotFoundErr,
                     fmt::format(
@@ -2195,10 +2203,10 @@ auto MySqlDataStorage::get_task_kv_data(
         res->next();
         *value = get_sql_string(res->getString(1));
     } catch (sql::SQLException& e) {
-        conn->rollback();
+        static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    conn->commit();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 

--- a/src/spider/storage/MySqlStorage.hpp
+++ b/src/spider/storage/MySqlStorage.hpp
@@ -27,7 +27,9 @@ namespace spider::core {
 class MySqlMetadataStorage : public MetadataStorage {
 public:
     MySqlMetadataStorage() = delete;
-    explicit MySqlMetadataStorage(std::string url): m_url{std::move(url)} {}
+
+    explicit MySqlMetadataStorage(std::string url) : m_url{std::move(url)} {}
+
     MySqlMetadataStorage(MySqlMetadataStorage const&) = delete;
     MySqlMetadataStorage(MySqlMetadataStorage&&) = delete;
     auto operator=(MySqlMetadataStorage const&) -> MySqlMetadataStorage& = delete;
@@ -129,7 +131,9 @@ private:
 class MySqlDataStorage : public DataStorage {
 public:
     MySqlDataStorage() = delete;
-    explicit MySqlDataStorage(std::string url): m_url{std::move(url)} {}
+
+    explicit MySqlDataStorage(std::string url) : m_url{std::move(url)} {}
+
     MySqlDataStorage(MySqlDataStorage const&) = delete;
     MySqlDataStorage(MySqlDataStorage&&) = delete;
     auto operator=(MySqlDataStorage const&) -> MySqlDataStorage& = delete;

--- a/src/spider/storage/MySqlStorage.hpp
+++ b/src/spider/storage/MySqlStorage.hpp
@@ -26,7 +26,8 @@
 namespace spider::core {
 class MySqlMetadataStorage : public MetadataStorage {
 public:
-    MySqlMetadataStorage() = default;
+    MySqlMetadataStorage() = delete;
+    explicit MySqlMetadataStorage(std::string url): m_url{std::move(url)} {}
     MySqlMetadataStorage(MySqlMetadataStorage const&) = delete;
     MySqlMetadataStorage(MySqlMetadataStorage&&) = delete;
     auto operator=(MySqlMetadataStorage const&) -> MySqlMetadataStorage& = delete;
@@ -115,7 +116,11 @@ public:
             std::string const& state
     ) -> StorageErr override;
 
+    auto get_url() const -> std::string const& override { return m_url; }
+
 private:
+    std::string m_url;
+
     static void add_task(MySqlConnection& conn, sql::bytes job_id, Task const& task);
     static auto
     fetch_full_task(MySqlConnection& conn, std::unique_ptr<sql::ResultSet> const& res) -> Task;
@@ -123,7 +128,8 @@ private:
 
 class MySqlDataStorage : public DataStorage {
 public:
-    MySqlDataStorage() = default;
+    MySqlDataStorage() = delete;
+    explicit MySqlDataStorage(std::string url): m_url{std::move(url)} {}
     MySqlDataStorage(MySqlDataStorage const&) = delete;
     MySqlDataStorage(MySqlDataStorage&&) = delete;
     auto operator=(MySqlDataStorage const&) -> MySqlDataStorage& = delete;
@@ -175,6 +181,11 @@ public:
             std::string const& key,
             std::string* value
     ) -> StorageErr override;
+
+    auto get_url() const -> std::string const& override { return m_url; }
+
+private:
+    std::string m_url;
 };
 }  // namespace spider::core
 

--- a/src/spider/storage/MySqlStorage.hpp
+++ b/src/spider/storage/MySqlStorage.hpp
@@ -21,6 +21,7 @@
 #include "DataStorage.hpp"
 #include "MetadataStorage.hpp"
 #include "MySqlConnection.hpp"
+#include "StorageConnection.hpp"
 
 namespace spider::core {
 class MySqlMetadataStorage : public MetadataStorage {
@@ -32,48 +33,88 @@ public:
     auto operator=(MySqlMetadataStorage const&) -> MySqlMetadataStorage& = delete;
     auto operator=(MySqlMetadataStorage&&) -> MySqlMetadataStorage& = delete;
     ~MySqlMetadataStorage() override = default;
-    auto initialize() -> StorageErr override;
-    auto add_driver(Driver const& driver) -> StorageErr override;
-    auto add_scheduler(Scheduler const& scheduler) -> StorageErr override;
-    auto get_active_scheduler(std::vector<Scheduler>* schedulers) -> StorageErr override;
-    auto
-    add_job(boost::uuids::uuid job_id, boost::uuids::uuid client_id, TaskGraph const& task_graph
-    ) -> StorageErr override;
-    auto get_job_metadata(boost::uuids::uuid id, JobMetadata* job) -> StorageErr override;
-    auto get_job_complete(boost::uuids::uuid id, bool* complete) -> StorageErr override;
-    auto get_job_status(boost::uuids::uuid id, JobStatus* status) -> StorageErr override;
-    auto get_job_output_tasks(boost::uuids::uuid id, std::vector<boost::uuids::uuid>* task_ids)
+    auto initialize(StorageConnection& conn) -> StorageErr override;
+    auto add_driver(StorageConnection& conn, Driver const& driver) -> StorageErr override;
+    auto add_scheduler(StorageConnection& conn, Scheduler const& scheduler) -> StorageErr override;
+    auto get_active_scheduler(StorageConnection& conn, std::vector<Scheduler>* schedulers)
             -> StorageErr override;
-    auto get_task_graph(boost::uuids::uuid id, TaskGraph* task_graph) -> StorageErr override;
+    auto add_job(
+            StorageConnection& conn,
+            boost::uuids::uuid job_id,
+            boost::uuids::uuid client_id,
+            TaskGraph const& task_graph
+    ) -> StorageErr override;
+    auto get_job_metadata(StorageConnection& conn, boost::uuids::uuid id, JobMetadata* job)
+            -> StorageErr override;
+    auto get_job_complete(StorageConnection& conn, boost::uuids::uuid id, bool* complete)
+            -> StorageErr override;
+    auto get_job_status(StorageConnection& conn, boost::uuids::uuid id, JobStatus* status)
+            -> StorageErr override;
+    auto get_job_output_tasks(
+            StorageConnection& conn,
+            boost::uuids::uuid id,
+            std::vector<boost::uuids::uuid>* task_ids
+    ) -> StorageErr override;
+    auto get_task_graph(StorageConnection& conn, boost::uuids::uuid id, TaskGraph* task_graph)
+            -> StorageErr override;
     auto get_jobs_by_client_id(
+            StorageConnection& conn,
             boost::uuids::uuid client_id,
             std::vector<boost::uuids::uuid>* job_ids
     ) -> StorageErr override;
-    auto remove_job(boost::uuids::uuid id) -> StorageErr override;
-    auto reset_job(boost::uuids::uuid id) -> StorageErr override;
-    auto add_child(boost::uuids::uuid parent_id, Task const& child) -> StorageErr override;
-    auto get_task(boost::uuids::uuid id, Task* task) -> StorageErr override;
-    auto get_task_job_id(boost::uuids::uuid id, boost::uuids::uuid* job_id) -> StorageErr override;
-    auto get_ready_tasks(std::vector<Task>* tasks) -> StorageErr override;
-    auto set_task_state(boost::uuids::uuid id, TaskState state) -> StorageErr override;
-    auto set_task_running(boost::uuids::uuid id) -> StorageErr override;
-    auto add_task_instance(TaskInstance const& instance) -> StorageErr override;
-    auto create_task_instance(TaskInstance const& instance) -> StorageErr override;
-    auto task_finish(TaskInstance const& instance, std::vector<TaskOutput> const& outputs)
+    auto remove_job(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr override;
+    auto reset_job(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr override;
+    auto add_child(StorageConnection& conn, boost::uuids::uuid parent_id, Task const& child)
             -> StorageErr override;
-    auto task_fail(TaskInstance const& instance, std::string const& error) -> StorageErr override;
-    auto get_task_timeout(std::vector<std::tuple<TaskInstance, Task>>* tasks
+    auto
+    get_task(StorageConnection& conn, boost::uuids::uuid id, Task* task) -> StorageErr override;
+    auto get_task_job_id(StorageConnection& conn, boost::uuids::uuid id, boost::uuids::uuid* job_id)
+            -> StorageErr override;
+    auto get_ready_tasks(StorageConnection& conn, std::vector<Task>* tasks) -> StorageErr override;
+    auto set_task_state(StorageConnection& conn, boost::uuids::uuid id, TaskState state)
+            -> StorageErr override;
+    auto set_task_running(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr override;
+    auto
+    add_task_instance(StorageConnection& conn, TaskInstance const& instance) -> StorageErr override;
+    auto create_task_instance(StorageConnection& conn, TaskInstance const& instance)
+            -> StorageErr override;
+    auto task_finish(
+            StorageConnection& conn,
+            TaskInstance const& instance,
+            std::vector<TaskOutput> const& outputs
     ) -> StorageErr override;
-    auto get_child_tasks(boost::uuids::uuid id, std::vector<Task>* children) -> StorageErr override;
-    auto get_parent_tasks(boost::uuids::uuid id, std::vector<Task>* tasks) -> StorageErr override;
-    auto update_heartbeat(boost::uuids::uuid id) -> StorageErr override;
-    auto
-    heartbeat_timeout(double timeout, std::vector<boost::uuids::uuid>* ids) -> StorageErr override;
-    auto get_scheduler_state(boost::uuids::uuid id, std::string* state) -> StorageErr override;
-    auto
-    get_scheduler_addr(boost::uuids::uuid id, std::string* addr, int* port) -> StorageErr override;
-    auto
-    set_scheduler_state(boost::uuids::uuid id, std::string const& state) -> StorageErr override;
+    auto task_fail(StorageConnection& conn, TaskInstance const& instance, std::string const& error)
+            -> StorageErr override;
+    auto get_task_timeout(
+            StorageConnection& conn,
+            std::vector<std::tuple<TaskInstance, Task>>* tasks
+    ) -> StorageErr override;
+    auto get_child_tasks(
+            StorageConnection& conn,
+            boost::uuids::uuid id,
+            std::vector<Task>* children
+    ) -> StorageErr override;
+    auto get_parent_tasks(StorageConnection& conn, boost::uuids::uuid id, std::vector<Task>* tasks)
+            -> StorageErr override;
+    auto update_heartbeat(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr override;
+    auto heartbeat_timeout(
+            StorageConnection& conn,
+            double timeout,
+            std::vector<boost::uuids::uuid>* ids
+    ) -> StorageErr override;
+    auto get_scheduler_state(StorageConnection& conn, boost::uuids::uuid id, std::string* state)
+            -> StorageErr override;
+    auto get_scheduler_addr(
+            StorageConnection& conn,
+            boost::uuids::uuid id,
+            std::string* addr,
+            int* port
+    ) -> StorageErr override;
+    auto set_scheduler_state(
+            StorageConnection& conn,
+            boost::uuids::uuid id,
+            std::string const& state
+    ) -> StorageErr override;
 
 private:
     std::string m_url;
@@ -85,44 +126,58 @@ private:
 
 class MySqlDataStorage : public DataStorage {
 public:
-    MySqlDataStorage() = delete;
-    explicit MySqlDataStorage(std::string url) : m_url{std::move(url)} {};
+    MySqlDataStorage() = default;
     MySqlDataStorage(MySqlDataStorage const&) = delete;
     MySqlDataStorage(MySqlDataStorage&&) = delete;
     auto operator=(MySqlDataStorage const&) -> MySqlDataStorage& = delete;
     auto operator=(MySqlDataStorage&&) -> MySqlDataStorage& = delete;
     ~MySqlDataStorage() override = default;
-    auto initialize() -> StorageErr override;
-    auto add_driver_data(boost::uuids::uuid driver_id, Data const& data) -> StorageErr override;
-    auto add_task_data(boost::uuids::uuid task_id, Data const& data) -> StorageErr override;
-    auto get_data(boost::uuids::uuid id, Data* data) -> StorageErr override;
-    auto set_data_locality(Data const& data) -> StorageErr override;
-    auto remove_data(boost::uuids::uuid id) -> StorageErr override;
-    auto
-    add_task_reference(boost::uuids::uuid id, boost::uuids::uuid task_id) -> StorageErr override;
-    auto
-    remove_task_reference(boost::uuids::uuid id, boost::uuids::uuid task_id) -> StorageErr override;
-    auto add_driver_reference(boost::uuids::uuid id, boost::uuids::uuid driver_id)
+    auto initialize(StorageConnection& conn) -> StorageErr override;
+    auto add_driver_data(StorageConnection& conn, boost::uuids::uuid driver_id, Data const& data)
             -> StorageErr override;
-    auto remove_driver_reference(boost::uuids::uuid id, boost::uuids::uuid driver_id)
+    auto add_task_data(StorageConnection& conn, boost::uuids::uuid task_id, Data const& data)
             -> StorageErr override;
-    auto remove_dangling_data() -> StorageErr override;
+    auto
+    get_data(StorageConnection& conn, boost::uuids::uuid id, Data* data) -> StorageErr override;
+    auto set_data_locality(StorageConnection& conn, Data const& data) -> StorageErr override;
+    auto remove_data(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr override;
+    auto add_task_reference(
+            StorageConnection& conn,
+            boost::uuids::uuid id,
+            boost::uuids::uuid task_id
+    ) -> StorageErr override;
+    auto remove_task_reference(
+            StorageConnection& conn,
+            boost::uuids::uuid id,
+            boost::uuids::uuid task_id
+    ) -> StorageErr override;
+    auto add_driver_reference(
+            StorageConnection& conn,
+            boost::uuids::uuid id,
+            boost::uuids::uuid driver_id
+    ) -> StorageErr override;
+    auto remove_driver_reference(
+            StorageConnection& conn,
+            boost::uuids::uuid id,
+            boost::uuids::uuid driver_id
+    ) -> StorageErr override;
+    auto remove_dangling_data(StorageConnection& conn) -> StorageErr override;
 
-    auto add_client_kv_data(KeyValueData const& data) -> StorageErr override;
-    auto add_task_kv_data(KeyValueData const& data) -> StorageErr override;
+    auto
+    add_client_kv_data(StorageConnection& conn, KeyValueData const& data) -> StorageErr override;
+    auto add_task_kv_data(StorageConnection& conn, KeyValueData const& data) -> StorageErr override;
     auto get_client_kv_data(
+            StorageConnection& conn,
             boost::uuids::uuid const& client_id,
             std::string const& key,
             std::string* value
     ) -> StorageErr override;
     auto get_task_kv_data(
+            StorageConnection& conn,
             boost::uuids::uuid const& task_id,
             std::string const& key,
             std::string* value
     ) -> StorageErr override;
-
-private:
-    std::string m_url;
 };
 }  // namespace spider::core
 

--- a/src/spider/storage/MySqlStorage.hpp
+++ b/src/spider/storage/MySqlStorage.hpp
@@ -26,8 +26,7 @@
 namespace spider::core {
 class MySqlMetadataStorage : public MetadataStorage {
 public:
-    MySqlMetadataStorage() = delete;
-    explicit MySqlMetadataStorage(std::string url) : m_url{std::move(url)} {};
+    MySqlMetadataStorage() = default;
     MySqlMetadataStorage(MySqlMetadataStorage const&) = delete;
     MySqlMetadataStorage(MySqlMetadataStorage&&) = delete;
     auto operator=(MySqlMetadataStorage const&) -> MySqlMetadataStorage& = delete;
@@ -117,8 +116,6 @@ public:
     ) -> StorageErr override;
 
 private:
-    std::string m_url;
-
     static void add_task(MySqlConnection& conn, sql::bytes job_id, Task const& task);
     static auto
     fetch_full_task(MySqlConnection& conn, std::unique_ptr<sql::ResultSet> const& res) -> Task;

--- a/src/spider/storage/StorageConnection.hpp
+++ b/src/spider/storage/StorageConnection.hpp
@@ -4,7 +4,6 @@
 namespace spider::core {
 
 class StorageConnection {
-    virtual ~StorageConnection() = 0;
 };
 
 }  // namespace spider::core

--- a/src/spider/storage/StorageConnection.hpp
+++ b/src/spider/storage/StorageConnection.hpp
@@ -1,0 +1,12 @@
+#ifndef SPIDER_STORAGE_STORAGECONNECTION_HPP
+#define SPIDER_STORAGE_STORAGECONNECTION_HPP
+
+namespace spider::core {
+
+class StorageConnection {
+    virtual ~StorageConnection() = 0;
+};
+
+}  // namespace spider::core
+
+#endif

--- a/src/spider/storage/StorageConnection.hpp
+++ b/src/spider/storage/StorageConnection.hpp
@@ -3,8 +3,7 @@
 
 namespace spider::core {
 
-class StorageConnection {
-};
+class StorageConnection {};
 
 }  // namespace spider::core
 

--- a/src/spider/worker/FunctionManager.hpp
+++ b/src/spider/worker/FunctionManager.hpp
@@ -89,8 +89,8 @@ MSGPACK_ADD_ENUM(spider::core::FunctionInvokeError);
 
 namespace spider::core {
 
-auto response_get_error(msgpack::sbuffer const& buffer)
-        -> std::optional<std::tuple<FunctionInvokeError, std::string>>;
+auto response_get_error(msgpack::sbuffer const& buffer
+) -> std::optional<std::tuple<FunctionInvokeError, std::string>>;
 
 auto create_error_response(FunctionInvokeError error, std::string const& message)
         -> msgpack::sbuffer;
@@ -163,8 +163,8 @@ auto response_get_result(msgpack::sbuffer const& buffer) -> std::optional<std::t
     // NOLINTEND(cppcoreguidelines-pro-type-union-access,cppcoreguidelines-pro-bounds-pointer-arithmetic)
 }
 
-auto response_get_result_buffers(msgpack::sbuffer const& buffer)
-        -> std::optional<std::vector<msgpack::sbuffer>>;
+auto response_get_result_buffers(msgpack::sbuffer const& buffer
+) -> std::optional<std::vector<msgpack::sbuffer>>;
 
 template <TaskIo T>
 auto create_result_response(T const& t) -> msgpack::sbuffer {
@@ -219,8 +219,8 @@ auto create_args_request(Args&&... args) -> msgpack::sbuffer {
     return buffer;
 }
 
-inline auto create_args_request(std::vector<msgpack::sbuffer> const& args_buffers)
-        -> msgpack::sbuffer {
+inline auto create_args_request(std::vector<msgpack::sbuffer> const& args_buffers
+) -> msgpack::sbuffer {
     msgpack::sbuffer buffer;
     msgpack::packer packer{buffer};
     packer.pack_array(2);
@@ -237,8 +237,8 @@ inline auto create_args_request(std::vector<msgpack::sbuffer> const& args_buffer
 template <class F>
 class FunctionInvoker {
 public:
-    static auto apply(F const& function, TaskContext& context, ArgsBuffer const& args_buffer)
-            -> ResultBuffer {
+    static auto
+    apply(F const& function, TaskContext& context, ArgsBuffer const& args_buffer) -> ResultBuffer {
         // NOLINTBEGIN(cppcoreguidelines-pro-type-union-access,cppcoreguidelines-pro-bounds-pointer-arithmetic)
         using ArgsTuple = signature<F>::args_t;
         using ReturnType = signature<F>::ret_t;

--- a/src/spider/worker/WorkerClient.cpp
+++ b/src/spider/worker/WorkerClient.cpp
@@ -30,14 +30,12 @@ WorkerClient::WorkerClient(
         boost::uuids::uuid const worker_id,
         std::string worker_addr,
         std::shared_ptr<core::DataStorage> data_store,
-        std::shared_ptr<core::MetadataStorage> metadata_store,
-        std::string const& storage_url
+        std::shared_ptr<core::MetadataStorage> metadata_store
 )
         : m_worker_id{worker_id},
           m_worker_addr{std::move(worker_addr)},
           m_data_store(std::move(data_store)),
-          m_metadata_store(std::move(metadata_store)),
-          m_storage_url{storage_url} {}
+          m_metadata_store(std::move(metadata_store)) {}
 
 auto WorkerClient::get_next_task(std::optional<boost::uuids::uuid> const& fail_task_id
 ) -> std::optional<std::tuple<boost::uuids::uuid, boost::uuids::uuid>> {
@@ -45,7 +43,7 @@ auto WorkerClient::get_next_task(std::optional<boost::uuids::uuid> const& fail_t
     std::vector<core::Scheduler> schedulers;
 
     std::variant<spider::core::MySqlConnection, spider::core::StorageErr> conn_result
-            = spider::core::MySqlConnection::create(m_storage_url);
+            = spider::core::MySqlConnection::create(m_metadata_store->get_url());
     if (std::holds_alternative<spider::core::StorageErr>(conn_result)) {
         spdlog::error(
                 "Failed to connection to storage: {}",

--- a/src/spider/worker/WorkerClient.hpp
+++ b/src/spider/worker/WorkerClient.hpp
@@ -26,7 +26,8 @@ public:
             boost::uuids::uuid worker_id,
             std::string worker_addr,
             std::shared_ptr<core::DataStorage> data_store,
-            std::shared_ptr<core::MetadataStorage> metadata_store
+            std::shared_ptr<core::MetadataStorage> metadata_store,
+            std::string const& storage_url
     );
 
     auto get_next_task(std::optional<boost::uuids::uuid> const& fail_task_id
@@ -38,6 +39,8 @@ private:
 
     std::shared_ptr<core::DataStorage> m_data_store;
     std::shared_ptr<core::MetadataStorage> m_metadata_store;
+
+    std::string m_storage_url;
 };
 }  // namespace spider::worker
 #endif  // SPIDER_WORKER_WORKERCLIENT_HPP

--- a/src/spider/worker/WorkerClient.hpp
+++ b/src/spider/worker/WorkerClient.hpp
@@ -26,8 +26,7 @@ public:
             boost::uuids::uuid worker_id,
             std::string worker_addr,
             std::shared_ptr<core::DataStorage> data_store,
-            std::shared_ptr<core::MetadataStorage> metadata_store,
-            std::string const& storage_url
+            std::shared_ptr<core::MetadataStorage> metadata_store
     );
 
     auto get_next_task(std::optional<boost::uuids::uuid> const& fail_task_id
@@ -39,8 +38,6 @@ private:
 
     std::shared_ptr<core::DataStorage> m_data_store;
     std::shared_ptr<core::MetadataStorage> m_metadata_store;
-
-    std::string m_storage_url;
 };
 }  // namespace spider::worker
 #endif  // SPIDER_WORKER_WORKERCLIENT_HPP

--- a/src/spider/worker/worker.cpp
+++ b/src/spider/worker/worker.cpp
@@ -229,8 +229,8 @@ auto task_loop(
         spider::core::StopToken const& stop_token
 ) -> void {
     std::optional<boost::uuids::uuid> fail_task_id = std::nullopt;
-    boost::asio::io_context context;
     while (!stop_token.stop_requested()) {
+        boost::asio::io_context context;
         std::variant<spider::core::MySqlConnection, spider::core::StorageErr> conn_result
                 = spider::core::MySqlConnection::create(metadata_store->get_url());
         if (std::holds_alternative<spider::core::StorageErr>(conn_result)) {

--- a/tests/scheduler/test-SchedulerServer.cpp
+++ b/tests/scheduler/test-SchedulerServer.cpp
@@ -45,13 +45,18 @@ TEMPLATE_LIST_TEST_CASE(
             = std::move(std::get<0>(storages));
     std::shared_ptr<spider::core::DataStorage> const data_store = std::move(std::get<1>(storages));
 
+    std::variant<spider::core::MySqlConnection, spider::core::StorageErr> conn_result
+            = spider::core::MySqlConnection::create(metadata_store->get_url());
+    REQUIRE(std::holds_alternative<spider::core::MySqlConnection>(conn_result));
+    spider::core::MySqlConnection& conn = std::get<spider::core::MySqlConnection>(conn_result);
+
     std::shared_ptr<spider::scheduler::SchedulerPolicy> const policy
-            = std::make_shared<spider::scheduler::FifoPolicy>(metadata_store, data_store);
+            = std::make_shared<spider::scheduler::FifoPolicy>(metadata_store, data_store, conn);
 
     constexpr unsigned short cPort = 6021;
     spider::core::StopToken stop_token;
     spider::scheduler::SchedulerServer
-            server{cPort, policy, metadata_store, data_store, stop_token};
+            server{cPort, policy, metadata_store, data_store, conn, stop_token};
 
     // Pause and resume server
     server.pause();
@@ -76,7 +81,7 @@ TEMPLATE_LIST_TEST_CASE(
     graph.add_output_task(child_task.get_id());
     boost::uuids::random_generator gen;
     boost::uuids::uuid const job_id = gen();
-    REQUIRE(metadata_store->add_job(job_id, gen(), graph).success());
+    REQUIRE(metadata_store->add_job(conn, job_id, gen(), graph).success());
 
     // Schedule request should succeed
     spider::scheduler::ScheduleTaskRequest const req{gen(), ""};
@@ -91,7 +96,7 @@ TEMPLATE_LIST_TEST_CASE(
 
     // Get response should succeed and get child task
     std::optional<msgpack::sbuffer> const& res_buffer = spider::core::receive_message(socket);
-    REQUIRE(metadata_store->remove_job(job_id).success());
+    REQUIRE(metadata_store->remove_job(conn, job_id).success());
     REQUIRE(res_buffer.has_value());
     if (res_buffer.has_value()) {
         msgpack::object_handle const handle

--- a/tests/storage/test-DataStorage.cpp
+++ b/tests/storage/test-DataStorage.cpp
@@ -21,29 +21,34 @@ TEMPLATE_LIST_TEST_CASE("Add, get and remove data", "[storage]", spider::test::S
     auto [metadata_storage, data_storage] = spider::test::
             create_storage<std::tuple_element_t<0, TestType>, std::tuple_element_t<1, TestType>>();
 
+    std::variant<spider::core::MySqlConnection, spider::core::StorageErr> conn_result
+            = spider::core::MySqlConnection::create(metadata_storage->get_url());
+    REQUIRE(std::holds_alternative<spider::core::MySqlConnection>(conn_result));
+    spider::core::MySqlConnection& conn = std::get<spider::core::MySqlConnection>(conn_result);
+
     // Add driver and data
     spider::core::Data const data{"value"};
     boost::uuids::random_generator gen;
     boost::uuids::uuid const driver_id = gen();
-    REQUIRE(metadata_storage->add_driver(spider::core::Driver{driver_id}).success());
-    REQUIRE(data_storage->add_driver_data(driver_id, data).success());
+    REQUIRE(metadata_storage->add_driver(conn, spider::core::Driver{driver_id}).success());
+    REQUIRE(data_storage->add_driver_data(conn, driver_id, data).success());
 
     // Add data with same id again should fail
     spider::core::Data const data_same_id{data.get_id(), "value2"};
     REQUIRE(spider::core::StorageErrType::DuplicateKeyErr
-            == data_storage->add_driver_data(driver_id, data_same_id).type);
+            == data_storage->add_driver_data(conn, driver_id, data_same_id).type);
 
     // Get data should match
     spider::core::Data result{"temp"};
-    REQUIRE(data_storage->get_data(data.get_id(), &result).success());
+    REQUIRE(data_storage->get_data(conn, data.get_id(), &result).success());
     REQUIRE(spider::test::data_equal(data, result));
 
     // Remove data should succeed
-    REQUIRE(data_storage->remove_data(data.get_id()).success());
+    REQUIRE(data_storage->remove_data(conn, data.get_id()).success());
 
     // Get data should fail
     REQUIRE(spider::core::StorageErrType::KeyNotFoundErr
-            == data_storage->get_data(data.get_id(), &result).type);
+            == data_storage->get_data(conn, data.get_id(), &result).type);
 }
 
 TEMPLATE_LIST_TEST_CASE(
@@ -54,24 +59,29 @@ TEMPLATE_LIST_TEST_CASE(
     auto [metadata_storage, data_storage] = spider::test::
             create_storage<std::tuple_element_t<0, TestType>, std::tuple_element_t<1, TestType>>();
 
+    std::variant<spider::core::MySqlConnection, spider::core::StorageErr> conn_result
+            = spider::core::MySqlConnection::create(metadata_storage->get_url());
+    REQUIRE(std::holds_alternative<spider::core::MySqlConnection>(conn_result));
+    spider::core::MySqlConnection& conn = std::get<spider::core::MySqlConnection>(conn_result);
+
     // Add driver
     boost::uuids::random_generator gen;
     boost::uuids::uuid const driver_id = gen();
-    REQUIRE(metadata_storage->add_driver(spider::core::Driver{driver_id}).success());
+    REQUIRE(metadata_storage->add_driver(conn, spider::core::Driver{driver_id}).success());
 
     // Add data
     spider::core::KeyValueData const data{"key", "value", driver_id};
-    REQUIRE(data_storage->add_client_kv_data(data).success());
+    REQUIRE(data_storage->add_client_kv_data(conn, data).success());
 
     // Add data with same key and id again should fail
     spider::core::KeyValueData const data_same_key{"key", "value2", driver_id};
     REQUIRE(spider::core::StorageErrType::DuplicateKeyErr
-            == data_storage->add_client_kv_data(data_same_key).type);
+            == data_storage->add_client_kv_data(conn, data_same_key).type);
 
     // Get data should match
     std::string value;
-    auto err = data_storage->get_client_kv_data(driver_id, "key", &value);
-    REQUIRE(data_storage->get_client_kv_data(driver_id, "key", &value).success());
+    auto err = data_storage->get_client_kv_data(conn, driver_id, "key", &value);
+    REQUIRE(data_storage->get_client_kv_data(conn, driver_id, "key", &value).success());
     REQUIRE(data.get_value() == value);
 }
 
@@ -83,6 +93,11 @@ TEMPLATE_LIST_TEST_CASE(
     auto [metadata_storage, data_storage] = spider::test::
             create_storage<std::tuple_element_t<0, TestType>, std::tuple_element_t<1, TestType>>();
 
+    std::variant<spider::core::MySqlConnection, spider::core::StorageErr> conn_result
+            = spider::core::MySqlConnection::create(metadata_storage->get_url());
+    REQUIRE(std::holds_alternative<spider::core::MySqlConnection>(conn_result));
+    spider::core::MySqlConnection& conn = std::get<spider::core::MySqlConnection>(conn_result);
+
     // Add task
     boost::uuids::random_generator gen;
     spider::core::Task const task{"func"};
@@ -91,24 +106,24 @@ TEMPLATE_LIST_TEST_CASE(
     graph.add_input_task(task.get_id());
     graph.add_output_task(task.get_id());
     boost::uuids::uuid const job_id = gen();
-    REQUIRE(metadata_storage->add_job(job_id, gen(), graph).success());
+    REQUIRE(metadata_storage->add_job(conn, job_id, gen(), graph).success());
 
     // Add data
     spider::core::KeyValueData const data{"key", "value", task.get_id()};
-    REQUIRE(data_storage->add_task_kv_data(data).success());
+    REQUIRE(data_storage->add_task_kv_data(conn, data).success());
 
     // Add data with same key and id again should fail
     spider::core::KeyValueData const data_same_key{"key", "value2", task.get_id()};
     REQUIRE(spider::core::StorageErrType::DuplicateKeyErr
-            == data_storage->add_task_kv_data(data_same_key).type);
+            == data_storage->add_task_kv_data(conn, data_same_key).type);
 
     // Get data should match
     std::string value;
-    REQUIRE(data_storage->get_task_kv_data(task.get_id(), "key", &value).success());
+    REQUIRE(data_storage->get_task_kv_data(conn, task.get_id(), "key", &value).success());
     REQUIRE(data.get_value() == value);
 
     // Clean up
-    REQUIRE(metadata_storage->remove_job(job_id).success());
+    REQUIRE(metadata_storage->remove_job(conn, job_id).success());
 }
 
 TEMPLATE_LIST_TEST_CASE(
@@ -119,9 +134,14 @@ TEMPLATE_LIST_TEST_CASE(
     auto [metadata_storage, data_storage] = spider::test::
             create_storage<std::tuple_element_t<0, TestType>, std::tuple_element_t<1, TestType>>();
 
+    std::variant<spider::core::MySqlConnection, spider::core::StorageErr> conn_result
+            = spider::core::MySqlConnection::create(metadata_storage->get_url());
+    REQUIRE(std::holds_alternative<spider::core::MySqlConnection>(conn_result));
+    spider::core::MySqlConnection& conn = std::get<spider::core::MySqlConnection>(conn_result);
+
     boost::uuids::random_generator gen;
     // Add task reference without data and task should fail.
-    REQUIRE(!data_storage->add_task_reference(gen(), gen()).success());
+    REQUIRE(!data_storage->add_task_reference(conn, gen(), gen()).success());
 
     // Add task
     spider::core::Task const task{"func"};
@@ -133,31 +153,31 @@ TEMPLATE_LIST_TEST_CASE(
     graph.add_input_task(task.get_id());
     graph.add_output_task(task_2.get_id());
     boost::uuids::uuid const job_id = gen();
-    REQUIRE(metadata_storage->add_job(job_id, gen(), graph).success());
+    REQUIRE(metadata_storage->add_job(conn, job_id, gen(), graph).success());
 
     // Add task reference without data should fail.
-    REQUIRE(!data_storage->add_task_reference(gen(), task.get_id()).success());
+    REQUIRE(!data_storage->add_task_reference(conn, gen(), task.get_id()).success());
 
     // Add data
     spider::core::Data const data{"value"};
-    REQUIRE(data_storage->add_task_data(task.get_id(), data).success());
+    REQUIRE(data_storage->add_task_data(conn, task.get_id(), data).success());
 
     // Add task reference
-    REQUIRE(data_storage->add_task_reference(data.get_id(), task_2.get_id()).success());
+    REQUIRE(data_storage->add_task_reference(conn, data.get_id(), task_2.get_id()).success());
 
     // Remove task reference
-    REQUIRE(data_storage->remove_task_reference(data.get_id(), task_2.get_id()).success());
+    REQUIRE(data_storage->remove_task_reference(conn, data.get_id(), task_2.get_id()).success());
 
     // Remove job
-    REQUIRE(metadata_storage->remove_job(job_id).success());
+    REQUIRE(metadata_storage->remove_job(conn, job_id).success());
 
     // Clean up
-    REQUIRE(data_storage->remove_dangling_data().success());
+    REQUIRE(data_storage->remove_dangling_data(conn).success());
 
     // Get data should fail
     spider::core::Data res{"temp"};
     REQUIRE(spider::core::StorageErrType::KeyNotFoundErr
-            == data_storage->get_data(data.get_id(), &res).type);
+            == data_storage->get_data(conn, data.get_id(), &res).type);
 }
 
 TEMPLATE_LIST_TEST_CASE(
@@ -168,29 +188,34 @@ TEMPLATE_LIST_TEST_CASE(
     auto [metadata_storage, data_storage] = spider::test::
             create_storage<std::tuple_element_t<0, TestType>, std::tuple_element_t<1, TestType>>();
 
+    std::variant<spider::core::MySqlConnection, spider::core::StorageErr> conn_result
+            = spider::core::MySqlConnection::create(metadata_storage->get_url());
+    REQUIRE(std::holds_alternative<spider::core::MySqlConnection>(conn_result));
+    spider::core::MySqlConnection& conn = std::get<spider::core::MySqlConnection>(conn_result);
+
     boost::uuids::random_generator gen;
 
     // Add driver reference without data and driver should fail
-    REQUIRE(!data_storage->add_driver_reference(gen(), gen()).success());
+    REQUIRE(!data_storage->add_driver_reference(conn, gen(), gen()).success());
 
     // Add driver
     boost::uuids::uuid const driver_id = gen();
     boost::uuids::uuid const driver_id_2 = gen();
-    REQUIRE(metadata_storage->add_driver(spider::core::Driver{driver_id}).success());
-    REQUIRE(metadata_storage->add_driver(spider::core::Driver{driver_id_2}).success());
+    REQUIRE(metadata_storage->add_driver(conn, spider::core::Driver{driver_id}).success());
+    REQUIRE(metadata_storage->add_driver(conn, spider::core::Driver{driver_id_2}).success());
 
     // Add driver reference without data should fail
-    REQUIRE(!data_storage->add_driver_reference(gen(), driver_id).success());
+    REQUIRE(!data_storage->add_driver_reference(conn, gen(), driver_id).success());
 
     // Add data
     spider::core::Data const data{"value"};
-    REQUIRE(data_storage->add_driver_data(driver_id, data).success());
+    REQUIRE(data_storage->add_driver_data(conn, driver_id, data).success());
 
     // Add driver reference
-    REQUIRE(data_storage->add_driver_reference(data.get_id(), driver_id_2).success());
+    REQUIRE(data_storage->add_driver_reference(conn, data.get_id(), driver_id_2).success());
 
     // Remove driver reference
-    REQUIRE(data_storage->remove_driver_reference(data.get_id(), driver_id_2).success());
+    REQUIRE(data_storage->remove_driver_reference(conn, data.get_id(), driver_id_2).success());
 }
 }  // namespace
 

--- a/tests/worker/test-FunctionManager.cpp
+++ b/tests/worker/test-FunctionManager.cpp
@@ -148,14 +148,19 @@ TEMPLATE_LIST_TEST_CASE(
             = std::move(unique_metadata_storage);
     std::shared_ptr<spider::core::DataStorage> const data_storage = std::move(unique_data_storage);
 
+    std::variant<spider::core::MySqlConnection, spider::core::StorageErr> conn_result
+            = spider::core::MySqlConnection::create(metadata_storage->get_url());
+    REQUIRE(std::holds_alternative<spider::core::MySqlConnection>(conn_result));
+    spider::core::MySqlConnection& conn = std::get<spider::core::MySqlConnection>(conn_result);
+
     msgpack::sbuffer buffer;
     msgpack::pack(buffer, 3);
     spider::core::Data const data{std::string{buffer.data(), buffer.size()}};
     boost::uuids::random_generator gen;
     boost::uuids::uuid const driver_id = gen();
     spider::core::Driver const driver{driver_id};
-    REQUIRE(metadata_storage->add_driver(driver).success());
-    REQUIRE(data_storage->add_driver_data(driver_id, data).success());
+    REQUIRE(metadata_storage->add_driver(conn, driver).success());
+    REQUIRE(data_storage->add_driver_data(conn, driver_id, data).success());
 
     spider::TaskContext context = spider::core::TaskContextImpl::create_task_context(
             gen(),
@@ -171,7 +176,7 @@ TEMPLATE_LIST_TEST_CASE(
     msgpack::sbuffer const result = (*function)(context, args_buffers);
     REQUIRE(3 == spider::core::response_get_result<int>(result).value_or(0));
 
-    REQUIRE(data_storage->remove_data(data.get_id()).success());
+    REQUIRE(data_storage->remove_data(conn, data.get_id()).success());
 }
 }  // namespace
 


### PR DESCRIPTION
# Description

Previously, all components create new storage connections on need to save database connection resource, as stated in #57. However, this induce significant overhead, especially in scheduler, which is performance critical and execute storage queries frequently.

This pr adds storage connection explicitly in the storage interface and leaves it to the user of the storage interface to decide whether to keep a connection open or create a new one on need. Scheduler takes the first approach, while other components remain using the later.


# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* [ ] GitHub workflows pass
* [x] Unit tests pass in dev container
* [x] Integration tests pass in dev container



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
