### PR TITLE
fix: Retry deadlocked `task_finish` call

### DIFF
--- a/src/spider/core/Error.hpp
+++ b/src/spider/core/Error.hpp
@@ -13,7 +13,7 @@ enum class StorageErrType : std::uint8_t {
     KeyNotFoundErr,
     DuplicateKeyErr,
     ConstraintViolationErr,
-    DeakLockErr,
+    DeadLockErr,
     OtherErr
 };
 

--- a/src/spider/core/Error.hpp
+++ b/src/spider/core/Error.hpp
@@ -13,6 +13,7 @@ enum class StorageErrType : std::uint8_t {
     KeyNotFoundErr,
     DuplicateKeyErr,
     ConstraintViolationErr,
+    DeakLockErr,
     OtherErr
 };
 

--- a/src/spider/storage/mysql/MySqlStorage.cpp
+++ b/src/spider/storage/mysql/MySqlStorage.cpp
@@ -50,6 +50,7 @@ enum MariadbErr : uint16_t {
     ErWrongDbName = 1102,
     ErWrongTableName = 1103,
     ErUnknownTable = 1109,
+    ErDeakLock = 1213,
 };
 
 namespace spider::core {
@@ -1347,8 +1348,8 @@ auto MySqlMetadataStorage::create_task_instance(
                 static_cast<MySqlConnection&>(conn)->prepareStatement(
                         "SELECT `t1`.`id` FROM `task_instances` as `t1` JOIN `tasks` ON "
                         "`t1`.`task_id` = `tasks`.`id` WHERE `t1`.`task_id` = ? AND "
-                        "`tasks`.`timeout` < 0.0001 AND TIMESTAMPDIFF(MICROSECOND, "
-                        "`t1`.`start_time`, CURRENT_TIMESTAMP()) < `tasks`.`timeout` * 1000"
+                        "(`tasks`.`timeout` < 0.0001 OR TIMESTAMPDIFF(MICROSECOND, "
+                        "`t1`.`start_time`, CURRENT_TIMESTAMP()) < `tasks`.`timeout` * 1000)"
                 )
         );
         not_timeout_statement->setBytes(1, &id_bytes);
@@ -1481,6 +1482,9 @@ auto MySqlMetadataStorage::task_finish(
         static_cast<MySqlConnection&>(conn)->rollback();
         if (e.getErrorCode() == ErDupKey || e.getErrorCode() == ErDupEntry) {
             return StorageErr{StorageErrType::DuplicateKeyErr, e.what()};
+        }
+        if (e.getErrorCode() == ErDeakLock) {
+            return StorageErr{StorageErrType::DeakLockErr, e.what()};
         }
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }

--- a/src/spider/storage/mysql/MySqlStorage.cpp
+++ b/src/spider/storage/mysql/MySqlStorage.cpp
@@ -50,7 +50,7 @@ enum MariadbErr : uint16_t {
     ErWrongDbName = 1102,
     ErWrongTableName = 1103,
     ErUnknownTable = 1109,
-    ErDeakLock = 1213,
+    ErDeadLock = 1213,
 };
 
 namespace spider::core {
@@ -1483,8 +1483,8 @@ auto MySqlMetadataStorage::task_finish(
         if (e.getErrorCode() == ErDupKey || e.getErrorCode() == ErDupEntry) {
             return StorageErr{StorageErrType::DuplicateKeyErr, e.what()};
         }
-        if (e.getErrorCode() == ErDeakLock) {
-            return StorageErr{StorageErrType::DeakLockErr, e.what()};
+        if (e.getErrorCode() == ErDeadLock) {
+            return StorageErr{StorageErrType::DeadLockErr, e.what()};
         }
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }

--- a/src/spider/worker/worker.cpp
+++ b/src/spider/worker/worker.cpp
@@ -345,7 +345,7 @@ auto task_loop(
             if (err.success()) {
                 break;
             }
-            if (spider::core::StorageErrType::DeakLockErr != err.type) {
+            if (spider::core::StorageErrType::DeadLockErr != err.type) {
                 spdlog::error(
                         "Submit task {} fails: {}",
                         task.get_function_name(),


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description

With the introduction of #76, `task_finish` is more likely to deadlock. Since there is no order to prevent the deadlock, this pr add retry of `task_finish` for up to 5 times.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* [ ] GitHub workflows pass
* [x] Unit tests pass in dev container
* [x] Integration tests pass in dev container



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced error categorisation to better handle temporary concurrency issues, including a new `DeadLockErr` type.
- **Bug Fixes**
  - Introduced a retry mechanism during task processing to improve reliability.
  - Optimised task condition checks to further bolster system performance and resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->