### PR TITLE
feat: Add batch job submission

### DIFF
--- a/src/spider/CMakeLists.txt
+++ b/src/spider/CMakeLists.txt
@@ -1,7 +1,7 @@
 # set variable as CACHE INTERNAL to access it from other scope
 set(SPIDER_CORE_SOURCES
-    storage/MySqlConnection.cpp
-    storage/MySqlStorage.cpp
+        storage/mysql/MySqlConnection.cpp
+        storage/mysql/MySqlStorage.cpp
     worker/FunctionManager.cpp
     worker/FunctionNameManager.cpp
     io/msgpack_message.cpp
@@ -25,8 +25,9 @@ set(SPIDER_CORE_HEADERS
     storage/MetadataStorage.hpp
     storage/DataStorage.hpp
     storage/StorageConnection.hpp
-    storage/MySqlConnection.hpp
-    storage/MySqlStorage.hpp
+        storage/mysql/MySqlConnection.hpp
+        storage/mysql/MySqlStorage.hpp
+    storage/JobSubmissionBatch.hpp
     worker/FunctionManager.hpp
     worker/FunctionNameManager.hpp
     CACHE INTERNAL

--- a/src/spider/CMakeLists.txt
+++ b/src/spider/CMakeLists.txt
@@ -1,7 +1,7 @@
 # set variable as CACHE INTERNAL to access it from other scope
 set(SPIDER_CORE_SOURCES
-        storage/mysql/MySqlConnection.cpp
-        storage/mysql/MySqlStorage.cpp
+    storage/mysql/MySqlConnection.cpp
+    storage/mysql/MySqlStorage.cpp
     worker/FunctionManager.cpp
     worker/FunctionNameManager.cpp
     io/msgpack_message.cpp
@@ -25,8 +25,10 @@ set(SPIDER_CORE_HEADERS
     storage/MetadataStorage.hpp
     storage/DataStorage.hpp
     storage/StorageConnection.hpp
-        storage/mysql/MySqlConnection.hpp
-        storage/mysql/MySqlStorage.hpp
+    storage/mysql/mysql_stmt.hpp
+    storage/mysql/MySqlConnection.hpp
+    storage/mysql/MySqlStorage.hpp
+    storage/mysql/MySqlJobSubmissionBatch.hpp
     storage/JobSubmissionBatch.hpp
     worker/FunctionManager.hpp
     worker/FunctionNameManager.hpp

--- a/src/spider/client/Data.hpp
+++ b/src/spider/client/Data.hpp
@@ -15,7 +15,7 @@
 #include "../io/MsgPack.hpp"  // IWYU pragma: keep
 #include "../io/Serializer.hpp"
 #include "../storage/DataStorage.hpp"
-#include "../storage/MySqlConnection.hpp"
+#include "../storage/mysql/MySqlConnection.hpp"
 #include "Exception.hpp"
 
 namespace spider {

--- a/src/spider/client/Driver.cpp
+++ b/src/spider/client/Driver.cpp
@@ -17,6 +17,7 @@
 #include "../io/BoostAsio.hpp"  // IWYU pragma: keep
 #include "../storage/mysql/MySqlConnection.hpp"
 #include "../storage/mysql/MySqlStorage.hpp"
+#include "../storage/StorageConnection.hpp"
 #include "Exception.hpp"
 
 namespace spider {
@@ -33,9 +34,10 @@ Driver::Driver(std::string const& storage_url) {
     if (std::holds_alternative<core::StorageErr>(conn_result)) {
         throw ConnectionException(std::get<core::StorageErr>(conn_result).description);
     }
-    auto& conn = std::get<core::MySqlConnection>(conn_result);
+    m_conn = std::make_shared<core::StorageConnection>(std::get<core::MySqlConnection>(conn_result)
+    );
 
-    core::StorageErr const err = m_metadata_storage->add_driver(conn, core::Driver{m_id});
+    core::StorageErr const err = m_metadata_storage->add_driver(*m_conn, core::Driver{m_id});
     if (!err.success()) {
         if (core::StorageErrType::DuplicateKeyErr == err.type) {
             throw DriverIdInUseException(m_id);
@@ -71,9 +73,10 @@ Driver::Driver(std::string const& storage_url, boost::uuids::uuid const id) : m_
     if (std::holds_alternative<core::StorageErr>(conn_result)) {
         throw ConnectionException(std::get<core::StorageErr>(conn_result).description);
     }
-    auto& conn = std::get<core::MySqlConnection>(conn_result);
+    m_conn = std::make_shared<core::StorageConnection>(std::get<core::MySqlConnection>(conn_result)
+    );
 
-    core::StorageErr const err = m_metadata_storage->add_driver(conn, core::Driver{m_id});
+    core::StorageErr const err = m_metadata_storage->add_driver(*m_conn, core::Driver{m_id});
     if (!err.success()) {
         if (core::StorageErrType::DuplicateKeyErr == err.type) {
             throw DriverIdInUseException(m_id);
@@ -104,29 +107,15 @@ Driver::Driver(std::string const& storage_url, boost::uuids::uuid const id) : m_
 auto Driver::kv_store_insert(std::string const& key, std::string const& value) -> void {
     core::KeyValueData const kv_data{key, value, m_id};
 
-    std::variant<core::MySqlConnection, core::StorageErr> conn_result
-            = core::MySqlConnection::create(m_data_storage->get_url());
-    if (std::holds_alternative<core::StorageErr>(conn_result)) {
-        throw ConnectionException(std::get<core::StorageErr>(conn_result).description);
-    }
-    auto& conn = std::get<core::MySqlConnection>(conn_result);
-
-    core::StorageErr const err = m_data_storage->add_client_kv_data(conn, kv_data);
+    core::StorageErr const err = m_data_storage->add_client_kv_data(*m_conn, kv_data);
     if (!err.success()) {
         throw ConnectionException(err.description);
     }
 }
 
 auto Driver::kv_store_get(std::string const& key) -> std::optional<std::string> {
-    std::variant<core::MySqlConnection, core::StorageErr> conn_result
-            = core::MySqlConnection::create(m_data_storage->get_url());
-    if (std::holds_alternative<core::StorageErr>(conn_result)) {
-        throw ConnectionException(std::get<core::StorageErr>(conn_result).description);
-    }
-    auto& conn = std::get<core::MySqlConnection>(conn_result);
-
     std::string value;
-    core::StorageErr const err = m_data_storage->get_client_kv_data(conn, m_id, key, &value);
+    core::StorageErr const err = m_data_storage->get_client_kv_data(*m_conn, m_id, key, &value);
     if (!err.success()) {
         if (core::StorageErrType::KeyNotFoundErr == err.type) {
             return std::nullopt;

--- a/src/spider/client/Driver.cpp
+++ b/src/spider/client/Driver.cpp
@@ -6,6 +6,7 @@
 #include <stop_token>
 #include <string>
 #include <thread>
+#include <utility>
 #include <variant>
 
 #include <boost/uuid/random_generator.hpp>
@@ -17,7 +18,6 @@
 #include "../io/BoostAsio.hpp"  // IWYU pragma: keep
 #include "../storage/mysql/MySqlConnection.hpp"
 #include "../storage/mysql/MySqlStorage.hpp"
-#include "../storage/StorageConnection.hpp"
 #include "Exception.hpp"
 
 namespace spider {

--- a/src/spider/client/Driver.cpp
+++ b/src/spider/client/Driver.cpp
@@ -15,8 +15,8 @@
 #include "../core/Error.hpp"
 #include "../core/KeyValueData.hpp"
 #include "../io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "../storage/MySqlConnection.hpp"
-#include "../storage/MySqlStorage.hpp"
+#include "../storage/mysql/MySqlConnection.hpp"
+#include "../storage/mysql/MySqlStorage.hpp"
 #include "Exception.hpp"
 
 namespace spider {

--- a/src/spider/client/Driver.cpp
+++ b/src/spider/client/Driver.cpp
@@ -34,7 +34,8 @@ Driver::Driver(std::string const& storage_url) {
     if (std::holds_alternative<core::StorageErr>(conn_result)) {
         throw ConnectionException(std::get<core::StorageErr>(conn_result).description);
     }
-    m_conn = std::make_shared<core::StorageConnection>(std::get<core::MySqlConnection>(conn_result)
+    m_conn = std::make_shared<core::MySqlConnection>(
+            std::get<core::MySqlConnection>(std::move(conn_result))
     );
 
     core::StorageErr const err = m_metadata_storage->add_driver(*m_conn, core::Driver{m_id});
@@ -73,7 +74,8 @@ Driver::Driver(std::string const& storage_url, boost::uuids::uuid const id) : m_
     if (std::holds_alternative<core::StorageErr>(conn_result)) {
         throw ConnectionException(std::get<core::StorageErr>(conn_result).description);
     }
-    m_conn = std::make_shared<core::StorageConnection>(std::get<core::MySqlConnection>(conn_result)
+    m_conn = std::make_shared<core::MySqlConnection>(
+            std::get<core::MySqlConnection>(std::move(conn_result))
     );
 
     core::StorageErr const err = m_metadata_storage->add_driver(*m_conn, core::Driver{m_id});

--- a/src/spider/client/Driver.hpp
+++ b/src/spider/client/Driver.hpp
@@ -225,7 +225,7 @@ public:
             }
         }
 
-        return Job<ReturnType>{job_id, m_metadata_storage, m_data_storage};
+        return Job<ReturnType>{job_id, m_metadata_storage, m_data_storage, m_conn};
     }
 
     /**
@@ -269,7 +269,7 @@ public:
             throw ConnectionException(fmt::format("Failed to start job: {}", err.description));
         }
 
-        return Job<ReturnType>{job_id, m_metadata_storage, m_data_storage};
+        return Job<ReturnType>{job_id, m_metadata_storage, m_data_storage, m_conn};
     }
 
     /**

--- a/src/spider/client/Driver.hpp
+++ b/src/spider/client/Driver.hpp
@@ -8,7 +8,6 @@
 #include <thread>
 #include <tuple>
 #include <type_traits>
-#include <variant>
 #include <vector>
 
 #include <boost/uuid/random_generator.hpp>
@@ -148,8 +147,8 @@ public:
         if (nullptr != m_batch) {
             return;
         }
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
         m_batch = std::make_shared<core::MySqlJobSubmissionBatch>(
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
                 static_cast<core::MySqlConnection&>(*m_conn)
         );
     }

--- a/src/spider/client/Driver.hpp
+++ b/src/spider/client/Driver.hpp
@@ -18,7 +18,7 @@
 #include "../core/Error.hpp"
 #include "../core/TaskGraphImpl.hpp"
 #include "../io/Serializer.hpp"
-#include "../storage/MySqlConnection.hpp"
+#include "../storage/mysql/MySqlConnection.hpp"
 #include "../worker/FunctionManager.hpp"
 #include "../worker/FunctionNameManager.hpp"
 #include "Data.hpp"

--- a/src/spider/client/Job.hpp
+++ b/src/spider/client/Job.hpp
@@ -21,7 +21,7 @@
 #include "../core/JobMetadata.hpp"
 #include "../io/MsgPack.hpp"  // IWYU pragma: keep
 #include "../storage/MetadataStorage.hpp"
-#include "../storage/MySqlConnection.hpp"
+#include "../storage/mysql/MySqlConnection.hpp"
 #include "Data.hpp"
 #include "Exception.hpp"
 #include "task.hpp"

--- a/src/spider/client/Job.hpp
+++ b/src/spider/client/Job.hpp
@@ -72,8 +72,9 @@ public:
             }
             auto& conn = std::get<core::MySqlConnection>(conn_result);
             wait_complete_conn(conn);
+        } else {
+            wait_complete_conn(*m_conn);
         }
-        wait_complete_conn(*m_conn);
     }
 
     /**

--- a/src/spider/client/TaskContext.cpp
+++ b/src/spider/client/TaskContext.cpp
@@ -9,7 +9,7 @@
 
 #include "../core/Error.hpp"
 #include "../core/KeyValueData.hpp"
-#include "../storage/MySqlConnection.hpp"
+#include "../storage/mysql/MySqlConnection.hpp"
 #include "Exception.hpp"
 
 namespace spider {

--- a/src/spider/client/TaskContext.hpp
+++ b/src/spider/client/TaskContext.hpp
@@ -19,7 +19,7 @@
 #include "../core/TaskGraph.hpp"
 #include "../core/TaskGraphImpl.hpp"
 #include "../io/Serializer.hpp"
-#include "../storage/MySqlConnection.hpp"
+#include "../storage/mysql/MySqlConnection.hpp"
 #include "Data.hpp"
 #include "Exception.hpp"
 #include "Job.hpp"

--- a/src/spider/scheduler/scheduler.cpp
+++ b/src/spider/scheduler/scheduler.cpp
@@ -24,8 +24,8 @@
 #include "../io/BoostAsio.hpp"  // IWYU pragma: keep
 #include "../storage/DataStorage.hpp"
 #include "../storage/MetadataStorage.hpp"
-#include "../storage/MySqlConnection.hpp"
-#include "../storage/MySqlStorage.hpp"
+#include "../storage/mysql/MySqlConnection.hpp"
+#include "../storage/mysql/MySqlStorage.hpp"
 #include "../utils/StopToken.hpp"
 #include "FifoPolicy.hpp"
 #include "SchedulerPolicy.hpp"

--- a/src/spider/storage/JobSubmissionBatch.hpp
+++ b/src/spider/storage/JobSubmissionBatch.hpp
@@ -1,8 +1,15 @@
 #ifndef SPIDER_STORAGE_JOBSUBMISSIONBATCH_HPP
 #define SPIDER_STORAGE_JOBSUBMISSIONBATCH_HPP
 
+#include "../../core/Error.hpp"
+#include "../StorageConnection.hpp"
+
 namespace spider::core {
-class JobSubmissionBatch {};
+class JobSubmissionBatch {
+public:
+    virtual ~JobSubmissionBatch() = 0;
+    virtual auto submit_batch(StorageConnection& conn) -> StorageErr = 0;
+};
 }  // namespace spider::core
 
 #endif

--- a/src/spider/storage/JobSubmissionBatch.hpp
+++ b/src/spider/storage/JobSubmissionBatch.hpp
@@ -1,13 +1,12 @@
 #ifndef SPIDER_STORAGE_JOBSUBMISSIONBATCH_HPP
 #define SPIDER_STORAGE_JOBSUBMISSIONBATCH_HPP
 
-#include "../../core/Error.hpp"
-#include "../StorageConnection.hpp"
+#include "../core/Error.hpp"
+#include "StorageConnection.hpp"
 
 namespace spider::core {
 class JobSubmissionBatch {
 public:
-    virtual ~JobSubmissionBatch() = 0;
     virtual auto submit_batch(StorageConnection& conn) -> StorageErr = 0;
 };
 }  // namespace spider::core

--- a/src/spider/storage/JobSubmissionBatch.hpp
+++ b/src/spider/storage/JobSubmissionBatch.hpp
@@ -8,6 +8,13 @@ namespace spider::core {
 class JobSubmissionBatch {
 public:
     virtual auto submit_batch(StorageConnection& conn) -> StorageErr = 0;
+
+    JobSubmissionBatch() = default;
+    JobSubmissionBatch(JobSubmissionBatch const&) = delete;
+    auto operator=(JobSubmissionBatch const&) -> JobSubmissionBatch& = delete;
+    JobSubmissionBatch(JobSubmissionBatch&&) = delete;
+    auto operator=(JobSubmissionBatch&&) -> JobSubmissionBatch& = delete;
+    virtual ~JobSubmissionBatch() = default;
 };
 }  // namespace spider::core
 

--- a/src/spider/storage/JobSubmissionBatch.hpp
+++ b/src/spider/storage/JobSubmissionBatch.hpp
@@ -1,0 +1,8 @@
+#ifndef SPIDER_STORAGE_JOBSUBMISSIONBATCH_HPP
+#define SPIDER_STORAGE_JOBSUBMISSIONBATCH_HPP
+
+namespace spider::core {
+class JobSubmissionBatch {};
+}  // namespace spider::core
+
+#endif

--- a/src/spider/storage/MetadataStorage.hpp
+++ b/src/spider/storage/MetadataStorage.hpp
@@ -12,6 +12,7 @@
 #include "../core/JobMetadata.hpp"
 #include "../core/Task.hpp"
 #include "../core/TaskGraph.hpp"
+#include "JobSubmissionBatch.hpp"
 #include "StorageConnection.hpp"
 
 namespace spider::core {
@@ -34,6 +35,13 @@ public:
 
     virtual auto add_job(
             StorageConnection& conn,
+            boost::uuids::uuid job_id,
+            boost::uuids::uuid client_id,
+            TaskGraph const& task_graph
+    ) -> StorageErr = 0;
+    virtual auto add_job_batch(
+            StorageConnection& conn,
+            JobSubmissionBatch& batch,
             boost::uuids::uuid job_id,
             boost::uuids::uuid client_id,
             TaskGraph const& task_graph

--- a/src/spider/storage/mysql/MySqlConnection.cpp
+++ b/src/spider/storage/mysql/MySqlConnection.cpp
@@ -7,9 +7,8 @@
 #include <variant>
 
 #include <mariadb/conncpp/Connection.hpp>
-#include <mariadb/conncpp/Driver.hpp>
+#include <mariadb/conncpp/DriverManager.hpp>
 #include <mariadb/conncpp/Exception.hpp>
-#include <mariadb/conncpp/SQLString.hpp>
 #include <spdlog/spdlog.h>
 
 #include "../../core/Error.hpp"
@@ -17,25 +16,15 @@
 namespace spider::core {
 
 auto MySqlConnection::create(std::string const& url) -> std::variant<MySqlConnection, StorageErr> {
-    // Parse jdbc url
+    // Validate jdbc url
     std::regex const url_regex(R"(jdbc:mariadb://[^?]+(\?user=([^&]*)(&password=([^&]*))?)?)");
     std::smatch match;
     if (false == std::regex_match(url, match, url_regex)) {
         return StorageErr{StorageErrType::OtherErr, "Invalid url"};
     }
-    bool const credential = match[2].matched && match[4].matched;
-    std::unique_ptr<sql::Connection> conn;
     try {
-        sql::Driver* driver = sql::mariadb::get_driver_instance();
-        if (credential) {
-            conn = std::unique_ptr<sql::Connection>(
-                    driver->connect(sql::SQLString(url), match[2].str(), match[4].str())
-            );
-        } else {
-            conn = std::unique_ptr<sql::Connection>(
-                    driver->connect(sql::SQLString(url), sql::Properties{})
-            );
-        }
+        sql::Properties const properties{{{"useBulkStmts", "true"}}};
+        std::unique_ptr<sql::Connection> conn{sql::DriverManager::getConnection(url, properties)};
         conn->setAutoCommit(false);
         return MySqlConnection{std::move(conn)};
     } catch (sql::SQLException& e) {

--- a/src/spider/storage/mysql/MySqlConnection.cpp
+++ b/src/spider/storage/mysql/MySqlConnection.cpp
@@ -12,7 +12,7 @@
 #include <mariadb/conncpp/SQLString.hpp>
 #include <spdlog/spdlog.h>
 
-#include "../core/Error.hpp"
+#include "../../core/Error.hpp"
 
 namespace spider::core {
 

--- a/src/spider/storage/mysql/MySqlConnection.cpp
+++ b/src/spider/storage/mysql/MySqlConnection.cpp
@@ -9,6 +9,7 @@
 #include <mariadb/conncpp/Connection.hpp>
 #include <mariadb/conncpp/DriverManager.hpp>
 #include <mariadb/conncpp/Exception.hpp>
+#include <mariadb/conncpp/Properties.hpp>
 #include <spdlog/spdlog.h>
 
 #include "../../core/Error.hpp"

--- a/src/spider/storage/mysql/MySqlConnection.hpp
+++ b/src/spider/storage/mysql/MySqlConnection.hpp
@@ -8,8 +8,8 @@
 
 #include <mariadb/conncpp/Connection.hpp>
 
-#include "../core/Error.hpp"
-#include "StorageConnection.hpp"
+#include "../../core/Error.hpp"
+#include "../StorageConnection.hpp"
 
 namespace spider::core {
 

--- a/src/spider/storage/mysql/MySqlJobSubmissionBatch.hpp
+++ b/src/spider/storage/mysql/MySqlJobSubmissionBatch.hpp
@@ -7,6 +7,7 @@
 #include <mariadb/conncpp/Exception.hpp>
 #include <mariadb/conncpp/PreparedStatement.hpp>
 
+#include "../../core/Error.hpp"
 #include "../JobSubmissionBatch.hpp"
 #include "mysql_stmt.hpp"
 #include "MySqlConnection.hpp"

--- a/src/spider/storage/mysql/MySqlJobSubmissionBatch.hpp
+++ b/src/spider/storage/mysql/MySqlJobSubmissionBatch.hpp
@@ -9,6 +9,7 @@
 
 #include "../../core/Error.hpp"
 #include "../JobSubmissionBatch.hpp"
+#include "../StorageConnection.hpp"
 #include "mysql_stmt.hpp"
 #include "MySqlConnection.hpp"
 

--- a/src/spider/storage/mysql/MySqlJobSubmissionBatch.hpp
+++ b/src/spider/storage/mysql/MySqlJobSubmissionBatch.hpp
@@ -1,0 +1,41 @@
+#ifndef SPIDER_STORAGE_MYSQLJOBSUBMISSIONBATCH_HPP
+#define SPIDER_STORAGE_MYSQLJOBSUBMISSIONBATCH_HPP
+
+#include <memory>
+
+#include <mariadb/conncpp/PreparedStatement.hpp>
+
+#include "JobSubmissionBatch.hpp"
+
+namespace spider::core {
+class MySqlJobSubmissionBatch : public JobSubmissionBatch {
+public:
+    auto get_job_stmt() -> sql::PreparedStatement& { return *m_job_stmt; }
+
+    auto get_task_stmt() -> sql::PreparedStatement& { return *m_task_stmt; }
+
+    auto get_task_input_value_stmt() -> sql::PreparedStatement& { return *m_task_input_value_stmt; }
+
+    auto get_task_input_data_stmt() -> sql::PreparedStatement& { return *m_task_input_data_stmt; }
+
+    auto get_task_output_stmt() -> sql::PreparedStatement& { return *m_task_output_stmt; }
+
+    auto get_task_dependency_stmt() -> sql::PreparedStatement& { return *m_task_dependency_stmt; }
+
+    auto get_input_task_stmt() -> sql::PreparedStatement& { return *m_input_task_stmt; }
+
+    auto get_output_task_stmt() -> sql::PreparedStatement& { return *m_output_task_stmt; }
+
+private:
+    std::unique_ptr<sql::PreparedStatement> m_job_stmt;
+    std::unique_ptr<sql::PreparedStatement> m_task_stmt;
+    std::unique_ptr<sql::PreparedStatement> m_task_input_value_stmt;
+    std::unique_ptr<sql::PreparedStatement> m_task_input_data_stmt;
+    std::unique_ptr<sql::PreparedStatement> m_task_output_stmt;
+    std::unique_ptr<sql::PreparedStatement> m_task_dependency_stmt;
+    std::unique_ptr<sql::PreparedStatement> m_input_task_stmt;
+    std::unique_ptr<sql::PreparedStatement> m_output_task_stmt;
+};
+}  // namespace spider::core
+
+#endif

--- a/src/spider/storage/mysql/MySqlJobSubmissionBatch.hpp
+++ b/src/spider/storage/mysql/MySqlJobSubmissionBatch.hpp
@@ -5,11 +5,23 @@
 
 #include <mariadb/conncpp/PreparedStatement.hpp>
 
-#include "JobSubmissionBatch.hpp"
+#include "../JobSubmissionBatch.hpp"
+#include "mysql_stmt.hpp"
 
 namespace spider::core {
 class MySqlJobSubmissionBatch : public JobSubmissionBatch {
 public:
+    explicit MySqlJobSubmissionBatch(sql::Connection& conn)
+            : m_job_stmt{conn.prepareStatement(mysql::cInsertJob)},
+              m_task_stmt{conn.prepareStatement(mysql::cInsertTask)},
+              m_task_input_output_stmt{conn.prepareStatement(mysql::cInsertTaskInputOutput)},
+              m_task_input_value_stmt{conn.prepareStatement(mysql::cInsertTaskInputValue)},
+              m_task_input_data_stmt{conn.prepareStatement(mysql::cInsertTaskInputData)},
+              m_task_output_stmt{conn.prepareStatement(mysql::cInsertTaskOutput)},
+              m_task_dependency_stmt{conn.prepareStatement(mysql::cInsertTaskDependency)},
+              m_input_task_stmt{conn.prepareStatement(mysql::cInsertInputTask)},
+              m_output_task_stmt{conn.prepareStatement(mysql::cInsertOutputTask)} {}
+
     auto get_job_stmt() -> sql::PreparedStatement& { return *m_job_stmt; }
 
     auto get_task_stmt() -> sql::PreparedStatement& { return *m_task_stmt; }

--- a/src/spider/storage/mysql/MySqlJobSubmissionBatch.hpp
+++ b/src/spider/storage/mysql/MySqlJobSubmissionBatch.hpp
@@ -14,6 +14,10 @@ public:
 
     auto get_task_stmt() -> sql::PreparedStatement& { return *m_task_stmt; }
 
+    auto get_task_input_output_stmt() -> sql::PreparedStatement& {
+        return *m_task_input_output_stmt;
+    }
+
     auto get_task_input_value_stmt() -> sql::PreparedStatement& { return *m_task_input_value_stmt; }
 
     auto get_task_input_data_stmt() -> sql::PreparedStatement& { return *m_task_input_data_stmt; }
@@ -29,6 +33,7 @@ public:
 private:
     std::unique_ptr<sql::PreparedStatement> m_job_stmt;
     std::unique_ptr<sql::PreparedStatement> m_task_stmt;
+    std::unique_ptr<sql::PreparedStatement> m_task_input_output_stmt;
     std::unique_ptr<sql::PreparedStatement> m_task_input_value_stmt;
     std::unique_ptr<sql::PreparedStatement> m_task_input_data_stmt;
     std::unique_ptr<sql::PreparedStatement> m_task_output_stmt;

--- a/src/spider/storage/mysql/MySqlJobSubmissionBatch.hpp
+++ b/src/spider/storage/mysql/MySqlJobSubmissionBatch.hpp
@@ -3,10 +3,12 @@
 
 #include <memory>
 
+#include <mariadb/conncpp/Connection.hpp>
 #include <mariadb/conncpp/PreparedStatement.hpp>
 
 #include "../JobSubmissionBatch.hpp"
 #include "mysql_stmt.hpp"
+#include "MySqlConnection.hpp"
 
 namespace spider::core {
 class MySqlJobSubmissionBatch : public JobSubmissionBatch {

--- a/src/spider/storage/mysql/MySqlJobSubmissionBatch.hpp
+++ b/src/spider/storage/mysql/MySqlJobSubmissionBatch.hpp
@@ -22,6 +22,29 @@ public:
               m_input_task_stmt{conn.prepareStatement(mysql::cInsertInputTask)},
               m_output_task_stmt{conn.prepareStatement(mysql::cInsertOutputTask)} {}
 
+    explicit MySqlJobSubmissionBatch(MySqlConnection& conn)
+            : m_job_stmt{conn->prepareStatement(mysql::cInsertJob)},
+              m_task_stmt{conn->prepareStatement(mysql::cInsertTask)},
+              m_task_input_output_stmt{conn->prepareStatement(mysql::cInsertTaskInputOutput)},
+              m_task_input_value_stmt{conn->prepareStatement(mysql::cInsertTaskInputValue)},
+              m_task_input_data_stmt{conn->prepareStatement(mysql::cInsertTaskInputData)},
+              m_task_output_stmt{conn->prepareStatement(mysql::cInsertTaskOutput)},
+              m_task_dependency_stmt{conn->prepareStatement(mysql::cInsertTaskDependency)},
+              m_input_task_stmt{conn->prepareStatement(mysql::cInsertInputTask)},
+              m_output_task_stmt{conn->prepareStatement(mysql::cInsertOutputTask)} {}
+
+    auto submit_batch() -> void {
+        m_job_stmt->executeBatch();
+        m_task_stmt->executeBatch();
+        m_task_output_stmt->executeBatch();  // Update task outputs in case of input reference
+        m_task_input_output_stmt->executeBatch();
+        m_task_input_value_stmt->executeBatch();
+        m_task_input_data_stmt->executeBatch();
+        m_task_dependency_stmt->executeBatch();
+        m_input_task_stmt->executeBatch();
+        m_output_task_stmt->executeBatch();
+    }
+
     auto get_job_stmt() -> sql::PreparedStatement& { return *m_job_stmt; }
 
     auto get_task_stmt() -> sql::PreparedStatement& { return *m_task_stmt; }

--- a/src/spider/storage/mysql/MySqlStorage.cpp
+++ b/src/spider/storage/mysql/MySqlStorage.cpp
@@ -28,15 +28,15 @@
 #include <mariadb/conncpp/Types.hpp>
 #include <spdlog/spdlog.h>
 
-#include "../core/Data.hpp"
-#include "../core/Driver.hpp"
-#include "../core/Error.hpp"
-#include "../core/JobMetadata.hpp"
-#include "../core/KeyValueData.hpp"
-#include "../core/Task.hpp"
-#include "../core/TaskGraph.hpp"
+#include "../../core/Data.hpp"
+#include "../../core/Driver.hpp"
+#include "../../core/Error.hpp"
+#include "../../core/JobMetadata.hpp"
+#include "../../core/KeyValueData.hpp"
+#include "../../core/Task.hpp"
+#include "../../core/TaskGraph.hpp"
+#include "../StorageConnection.hpp"
 #include "MySqlConnection.hpp"
-#include "StorageConnection.hpp"
 
 // mariadb-connector-cpp does not define SQL errcode. Just include some useful ones.
 enum MariadbErr : uint16_t {
@@ -598,6 +598,16 @@ auto MySqlMetadataStorage::add_job(
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
     static_cast<MySqlConnection&>(conn)->commit();
+    return StorageErr{};
+}
+
+auto MySqlMetadataStorage::add_job_batch(
+        StorageConnection& conn,
+        JobSubmissionBatch& batch,
+        boost::uuids::uuid job_id,
+        boost::uuids::uuid client_id,
+        TaskGraph const& task_graph
+) -> StorageErr {
     return StorageErr{};
 }
 

--- a/src/spider/storage/mysql/MySqlStorage.cpp
+++ b/src/spider/storage/mysql/MySqlStorage.cpp
@@ -1,7 +1,6 @@
 #include "MySqlStorage.hpp"
 
 #include <algorithm>
-#include <array>
 #include <chrono>
 #include <cstdint>
 #include <ctime>
@@ -35,6 +34,7 @@
 #include "../../core/KeyValueData.hpp"
 #include "../../core/Task.hpp"
 #include "../../core/TaskGraph.hpp"
+#include "../JobSubmissionBatch.hpp"
 #include "../StorageConnection.hpp"
 #include "mysql_stmt.hpp"
 #include "MySqlConnection.hpp"

--- a/src/spider/storage/mysql/MySqlStorage.cpp
+++ b/src/spider/storage/mysql/MySqlStorage.cpp
@@ -376,7 +376,7 @@ auto MySqlMetadataStorage::add_job(
         {
             std::unique_ptr<sql::PreparedStatement> dep_statement{
                     static_cast<MySqlConnection&>(conn)->prepareStatement(
-                            "INSERT INTO `task_dependencies` (parent, child) VALUES (?, ?)"
+                            mysql::cInsertTaskDependency
                     )
             };
             sql::bytes parent_id_bytes = uuid_get_bytes(pair.first);

--- a/src/spider/storage/mysql/MySqlStorage.cpp
+++ b/src/spider/storage/mysql/MySqlStorage.cpp
@@ -36,6 +36,7 @@
 #include "../../core/Task.hpp"
 #include "../../core/TaskGraph.hpp"
 #include "../StorageConnection.hpp"
+#include "mysql_stmt.hpp"
 #include "MySqlConnection.hpp"
 
 // mariadb-connector-cpp does not define SQL errcode. Just include some useful ones.
@@ -52,171 +53,6 @@ enum MariadbErr : uint16_t {
 
 namespace spider::core {
 namespace {
-char const* const cCreateDriverTable = R"(CREATE TABLE IF NOT EXISTS `drivers` (
-    `id` BINARY(16) NOT NULL,
-    `heartbeat` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`)
-))";
-
-char const* const cCreateSchedulerTable = R"(CREATE TABLE IF NOT EXISTS `schedulers` (
-    `id` BINARY(16) NOT NULL,
-    `address` VARCHAR(40) NOT NULL,
-    `port` INT UNSIGNED NOT NULL,
-    `state` ENUM('normal', 'recovery', 'gc') NOT NULL,
-    CONSTRAINT `scheduler_driver_id` FOREIGN KEY (`id`) REFERENCES `drivers` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
-    PRIMARY KEY (`id`)
-))";
-
-char const* const cCreateJobTable = R"(CREATE TABLE IF NOT EXISTS jobs (
-    `id` BINARY(16) NOT NULL,
-    `client_id` BINARY(16) NOT NULL,
-    `creation_time` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    KEY (`client_id`) USING BTREE,
-    INDEX (`creation_time`),
-    PRIMARY KEY (`id`)
-))";
-
-char const* const cCreateTaskTable = R"(CREATE TABLE IF NOT EXISTS tasks (
-    `id` BINARY(16) NOT NULL,
-    `job_id` BINARY(16) NOT NULL,
-    `func_name` VARCHAR(64) NOT NULL,
-    `state` ENUM('pending', 'ready', 'running', 'success', 'cancel', 'fail') NOT NULL,
-    `timeout` FLOAT,
-    `max_retry` INT UNSIGNED DEFAULT 0,
-    `retry` INT UNSIGNED DEFAULT 0,
-    `instance_id` BINARY(16),
-    CONSTRAINT `task_job_id` FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
-    PRIMARY KEY (`id`)
-))";
-
-char const* const cCreateInputTaskTable = R"(CREATE TABLE IF NOT EXISTS input_tasks (
-    `job_id` BINARY(16) NOT NULL,
-    `task_id` BINARY(16) NOT NULL,
-    `position` INT UNSIGNED NOT NULL,
-    CONSTRAINT `input_task_job_id` FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
-    CONSTRAINT `input_task_task_id` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
-    INDEX (`job_id`, `position`),
-    PRIMARY KEY (`task_id`)
-))";
-
-char const* const cCreateOutputTaskTable = R"(CREATE TABLE IF NOT EXISTS output_tasks (
-    `job_id` BINARY(16) NOT NULL,
-    `task_id` BINARY(16) NOT NULL,
-    `position` INT UNSIGNED NOT NULL,
-    CONSTRAINT `output_task_job_id` FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
-    CONSTRAINT `output_task_task_id` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
-    INDEX (`job_id`, `position`),
-    PRIMARY KEY (`task_id`)
-))";
-
-char const* const cCreateTaskInputTable = R"(CREATE TABLE IF NOT EXISTS `task_inputs` (
-    `task_id` BINARY(16) NOT NULL,
-    `position` INT UNSIGNED NOT NULL,
-    `type` VARCHAR(64) NOT NULL,
-    `output_task_id` BINARY(16),
-    `output_task_position` INT UNSIGNED,
-    `value` VARBINARY(64), -- Use VARBINARY for all types of values
-    `data_id` BINARY(16),
-    CONSTRAINT `input_task_id` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
-    CONSTRAINT `input_task_output_match` FOREIGN KEY (`output_task_id`, `output_task_position`) REFERENCES task_outputs (`task_id`, `position`) ON UPDATE NO ACTION ON DELETE SET NULL,
-    CONSTRAINT `input_data_id` FOREIGN KEY (`data_id`) REFERENCES `data` (`id`) ON UPDATE NO ACTION ON DELETE NO ACTION,
-    PRIMARY KEY (`task_id`, `position`)
-))";
-
-char const* const cCreateTaskOutputTable = R"(CREATE TABLE IF NOT EXISTS `task_outputs` (
-    `task_id` BINARY(16) NOT NULL,
-    `position` INT UNSIGNED NOT NULL,
-    `type` VARCHAR(64) NOT NULL,
-    `value` VARBINARY(64),
-    `data_id` BINARY(16),
-    CONSTRAINT `output_task_id` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
-    CONSTRAINT `output_data_id` FOREIGN KEY (`data_id`) REFERENCES `data` (`id`) ON UPDATE NO ACTION ON DELETE NO ACTION,
-    PRIMARY KEY (`task_id`, `position`)
-))";
-
-char const* const cCreateTaskDependencyTable = R"(CREATE TABLE IF NOT EXISTS `task_dependencies` (
-    `parent` BINARY(16) NOT NULL,
-    `child` BINARY(16) NOT NULL,
-    KEY (`parent`) USING BTREE,
-    KEY (`child`) USING BTREE,
-    CONSTRAINT `task_dep_parent` FOREIGN KEY (`parent`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
-    CONSTRAINT `task_dep_child` FOREIGN KEY (`child`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
-))";
-
-char const* const cCreateTaskInstanceTable = R"(CREATE TABLE IF NOT EXISTS `task_instances` (
-    `id` BINARY(16) NOT NULL,
-    `task_id` BINARY(16) NOT NULL,
-    `start_time` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    CONSTRAINT `instance_task_id` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
-    PRIMARY KEY (`id`)
-))";
-
-char const* const cCreateDataTable = R"(CREATE TABLE IF NOT EXISTS `data` (
-    `id` BINARY(16) NOT NULL,
-    `value` VARBINARY(256) NOT NULL,
-    `hard_locality` BOOL DEFAULT FALSE,
-    `persisted` BOOL DEFAULT FALSE,
-    PRIMARY KEY (`id`)
-))";
-
-char const* const cCreateDataLocalityTable = R"(CREATE TABLE IF NOT EXISTS `data_locality` (
-    `id` BINARY(16) NOT NULL,
-    `address` VARCHAR(40) NOT NULL,
-    KEY (`id`) USING BTREE,
-    CONSTRAINT `locality_data_id` FOREIGN KEY (`id`) REFERENCES `data` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
-))";
-
-char const* const cCreateDataRefDriverTable = R"(CREATE TABLE IF NOT EXISTS `data_ref_driver` (
-    `id` BINARY(16) NOT NULL,
-    `driver_id` BINARY(16) NOT NULL,
-    KEY (`id`) USING BTREE,
-    KEY (`driver_id`) USING BTREE,
-    CONSTRAINT `data_driver_ref_id` FOREIGN KEY (`id`) REFERENCES `data` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
-    CONSTRAINT `data_ref_driver_id` FOREIGN KEY (`driver_id`) REFERENCES `drivers` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
-))";
-
-char const* const cCreateDataRefTaskTable = R"(CREATE TABLE IF NOT EXISTS `data_ref_task` (
-    `id` BINARY(16) NOT NULL,
-    `task_id` BINARY(16) NOT NULL,
-    KEY (`id`) USING BTREE,
-    KEY (`task_id`) USING BTREE,
-    CONSTRAINT `data_task_ref_id` FOREIGN KEY (`id`) REFERENCES `data` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
-    CONSTRAINT `data_ref_task_id` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
-))";
-
-char const* const cCreateClientKVDataTable = R"(CREATE TABLE IF NOT EXISTS `client_kv_data` (
-    `kv_key` VARCHAR(64) NOT NULL,
-    `value` VARBINARY(128) NOT NULL,
-    `client_id` BINARY(16) NOT NULL,
-    PRIMARY KEY (`client_id`, `kv_key`)
-))";
-
-char const* const cCreateTaskKVDataTable = R"(CREATE TABLE IF NOT EXISTS `task_kv_data` (
-    `kv_key` VARCHAR(64) NOT NULL,
-    `value` VARBINARY(128) NOT NULL,
-    `task_id` BINARY(16) NOT NULL,
-    PRIMARY KEY (`task_id`, `kv_key`),
-    CONSTRAINT `kv_data_task_id` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
-))";
-
-std::array<char const* const, 16> const cCreateStorage = {
-        cCreateDriverTable,  // drivers table must be created before data_ref_driver
-        cCreateSchedulerTable,
-        cCreateJobTable,  // jobs table must be created before task
-        cCreateTaskTable,  // tasks table must be created before data_ref_task
-        cCreateDataTable,  // data table must be created before task_outputs
-        cCreateDataLocalityTable,
-        cCreateDataRefDriverTable,
-        cCreateDataRefTaskTable,
-        cCreateClientKVDataTable,
-        cCreateTaskKVDataTable,
-        cCreateInputTaskTable,
-        cCreateOutputTaskTable,
-        cCreateTaskOutputTable,  // task_outputs table must be created before task_inputs
-        cCreateTaskInputTable,
-        cCreateTaskDependencyTable,
-        cCreateTaskInstanceTable,
-};
 
 auto uuid_get_bytes(boost::uuids::uuid const& id) -> sql::bytes {
     // NOLINTBEGIN(cppcoreguidelines-pro-type-cstyle-cast)
@@ -287,7 +123,7 @@ auto string_to_task_state(std::string const& state) -> spider::core::TaskState {
 // NOLINTBEGIN(cppcoreguidelines-pro-type-static-cast-downcast)
 auto MySqlMetadataStorage::initialize(StorageConnection& conn) -> StorageErr {
     try {
-        for (char const* create_table_str : cCreateStorage) {
+        for (std::string const& create_table_str : mysql::cCreateStorage) {
             std::unique_ptr<sql::Statement> statement(
                     static_cast<MySqlConnection&>(conn)->createStatement()
             );
@@ -381,18 +217,25 @@ auto MySqlMetadataStorage::get_active_scheduler(
     return StorageErr{};
 }
 
-void MySqlMetadataStorage::add_task(MySqlConnection& conn, sql::bytes job_id, Task const& task) {
+void MySqlMetadataStorage::add_task(
+        MySqlConnection& conn,
+        sql::bytes job_id,
+        Task const& task,
+        std::optional<TaskState> const& state
+) {
     // Add task
-    std::unique_ptr<sql::PreparedStatement> task_statement(
-            conn->prepareStatement("INSERT INTO `tasks` (`id`, `job_id`, `func_name`, `state`, "
-                                   "`timeout`, `max_retry`) VALUES (?, ?, ?, ?, ?, ?)")
-    );
+    std::unique_ptr<sql::PreparedStatement> task_statement(conn->prepareStatement(mysql::cInsertTask
+    ));
     sql::bytes task_id_bytes = uuid_get_bytes(task.get_id());
     // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
     task_statement->setBytes(1, &task_id_bytes);
     task_statement->setBytes(2, &job_id);
     task_statement->setString(3, task.get_function_name());
-    task_statement->setString(4, task_state_to_string(task.get_state()));
+    if (state.has_value()) {
+        task_statement->setString(4, task_state_to_string(state.value()));
+    } else {
+        task_statement->setString(4, task_state_to_string(task.get_state()));
+    }
     task_statement->setFloat(5, task.get_timeout());
     task_statement->setUInt(6, task.get_max_retries());
     // NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
@@ -407,10 +250,9 @@ void MySqlMetadataStorage::add_task(MySqlConnection& conn, sql::bytes job_id, Ta
         std::optional<std::string> const& value = input.get_value();
         if (task_output.has_value()) {
             std::tuple<boost::uuids::uuid, std::uint8_t> const pair = task_output.value();
-            std::unique_ptr<sql::PreparedStatement> input_statement(conn->prepareStatement(
-                    "INSERT INTO `task_inputs` (`task_id`, `position`, `type`, `output_task_id`, "
-                    "`output_task_position`) VALUES (?, ?, ?, ?, ?)"
-            ));
+            std::unique_ptr<sql::PreparedStatement> input_statement(
+                    conn->prepareStatement(mysql::cInsertTaskInputOutput)
+            );
             // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
             input_statement->setBytes(1, &task_id_bytes);
             input_statement->setUInt(2, i);
@@ -422,8 +264,7 @@ void MySqlMetadataStorage::add_task(MySqlConnection& conn, sql::bytes job_id, Ta
             input_statement->executeUpdate();
         } else if (data_id.has_value()) {
             std::unique_ptr<sql::PreparedStatement> input_statement(
-                    conn->prepareStatement("INSERT INTO `task_inputs` (`task_id`, `position`, "
-                                           "`type`, `data_id`) VALUES (?, ?, ?, ?)")
+                    conn->prepareStatement(mysql::cInsertTaskInputData)
             );
             input_statement->setBytes(1, &task_id_bytes);
             input_statement->setUInt(2, i);
@@ -433,8 +274,7 @@ void MySqlMetadataStorage::add_task(MySqlConnection& conn, sql::bytes job_id, Ta
             input_statement->executeUpdate();
         } else if (value.has_value()) {
             std::unique_ptr<sql::PreparedStatement> input_statement(
-                    conn->prepareStatement("INSERT INTO `task_inputs` (`task_id`, `position`, "
-                                           "`type`, `value`) VALUES (?, ?, ?, ?)")
+                    conn->prepareStatement(mysql::cInsertTaskInputValue)
             );
             input_statement->setBytes(1, &task_id_bytes);
             input_statement->setUInt(2, i);
@@ -447,9 +287,9 @@ void MySqlMetadataStorage::add_task(MySqlConnection& conn, sql::bytes job_id, Ta
     // Add task outputs
     for (std::uint64_t i = 0; i < task.get_num_outputs(); i++) {
         TaskOutput const output = task.get_output(i);
-        std::unique_ptr<sql::PreparedStatement> output_statement(conn->prepareStatement(
-                "INSERT INTO `task_outputs` (`task_id`, `position`, `type`) VALUES (?, ?, ?)"
-        ));
+        std::unique_ptr<sql::PreparedStatement> output_statement(
+                conn->prepareStatement(mysql::cInsertTaskOutput)
+        );
         output_statement->setBytes(1, &task_id_bytes);
         output_statement->setUInt(2, i);
         output_statement->setString(3, output.get_type());
@@ -469,9 +309,7 @@ auto MySqlMetadataStorage::add_job(
         sql::bytes client_id_bytes = uuid_get_bytes(client_id);
         {
             std::unique_ptr<sql::PreparedStatement> statement{
-                    static_cast<MySqlConnection&>(conn)->prepareStatement(
-                            "INSERT INTO `jobs` (`id`, `client_id`) VALUES (?, ?)"
-                    )
+                    static_cast<MySqlConnection&>(conn)->prepareStatement(mysql::cInsertJob)
             };
             statement->setBytes(1, &job_id_bytes);
             statement->setBytes(2, &client_id_bytes);
@@ -496,7 +334,7 @@ auto MySqlMetadataStorage::add_job(
                 };
             }
             Task const* task = task_option.value();
-            add_task(static_cast<MySqlConnection&>(conn), job_id_bytes, *task);
+            add_task(static_cast<MySqlConnection&>(conn), job_id_bytes, *task, TaskState::Ready);
             for (boost::uuids::uuid const id : task_graph.get_child_tasks(task_id)) {
                 std::vector<boost::uuids::uuid> const parents = task_graph.get_parent_tasks(id);
                 if (std::ranges::all_of(parents, [&](boost::uuids::uuid const& parent) {
@@ -519,7 +357,7 @@ auto MySqlMetadataStorage::add_job(
                     return StorageErr{StorageErrType::KeyNotFoundErr, "Task graph inconsistent"};
                 }
                 Task const* task = task_option.value();
-                add_task(static_cast<MySqlConnection&>(conn), job_id_bytes, *task);
+                add_task(static_cast<MySqlConnection&>(conn), job_id_bytes, *task, std::nullopt);
                 for (boost::uuids::uuid const id : task_graph.get_child_tasks(task_id)) {
                     std::vector<boost::uuids::uuid> const parents = task_graph.get_parent_tasks(id);
                     if (std::ranges::all_of(parents, [&](boost::uuids::uuid const& parent) {
@@ -551,10 +389,7 @@ auto MySqlMetadataStorage::add_job(
         // Add input tasks
         for (size_t i = 0; i < input_task_ids.size(); i++) {
             std::unique_ptr<sql::PreparedStatement> input_statement{
-                    static_cast<MySqlConnection&>(conn)->prepareStatement(
-                            "INSERT INTO `input_tasks` (`job_id`, `task_id`, `position`) VALUES "
-                            "(?, ?, ?)"
-                    )
+                    static_cast<MySqlConnection&>(conn)->prepareStatement(mysql::cInsertInputTask)
             };
             input_statement->setBytes(1, &job_id_bytes);
             sql::bytes task_id_bytes = uuid_get_bytes(input_task_ids[i]);
@@ -566,28 +401,13 @@ auto MySqlMetadataStorage::add_job(
         std::vector<boost::uuids::uuid> const& output_task_ids = task_graph.get_output_tasks();
         for (size_t i = 0; i < output_task_ids.size(); i++) {
             std::unique_ptr<sql::PreparedStatement> output_statement{
-                    static_cast<MySqlConnection&>(conn)->prepareStatement(
-                            "INSERT INTO `output_tasks` (`job_id`, `task_id`, `position`) VALUES "
-                            "(?, ?, ?)"
-                    )
+                    static_cast<MySqlConnection&>(conn)->prepareStatement(mysql::cInsertOutputTask)
             };
             output_statement->setBytes(1, &job_id_bytes);
             sql::bytes task_id_bytes = uuid_get_bytes(output_task_ids[i]);
             output_statement->setBytes(2, &task_id_bytes);
             output_statement->setUInt(3, i);
             output_statement->executeUpdate();
-        }
-
-        // Mark head tasks as ready
-        for (boost::uuids::uuid const& task_id : task_graph.get_input_tasks()) {
-            std::unique_ptr<sql::PreparedStatement> statement(
-                    static_cast<MySqlConnection&>(conn)->prepareStatement(
-                            "UPDATE `tasks` SET `state` = 'ready' WHERE `id` = ?"
-                    )
-            );
-            sql::bytes task_id_bytes = uuid_get_bytes(task_id);
-            statement->setBytes(1, &task_id_bytes);
-            statement->executeUpdate();
         }
 
     } catch (sql::SQLException& e) {
@@ -1136,7 +956,7 @@ auto MySqlMetadataStorage::add_child(
 ) -> StorageErr {
     try {
         sql::bytes const job_id = uuid_get_bytes(child.get_id());
-        add_task(static_cast<MySqlConnection&>(conn), job_id, child);
+        add_task(static_cast<MySqlConnection&>(conn), job_id, child, std::nullopt);
 
         // Add dependencies
         std::unique_ptr<sql::PreparedStatement> statement(
@@ -1770,7 +1590,7 @@ auto MySqlMetadataStorage::set_scheduler_state(
 auto MySqlDataStorage::initialize(StorageConnection& conn) -> StorageErr {
     try {
         // Need to initialize metadata storage first so that foreign constraint is not voilated
-        for (char const* create_table_str : cCreateStorage) {
+        for (std::string const& create_table_str : mysql::cCreateStorage) {
             std::unique_ptr<sql::Statement> statement(
                     static_cast<MySqlConnection&>(conn)->createStatement()
             );

--- a/src/spider/storage/mysql/MySqlStorage.hpp
+++ b/src/spider/storage/mysql/MySqlStorage.hpp
@@ -20,6 +20,7 @@
 #include "../../core/Task.hpp"
 #include "../../core/TaskGraph.hpp"
 #include "../DataStorage.hpp"
+#include "../JobSubmissionBatch.hpp"
 #include "../MetadataStorage.hpp"
 #include "../StorageConnection.hpp"
 #include "MySqlConnection.hpp"

--- a/src/spider/storage/mysql/MySqlStorage.hpp
+++ b/src/spider/storage/mysql/MySqlStorage.hpp
@@ -23,6 +23,7 @@
 #include "../MetadataStorage.hpp"
 #include "../StorageConnection.hpp"
 #include "MySqlConnection.hpp"
+#include "MySqlJobSubmissionBatch.hpp"
 
 namespace spider::core {
 class MySqlMetadataStorage : public MetadataStorage {
@@ -133,6 +134,12 @@ private:
 
     static void add_task(
             MySqlConnection& conn,
+            sql::bytes job_id,
+            Task const& task,
+            std::optional<TaskState> const& state
+    );
+    static void add_task_batch(
+            MySqlJobSubmissionBatch& batch,
             sql::bytes job_id,
             Task const& task,
             std::optional<TaskState> const& state

--- a/src/spider/storage/mysql/MySqlStorage.hpp
+++ b/src/spider/storage/mysql/MySqlStorage.hpp
@@ -11,17 +11,17 @@
 #include <mariadb/conncpp/CArray.hpp>
 #include <mariadb/conncpp/ResultSet.hpp>
 
-#include "../core/Data.hpp"
-#include "../core/Driver.hpp"
-#include "../core/Error.hpp"
-#include "../core/JobMetadata.hpp"
-#include "../core/KeyValueData.hpp"
-#include "../core/Task.hpp"
-#include "../core/TaskGraph.hpp"
-#include "DataStorage.hpp"
-#include "MetadataStorage.hpp"
+#include "../../core/Data.hpp"
+#include "../../core/Driver.hpp"
+#include "../../core/Error.hpp"
+#include "../../core/JobMetadata.hpp"
+#include "../../core/KeyValueData.hpp"
+#include "../../core/Task.hpp"
+#include "../../core/TaskGraph.hpp"
+#include "../DataStorage.hpp"
+#include "../MetadataStorage.hpp"
+#include "../StorageConnection.hpp"
 #include "MySqlConnection.hpp"
-#include "StorageConnection.hpp"
 
 namespace spider::core {
 class MySqlMetadataStorage : public MetadataStorage {
@@ -42,6 +42,13 @@ public:
             -> StorageErr override;
     auto add_job(
             StorageConnection& conn,
+            boost::uuids::uuid job_id,
+            boost::uuids::uuid client_id,
+            TaskGraph const& task_graph
+    ) -> StorageErr override;
+    auto add_job_batch(
+            StorageConnection& conn,
+            JobSubmissionBatch& batch,
             boost::uuids::uuid job_id,
             boost::uuids::uuid client_id,
             TaskGraph const& task_graph

--- a/src/spider/storage/mysql/MySqlStorage.hpp
+++ b/src/spider/storage/mysql/MySqlStorage.hpp
@@ -2,6 +2,7 @@
 #define SPIDER_STORAGE_MYSQLSTORAGE_HPP
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -130,7 +131,12 @@ public:
 private:
     std::string m_url;
 
-    static void add_task(MySqlConnection& conn, sql::bytes job_id, Task const& task);
+    static void add_task(
+            MySqlConnection& conn,
+            sql::bytes job_id,
+            Task const& task,
+            std::optional<TaskState> const& state
+    );
     static auto
     fetch_full_task(MySqlConnection& conn, std::unique_ptr<sql::ResultSet> const& res) -> Task;
 };

--- a/src/spider/storage/mysql/mysql_stmt.hpp
+++ b/src/spider/storage/mysql/mysql_stmt.hpp
@@ -5,6 +5,7 @@
 #include <string>
 
 namespace spider::core::mysql {
+// NOLINTBEGIN(cert-err58-cpp)
 
 std::string const cCreateDriverTable = R"(CREATE TABLE IF NOT EXISTS `drivers` (
     `id` BINARY(16) NOT NULL,
@@ -198,6 +199,7 @@ std::string const cInsertInputTask
 std::string const cInsertOutputTask
         = R"(INSERT INTO `output_tasks` (`job_id`, `task_id`, `position`) VALUES (?, ?, ?))";
 
+// NOLINTEND(cert-err58-cpp)
 }  // namespace spider::core::mysql
 
 #endif

--- a/src/spider/storage/mysql/mysql_stmt.hpp
+++ b/src/spider/storage/mysql/mysql_stmt.hpp
@@ -1,0 +1,200 @@
+#ifndef SPIDER_STORAGE_MYSQLSTMT_HPP
+#define SPIDER_STORAGE_MYSQLSTMT_HPP
+
+#include <array>
+#include <string>
+
+namespace spider::core::mysql {
+
+std::string const cCreateDriverTable = R"(CREATE TABLE IF NOT EXISTS `drivers` (
+    `id` BINARY(16) NOT NULL,
+    `heartbeat` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`)
+))";
+
+std::string const cCreateSchedulerTable = R"(CREATE TABLE IF NOT EXISTS `schedulers` (
+    `id` BINARY(16) NOT NULL,
+    `address` VARCHAR(40) NOT NULL,
+    `port` INT UNSIGNED NOT NULL,
+    `state` ENUM('normal', 'recovery', 'gc') NOT NULL,
+    CONSTRAINT `scheduler_driver_id` FOREIGN KEY (`id`) REFERENCES `drivers` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+    PRIMARY KEY (`id`)
+))";
+
+std::string const cCreateJobTable = R"(CREATE TABLE IF NOT EXISTS jobs (
+    `id` BINARY(16) NOT NULL,
+    `client_id` BINARY(16) NOT NULL,
+    `creation_time` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    KEY (`client_id`) USING BTREE,
+    INDEX (`creation_time`),
+    PRIMARY KEY (`id`)
+))";
+
+std::string const cCreateTaskTable = R"(CREATE TABLE IF NOT EXISTS tasks (
+    `id` BINARY(16) NOT NULL,
+    `job_id` BINARY(16) NOT NULL,
+    `func_name` VARCHAR(64) NOT NULL,
+    `state` ENUM('pending', 'ready', 'running', 'success', 'cancel', 'fail') NOT NULL,
+    `timeout` FLOAT,
+    `max_retry` INT UNSIGNED DEFAULT 0,
+    `retry` INT UNSIGNED DEFAULT 0,
+    `instance_id` BINARY(16),
+    CONSTRAINT `task_job_id` FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+    PRIMARY KEY (`id`)
+))";
+
+std::string const cCreateInputTaskTable = R"(CREATE TABLE IF NOT EXISTS input_tasks (
+    `job_id` BINARY(16) NOT NULL,
+    `task_id` BINARY(16) NOT NULL,
+    `position` INT UNSIGNED NOT NULL,
+    CONSTRAINT `input_task_job_id` FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+    CONSTRAINT `input_task_task_id` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+    INDEX (`job_id`, `position`),
+    PRIMARY KEY (`task_id`)
+))";
+
+std::string const cCreateOutputTaskTable = R"(CREATE TABLE IF NOT EXISTS output_tasks (
+    `job_id` BINARY(16) NOT NULL,
+    `task_id` BINARY(16) NOT NULL,
+    `position` INT UNSIGNED NOT NULL,
+    CONSTRAINT `output_task_job_id` FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+    CONSTRAINT `output_task_task_id` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+    INDEX (`job_id`, `position`),
+    PRIMARY KEY (`task_id`)
+))";
+
+std::string const cCreateTaskInputTable = R"(CREATE TABLE IF NOT EXISTS `task_inputs` (
+    `task_id` BINARY(16) NOT NULL,
+    `position` INT UNSIGNED NOT NULL,
+    `type` VARCHAR(64) NOT NULL,
+    `output_task_id` BINARY(16),
+    `output_task_position` INT UNSIGNED,
+    `value` VARBINARY(64), -- Use VARBINARY for all types of values
+    `data_id` BINARY(16),
+    CONSTRAINT `input_task_id` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+    CONSTRAINT `input_task_output_match` FOREIGN KEY (`output_task_id`, `output_task_position`) REFERENCES task_outputs (`task_id`, `position`) ON UPDATE NO ACTION ON DELETE SET NULL,
+    CONSTRAINT `input_data_id` FOREIGN KEY (`data_id`) REFERENCES `data` (`id`) ON UPDATE NO ACTION ON DELETE NO ACTION,
+    PRIMARY KEY (`task_id`, `position`)
+))";
+
+std::string const cCreateTaskOutputTable = R"(CREATE TABLE IF NOT EXISTS `task_outputs` (
+    `task_id` BINARY(16) NOT NULL,
+    `position` INT UNSIGNED NOT NULL,
+    `type` VARCHAR(64) NOT NULL,
+    `value` VARBINARY(64),
+    `data_id` BINARY(16),
+    CONSTRAINT `output_task_id` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+    CONSTRAINT `output_data_id` FOREIGN KEY (`data_id`) REFERENCES `data` (`id`) ON UPDATE NO ACTION ON DELETE NO ACTION,
+    PRIMARY KEY (`task_id`, `position`)
+))";
+
+std::string const cCreateTaskDependencyTable = R"(CREATE TABLE IF NOT EXISTS `task_dependencies` (
+    `parent` BINARY(16) NOT NULL,
+    `child` BINARY(16) NOT NULL,
+    KEY (`parent`) USING BTREE,
+    KEY (`child`) USING BTREE,
+    CONSTRAINT `task_dep_parent` FOREIGN KEY (`parent`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+    CONSTRAINT `task_dep_child` FOREIGN KEY (`child`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+))";
+
+std::string const cCreateTaskInstanceTable = R"(CREATE TABLE IF NOT EXISTS `task_instances` (
+    `id` BINARY(16) NOT NULL,
+    `task_id` BINARY(16) NOT NULL,
+    `start_time` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT `instance_task_id` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+    PRIMARY KEY (`id`)
+))";
+
+std::string const cCreateDataTable = R"(CREATE TABLE IF NOT EXISTS `data` (
+    `id` BINARY(16) NOT NULL,
+    `value` VARBINARY(256) NOT NULL,
+    `hard_locality` BOOL DEFAULT FALSE,
+    `persisted` BOOL DEFAULT FALSE,
+    PRIMARY KEY (`id`)
+))";
+
+std::string const cCreateDataLocalityTable = R"(CREATE TABLE IF NOT EXISTS `data_locality` (
+    `id` BINARY(16) NOT NULL,
+    `address` VARCHAR(40) NOT NULL,
+    KEY (`id`) USING BTREE,
+    CONSTRAINT `locality_data_id` FOREIGN KEY (`id`) REFERENCES `data` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+))";
+
+std::string const cCreateDataRefDriverTable = R"(CREATE TABLE IF NOT EXISTS `data_ref_driver` (
+    `id` BINARY(16) NOT NULL,
+    `driver_id` BINARY(16) NOT NULL,
+    KEY (`id`) USING BTREE,
+    KEY (`driver_id`) USING BTREE,
+    CONSTRAINT `data_driver_ref_id` FOREIGN KEY (`id`) REFERENCES `data` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+    CONSTRAINT `data_ref_driver_id` FOREIGN KEY (`driver_id`) REFERENCES `drivers` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+))";
+
+std::string const cCreateDataRefTaskTable = R"(CREATE TABLE IF NOT EXISTS `data_ref_task` (
+    `id` BINARY(16) NOT NULL,
+    `task_id` BINARY(16) NOT NULL,
+    KEY (`id`) USING BTREE,
+    KEY (`task_id`) USING BTREE,
+    CONSTRAINT `data_task_ref_id` FOREIGN KEY (`id`) REFERENCES `data` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+    CONSTRAINT `data_ref_task_id` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+))";
+
+std::string const cCreateClientKVDataTable = R"(CREATE TABLE IF NOT EXISTS `client_kv_data` (
+    `kv_key` VARCHAR(64) NOT NULL,
+    `value` VARBINARY(128) NOT NULL,
+    `client_id` BINARY(16) NOT NULL,
+    PRIMARY KEY (`client_id`, `kv_key`)
+))";
+
+std::string const cCreateTaskKVDataTable = R"(CREATE TABLE IF NOT EXISTS `task_kv_data` (
+    `kv_key` VARCHAR(64) NOT NULL,
+    `value` VARBINARY(128) NOT NULL,
+    `task_id` BINARY(16) NOT NULL,
+    PRIMARY KEY (`task_id`, `kv_key`),
+    CONSTRAINT `kv_data_task_id` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+))";
+
+std::array<std::string const, 16> const cCreateStorage = {
+        cCreateDriverTable,  // drivers table must be created before data_ref_driver
+        cCreateSchedulerTable,
+        cCreateJobTable,  // jobs table must be created before task
+        cCreateTaskTable,  // tasks table must be created before data_ref_task
+        cCreateDataTable,  // data table must be created before task_outputs
+        cCreateDataLocalityTable,
+        cCreateDataRefDriverTable,
+        cCreateDataRefTaskTable,
+        cCreateClientKVDataTable,
+        cCreateTaskKVDataTable,
+        cCreateInputTaskTable,
+        cCreateOutputTaskTable,
+        cCreateTaskOutputTable,  // task_outputs table must be created before task_inputs
+        cCreateTaskInputTable,
+        cCreateTaskDependencyTable,
+        cCreateTaskInstanceTable,
+};
+
+std::string const cInsertJob = R"(INSERT INTO `jobs` (`id`, `client_id`) VALUES (?, ?))";
+
+std::string const cInsertTask
+        = R"(INSERT INTO `tasks` (`id`, `job_id`, `func_name`, `state`, `timeout`, `max_retry`) VALUES (?, ?, ?, ?, ?, ?))";
+
+std::string const cInsertTaskInputOutput
+        = R"(INSERT INTO `task_inputs` (`task_id`, `position`, `type`, `output_task_id`, `output_task_position`) VALUES (?, ?, ?, ?, ?))";
+
+std::string const cInsertTaskInputData
+        = R"(INSERT INTO `task_inputs` (`task_id`, `position`, `type`, `data_id`) VALUES (?, ?, ?, ?))";
+
+std::string const cInsertTaskInputValue
+        = R"(INSERT INTO `task_inputs` (`task_id`, `position`, `type`, `value`) VALUES (?, ?, ?, ?))";
+
+std::string const cInsertTaskOutput
+        = R"(INSERT INTO `task_outputs` (`task_id`, `position`, `type`) VALUES (?, ?, ?))";
+
+std::string const cInsertInputTask
+        = R"(INSERT INTO `input_tasks` (`job_id`, `task_id`, `position`) VALUES (?, ?, ?))";
+
+std::string const cInsertOutputTask
+        = R"(INSERT INTO `output_tasks` (`job_id`, `task_id`, `position`) VALUES (?, ?, ?))";
+
+}  // namespace spider::core::mysql
+
+#endif

--- a/src/spider/storage/mysql/mysql_stmt.hpp
+++ b/src/spider/storage/mysql/mysql_stmt.hpp
@@ -189,6 +189,9 @@ std::string const cInsertTaskInputValue
 std::string const cInsertTaskOutput
         = R"(INSERT INTO `task_outputs` (`task_id`, `position`, `type`) VALUES (?, ?, ?))";
 
+std::string const cInsertTaskDependency
+        = R"(INSERT INTO `task_dependencies` (parent, child) VALUES (?, ?))";
+
 std::string const cInsertInputTask
         = R"(INSERT INTO `input_tasks` (`job_id`, `task_id`, `position`) VALUES (?, ?, ?))";
 

--- a/src/spider/worker/FunctionManager.hpp
+++ b/src/spider/worker/FunctionManager.hpp
@@ -26,7 +26,7 @@
 #include "../io/MsgPack.hpp"  // IWYU pragma: keep
 #include "../io/Serializer.hpp"
 #include "../storage/DataStorage.hpp"
-#include "../storage/MySqlConnection.hpp"
+#include "../storage/mysql/MySqlConnection.hpp"
 #include "TaskExecutorMessage.hpp"
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)

--- a/src/spider/worker/WorkerClient.cpp
+++ b/src/spider/worker/WorkerClient.cpp
@@ -23,7 +23,7 @@
 #include "../scheduler/SchedulerMessage.hpp"
 #include "../storage/DataStorage.hpp"
 #include "../storage/MetadataStorage.hpp"
-#include "../storage/MySqlConnection.hpp"
+#include "../storage/mysql/MySqlConnection.hpp"
 
 namespace spider::worker {
 

--- a/src/spider/worker/task_executor.cpp
+++ b/src/spider/worker/task_executor.cpp
@@ -24,7 +24,7 @@
 #include "../io/MsgPack.hpp"  // IWYU pragma: keep
 #include "../storage/DataStorage.hpp"
 #include "../storage/MetadataStorage.hpp"
-#include "../storage/MySqlStorage.hpp"
+#include "../storage/mysql/MySqlStorage.hpp"
 #include "DllLoader.hpp"
 #include "FunctionManager.hpp"
 #include "message_pipe.hpp"

--- a/src/spider/worker/worker.cpp
+++ b/src/spider/worker/worker.cpp
@@ -38,8 +38,8 @@
 #include "../io/Serializer.hpp"  // IWYU pragma: keep
 #include "../storage/DataStorage.hpp"
 #include "../storage/MetadataStorage.hpp"
-#include "../storage/MySqlConnection.hpp"
-#include "../storage/MySqlStorage.hpp"
+#include "../storage/mysql/MySqlConnection.hpp"
+#include "../storage/mysql/MySqlStorage.hpp"
 #include "../utils/StopToken.hpp"
 #include "TaskExecutor.hpp"
 #include "WorkerClient.hpp"

--- a/tests/client/client-test.cpp
+++ b/tests/client/client-test.cpp
@@ -169,10 +169,12 @@ auto main(int argc, char** argv) -> int {
         job.wait_complete();
         if (job.get_status() != spider::JobStatus::Succeeded) {
             spdlog::error("Batch job failed");
+            return cJobFailed;
         }
         int const result = job.get_result();
         if (result != i + i) {
             spdlog::error("Batch job wrong result. Expect {}. Get {}.", i + i, result);
+            return cJobFailed;
         }
     }
 

--- a/tests/client/client-test.cpp
+++ b/tests/client/client-test.cpp
@@ -1,5 +1,6 @@
 #include <string>
 #include <tuple>
+#include <vector>
 
 #include <boost/any/bad_any_cast.hpp>
 #include <boost/program_options/errors.hpp>
@@ -38,6 +39,8 @@ auto parse_args(int const argc, char** argv) -> boost::program_options::variable
 
 constexpr int cCmdArgParseErr = 1;
 constexpr int cJobFailed = 2;
+
+constexpr int cBatchSize = 10;
 
 }  // namespace
 
@@ -159,12 +162,13 @@ auto main(int argc, char** argv) -> int {
 
     // Run batch submission
     std::vector<spider::Job<int>> jobs;
+    jobs.reserve(cBatchSize);
     driver.begin_batch_start();
-    for (int i = 0; i < 10; ++i) {
+    for (int i = 0; i < cBatchSize; ++i) {
         jobs.emplace_back(driver.start(&sum_test, i, i));
     }
     driver.end_batch_start();
-    for (int i = 0; i < 10; ++i) {
+    for (int i = 0; i < cBatchSize; ++i) {
         spider::Job<int>& job = jobs[i];
         job.wait_complete();
         if (job.get_status() != spider::JobStatus::Succeeded) {

--- a/tests/scheduler/test-SchedulerPolicy.cpp
+++ b/tests/scheduler/test-SchedulerPolicy.cpp
@@ -21,7 +21,7 @@
 #include "../../src/spider/scheduler/FifoPolicy.hpp"
 #include "../../src/spider/storage/DataStorage.hpp"
 #include "../../src/spider/storage/MetadataStorage.hpp"
-#include "../../src/spider/storage/MySqlConnection.hpp"
+#include "../../src/spider/storage/mysql/MySqlConnection.hpp"
 #include "../storage/StorageTestHelper.hpp"
 
 namespace {

--- a/tests/scheduler/test-SchedulerServer.cpp
+++ b/tests/scheduler/test-SchedulerServer.cpp
@@ -25,7 +25,7 @@
 #include "../../src/spider/scheduler/SchedulerServer.hpp"
 #include "../../src/spider/storage/DataStorage.hpp"
 #include "../../src/spider/storage/MetadataStorage.hpp"
-#include "../../src/spider/storage/MySqlConnection.hpp"
+#include "../../src/spider/storage/mysql/MySqlConnection.hpp"
 #include "../../src/spider/utils/StopToken.hpp"
 #include "../storage/StorageTestHelper.hpp"
 

--- a/tests/storage/StorageTestHelper.hpp
+++ b/tests/storage/StorageTestHelper.hpp
@@ -13,8 +13,8 @@
 #include "../../src/spider/core/Error.hpp"
 #include "../../src/spider/storage/DataStorage.hpp"
 #include "../../src/spider/storage/MetadataStorage.hpp"
-#include "../../src/spider/storage/MySqlConnection.hpp"
-#include "../../src/spider/storage/MySqlStorage.hpp"
+#include "../../src/spider/storage/mysql/MySqlConnection.hpp"
+#include "../../src/spider/storage/mysql/MySqlStorage.hpp"
 
 namespace spider::test {
 char const* const cStorageUrl

--- a/tests/storage/test-DataStorage.cpp
+++ b/tests/storage/test-DataStorage.cpp
@@ -13,7 +13,7 @@
 #include "../../src/spider/core/KeyValueData.hpp"
 #include "../../src/spider/core/Task.hpp"
 #include "../../src/spider/core/TaskGraph.hpp"
-#include "../../src/spider/storage/MySqlConnection.hpp"
+#include "../../src/spider/storage/mysql/MySqlConnection.hpp"
 #include "../utils/CoreDataUtils.hpp"
 #include "StorageTestHelper.hpp"
 

--- a/tests/storage/test-MetadataStorage.cpp
+++ b/tests/storage/test-MetadataStorage.cpp
@@ -18,7 +18,7 @@
 #include "../../src/spider/core/Task.hpp"
 #include "../../src/spider/core/TaskGraph.hpp"
 #include "../../src/spider/storage/MetadataStorage.hpp"
-#include "../../src/spider/storage/MySqlConnection.hpp"
+#include "../../src/spider/storage/mysql/MySqlConnection.hpp"
 #include "../utils/CoreTaskUtils.hpp"
 #include "StorageTestHelper.hpp"
 

--- a/tests/storage/test-MetadataStorage.cpp
+++ b/tests/storage/test-MetadataStorage.cpp
@@ -181,7 +181,7 @@ TEMPLATE_LIST_TEST_CASE(
     // Submit job should success
     REQUIRE(storage->add_job_batch(conn, batch, job_id, client_id, graph).success());
     REQUIRE(storage->add_job_batch(conn, batch, simple_job_id, client_id, simple_graph).success());
-    batch.submit_batch();
+    batch.submit_batch(conn);
 
     // Get job id for non-existent client id should return empty vector
     std::vector<boost::uuids::uuid> job_ids;

--- a/tests/storage/test-MetadataStorage.cpp
+++ b/tests/storage/test-MetadataStorage.cpp
@@ -19,6 +19,7 @@
 #include "../../src/spider/core/TaskGraph.hpp"
 #include "../../src/spider/storage/MetadataStorage.hpp"
 #include "../../src/spider/storage/mysql/MySqlConnection.hpp"
+#include "../../src/spider/storage/mysql/MySqlJobSubmissionBatch.hpp"
 #include "../utils/CoreTaskUtils.hpp"
 #include "StorageTestHelper.hpp"
 
@@ -116,6 +117,136 @@ TEMPLATE_LIST_TEST_CASE(
 
 TEMPLATE_LIST_TEST_CASE(
         "Job add, get and remove",
+        "[storage]",
+        spider::test::MetadataStorageTypeList
+) {
+    std::unique_ptr<spider::core::MetadataStorage> storage
+            = spider::test::create_metadata_storage<TestType>();
+
+    std::variant<spider::core::MySqlConnection, spider::core::StorageErr> conn_result
+            = spider::core::MySqlConnection::create(storage->get_url());
+    REQUIRE(std::holds_alternative<spider::core::MySqlConnection>(conn_result));
+    auto& conn = std::get<spider::core::MySqlConnection>(conn_result);
+    spider::core::MySqlJobSubmissionBatch batch{conn};
+
+    boost::uuids::random_generator gen;
+    boost::uuids::uuid const job_id = gen();
+
+    // Create a complicated task graph
+    boost::uuids::uuid const client_id = gen();
+    spider::core::Task child_task{"child"};
+    spider::core::Task parent_1{"p1"};
+    spider::core::Task parent_2{"p2"};
+    parent_1.add_input(spider::core::TaskInput{"1", "float"});
+    parent_1.add_input(spider::core::TaskInput{"2", "float"});
+    parent_2.add_input(spider::core::TaskInput{"3", "int"});
+    parent_2.add_input(spider::core::TaskInput{"4", "int"});
+    parent_1.add_output(spider::core::TaskOutput{"float"});
+    parent_2.add_output(spider::core::TaskOutput{"int"});
+    child_task.add_input(spider::core::TaskInput{parent_1.get_id(), 0, "float"});
+    child_task.add_input(spider::core::TaskInput{parent_2.get_id(), 0, "int"});
+    child_task.add_output(spider::core::TaskOutput{"float"});
+    spider::core::TaskGraph graph;
+    // Add task and dependencies to task graph in wrong order
+    graph.add_task(child_task);
+    graph.add_task(parent_1);
+    graph.add_task(parent_2);
+    graph.add_dependency(parent_2.get_id(), child_task.get_id());
+    graph.add_dependency(parent_1.get_id(), child_task.get_id());
+    graph.add_input_task(parent_1.get_id());
+    graph.add_input_task(parent_2.get_id());
+    graph.add_output_task(child_task.get_id());
+
+    // Get head tasks should succeed
+    std::vector<boost::uuids::uuid> heads = graph.get_input_tasks();
+    REQUIRE(2 == heads.size());
+    REQUIRE(heads[0] == parent_1.get_id());
+    REQUIRE(heads[1] == parent_2.get_id());
+
+    std::chrono::system_clock::time_point const job_creation_time
+            = std::chrono::system_clock::now();
+
+    // Submit a simple job
+    boost::uuids::uuid const simple_job_id = gen();
+    spider::core::Task const simple_task{"simple"};
+    spider::core::TaskGraph simple_graph;
+    simple_graph.add_task(simple_task);
+    simple_graph.add_input_task(simple_task.get_id());
+    simple_graph.add_output_task(simple_task.get_id());
+
+    heads = simple_graph.get_input_tasks();
+    REQUIRE(1 == heads.size());
+    REQUIRE(heads[0] == simple_task.get_id());
+
+    // Submit job should success
+    REQUIRE(storage->add_job_batch(conn, batch, job_id, client_id, graph).success());
+    REQUIRE(storage->add_job_batch(conn, batch, simple_job_id, client_id, simple_graph).success());
+    batch.submit_batch();
+
+    // Get job id for non-existent client id should return empty vector
+    std::vector<boost::uuids::uuid> job_ids;
+    REQUIRE(storage->get_jobs_by_client_id(conn, gen(), &job_ids).success());
+    REQUIRE(job_ids.empty());
+
+    // Get job id for client id should get correct value
+    REQUIRE(storage->get_jobs_by_client_id(conn, client_id, &job_ids).success());
+    REQUIRE(2 == job_ids.size());
+    REQUIRE(
+            ((job_ids[0] == job_id && job_ids[1] == simple_job_id)
+             || (job_ids[0] == simple_job_id && job_ids[1] == job_id))
+    );
+
+    // Get job metadata should get correct value
+    spider::core::JobMetadata job_metadata{};
+    REQUIRE(storage->get_job_metadata(conn, job_id, &job_metadata).success());
+    REQUIRE(job_id == job_metadata.get_id());
+    REQUIRE(client_id == job_metadata.get_client_id());
+    std::chrono::seconds const time_delta{1};
+    // REQUIRE(job_creation_time + time_delta >= job_metadata.get_creation_time());
+    // REQUIRE(job_creation_time - time_delta <= job_metadata.get_creation_time());
+
+    // Get task graph should succeed
+    spider::core::TaskGraph graph_res{};
+    REQUIRE(storage->get_task_graph(conn, job_id, &graph_res).success());
+    REQUIRE(spider::test::task_graph_equal(graph, graph_res));
+    spider::core::TaskGraph simple_graph_res{};
+    REQUIRE(storage->get_task_graph(conn, simple_job_id, &simple_graph_res).success());
+    REQUIRE(spider::test::task_graph_equal(simple_graph, simple_graph_res));
+
+    // Get task should succeed
+    spider::core::Task task_res{""};
+    REQUIRE(storage->get_task(conn, child_task.get_id(), &task_res).success());
+    REQUIRE(spider::test::task_equal(child_task, task_res));
+
+    // Get child tasks should succeed
+    std::vector<spider::core::Task> tasks;
+    REQUIRE(storage->get_child_tasks(conn, parent_1.get_id(), &tasks).success());
+    REQUIRE(1 == tasks.size());
+    REQUIRE(spider::test::task_equal(child_task, tasks[0]));
+    tasks.clear();
+
+    // Get parent tasks should succeed
+    REQUIRE(storage->get_parent_tasks(conn, child_task.get_id(), &tasks).success());
+    REQUIRE(2 == tasks.size());
+    REQUIRE(
+            ((spider::test::task_equal(tasks[0], parent_1)
+              && spider::test::task_equal(tasks[1], parent_2))
+             || (spider::test::task_equal(tasks[0], parent_2)
+                 && spider::test::task_equal(tasks[1], parent_1)))
+    );
+
+    // Remove job should succeed
+    REQUIRE(storage->remove_job(conn, simple_job_id).success());
+    REQUIRE(spider::core::StorageErrType::KeyNotFoundErr
+            == storage->get_task_graph(conn, simple_job_id, &simple_graph_res).type);
+    graph_res = spider::core::TaskGraph{};
+    REQUIRE(storage->get_task_graph(conn, job_id, &graph_res).success());
+    REQUIRE(spider::test::task_graph_equal(graph, graph_res));
+    REQUIRE(storage->remove_job(conn, job_id).success());
+}
+
+TEMPLATE_LIST_TEST_CASE(
+        "Job batch add, get and remove",
         "[storage]",
         spider::test::MetadataStorageTypeList
 ) {

--- a/tests/worker/test-FunctionManager.cpp
+++ b/tests/worker/test-FunctionManager.cpp
@@ -17,7 +17,7 @@
 #include "../../src/spider/core/Error.hpp"
 #include "../../src/spider/core/TaskContextImpl.hpp"
 #include "../../src/spider/io/MsgPack.hpp"  // IWYU pragma: keep
-#include "../../src/spider/storage/MySqlConnection.hpp"
+#include "../../src/spider/storage/mysql/MySqlConnection.hpp"
 #include "../../src/spider/worker/FunctionManager.hpp"
 #include "../../src/spider/worker/FunctionNameManager.hpp"
 #include "../storage/StorageTestHelper.hpp"

--- a/tests/worker/test-TaskExecutor.cpp
+++ b/tests/worker/test-TaskExecutor.cpp
@@ -22,7 +22,7 @@
 #include "../../src/spider/io/MsgPack.hpp"  // IWYU pragma: keep
 #include "../../src/spider/storage/DataStorage.hpp"
 #include "../../src/spider/storage/MetadataStorage.hpp"
-#include "../../src/spider/storage/MySqlConnection.hpp"
+#include "../../src/spider/storage/mysql/MySqlConnection.hpp"
 #include "../../src/spider/worker/FunctionManager.hpp"
 #include "../../src/spider/worker/TaskExecutor.hpp"
 #include "../storage/StorageTestHelper.hpp"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description

Right now `Spider` only supports submitting one job at a time, which is inefficient when user submit a large group of jobs at the same time. This pr introduces to calls to the driver interface, `begin_batch_start` and `end_batch_start`, which can be used around multiple `start` calls, to send all storage requests in batch.

Client now also keeps an open storage connection to avoid unnecessary latency. However, `TaskContext` in task executor does not keep open storage connection to avoid running out open connection resource.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* [ ] GitHub workflows pass
* [x] Unit tests pass in dev container
* [x] Integration tests pass in dev container



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added batch job submission functionality for more efficient processing of multiple tasks.
- **Refactor**
  - Streamlined database connection handling to improve reliability and performance.
  - Reorganized MySQL integration into a dedicated structure for easier maintenance.
- **Chores**
  - Updated include paths to reflect the new directory structure for MySQL components.
- **Tests**
  - Enhanced automated test coverage to verify batch operations and robust error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->