### PR TITLE
fix: Move `create_task_instance` from scheduler to worker

### DIFF
--- a/src/spider/scheduler/SchedulerMessage.hpp
+++ b/src/spider/scheduler/SchedulerMessage.hpp
@@ -3,7 +3,6 @@
 
 #include <optional>
 #include <string>
-#include <tuple>
 #include <utility>
 
 #include <boost/uuid/uuid.hpp>
@@ -55,28 +54,19 @@ class ScheduleTaskResponse {
 public:
     ScheduleTaskResponse() = default;
 
-    ScheduleTaskResponse(
-            boost::uuids::uuid const task_id,
-            boost::uuids::uuid const task_instance_id
-    )
-            : m_task_ids{std::make_tuple(task_id, task_instance_id)} {}
+    explicit ScheduleTaskResponse(boost::uuids::uuid const task_id) : m_task_id{task_id} {}
 
-    explicit ScheduleTaskResponse(std::tuple<boost::uuids::uuid, boost::uuids::uuid> const& task_ids
-    )
-            : m_task_ids{task_ids} {}
+    [[nodiscard]] auto has_task_id() const -> bool { return m_task_id.has_value(); }
 
-    [[nodiscard]] auto has_task_id() const -> bool { return m_task_ids.has_value(); }
-
-    [[nodiscard]] auto get_task_ids(
-    ) const -> std::tuple<boost::uuids::uuid, boost::uuids::uuid> const& {
+    [[nodiscard]] auto get_task_id() const -> boost::uuids::uuid const& {
         // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-        return m_task_ids.value();
+        return m_task_id.value();
     }
 
-    MSGPACK_DEFINE_ARRAY(m_task_ids);
+    MSGPACK_DEFINE_ARRAY(m_task_id);
 
 private:
-    std::optional<std::tuple<boost::uuids::uuid, boost::uuids::uuid>> m_task_ids = std::nullopt;
+    std::optional<boost::uuids::uuid> m_task_id = std::nullopt;
 };
 
 }  // namespace spider::scheduler

--- a/src/spider/scheduler/SchedulerServer.cpp
+++ b/src/spider/scheduler/SchedulerServer.cpp
@@ -12,7 +12,6 @@
 #include <spdlog/spdlog.h>
 
 #include "../core/Error.hpp"
-#include "../core/Task.hpp"
 #include "../io/BoostAsio.hpp"  // IWYU pragma: keep
 #include "../io/MsgPack.hpp"  // IWYU pragma: keep
 #include "../io/msgpack_message.hpp"
@@ -160,17 +159,7 @@ auto SchedulerServer::process_message(boost::asio::ip::tcp::socket socket
             = m_policy->schedule_next(request.get_worker_id(), request.get_worker_addr());
     ScheduleTaskResponse response{};
     if (task_id.has_value()) {
-        core::TaskInstance const instance{task_id.value()};
-        core::StorageErr const err = m_metadata_store->create_task_instance(m_conn, instance);
-        if (err.success()) {
-            response = ScheduleTaskResponse{task_id.value(), instance.id};
-        } else {
-            spdlog::error(
-                    "Cannot create task instance {}: {}",
-                    boost::uuids::to_string(task_id.value()),
-                    err.description
-            );
-        }
+        response = ScheduleTaskResponse{task_id.value()};
     }
     msgpack::sbuffer response_buffer;
     msgpack::pack(response_buffer, response);

--- a/tests/scheduler/test-SchedulerPolicy.cpp
+++ b/tests/scheduler/test-SchedulerPolicy.cpp
@@ -66,16 +66,28 @@ TEMPLATE_LIST_TEST_CASE(
 
     spider::scheduler::FifoPolicy policy{metadata_store, data_store, conn};
 
-    // Scheduler the earlier task
-    std::optional<boost::uuids::uuid> const optional_task_id = policy.schedule_next(gen(), "");
+    // Schedule the earlier task
+    std::optional<boost::uuids::uuid> optional_task_id = policy.schedule_next(gen(), "");
     REQUIRE(optional_task_id.has_value());
     if (optional_task_id.has_value()) {
         boost::uuids::uuid const& task_id = optional_task_id.value();
         REQUIRE(task_id == task_1.get_id());
     }
 
+    // Schedule the later task
+    optional_task_id = policy.schedule_next(gen(), "");
+    REQUIRE(optional_task_id.has_value());
+    if (optional_task_id.has_value()) {
+        boost::uuids::uuid const& task_id = optional_task_id.value();
+        REQUIRE(task_id == task_2.get_id());
+    }
+
     REQUIRE(metadata_store->remove_job(conn, job_id_1).success());
     REQUIRE(metadata_store->remove_job(conn, job_id_2).success());
+
+    // Schedule when no task available
+    optional_task_id = policy.schedule_next(gen(), "");
+    REQUIRE(!optional_task_id.has_value());
 }
 
 TEMPLATE_LIST_TEST_CASE(

--- a/tests/scheduler/test-SchedulerServer.cpp
+++ b/tests/scheduler/test-SchedulerServer.cpp
@@ -108,7 +108,7 @@ TEMPLATE_LIST_TEST_CASE(
         spider::scheduler::ScheduleTaskResponse const res
                 = object.as<spider::scheduler::ScheduleTaskResponse>();
         REQUIRE(res.has_task_id());
-        REQUIRE(std::get<0>(res.get_task_ids()) == parent_task.get_id());
+        REQUIRE(res.get_task_id() == parent_task.get_id());
     }
     socket.close();
     server.stop();


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description

Scheduler runs `create_task_instance`, a storage call, for each schedule task, increasing response delay. This pr moves the call from scheduler to worker.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* [x] GitHub workflows pass
* [x] Unit tests pass in dev container
* [x] Integration tests pass in dev container



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined task scheduling by moving from dual identifiers to a single task identifier.
  - Enhanced error handling to provide a more reliable and straightforward task management process.

- **Tests**
  - Expanded test scenarios to validate scheduling under varied conditions, including multiple task scheduling and handling cases with no available tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->