### PR TITLE
fix(lint): Lock clang-tidy to v19 until we can upgrade our code to fix new v20 issues.

### DIFF
--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -2,7 +2,7 @@ black>=24.4.2
 # Lock to v18.x until we can upgrade our code to meet v19's formatting standards.
 clang-format~=18.1
 # Lock to v19.x until we can upgrade our code to fix new v20 issues.
-clang-tidy~=19.1.0
+clang-tidy~=19.1
 ruff>=0.4.4
 gersemi>=0.16.2
 yamllint>=1.35.1

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,7 +1,8 @@
 black>=24.4.2
 # Lock to v18.x until we can upgrade our code to meet v19's formatting standards.
 clang-format~=18.1
-clang-tidy>=19.1.0
+# Lock to v19.x until we can upgrade our code to fix new v20 issues.
+clang-tidy~=19.1.0
 ruff>=0.4.4
 gersemi>=0.16.2
 yamllint>=1.35.1


### PR DESCRIPTION
# Description

As title says. Use of `fmt`'s macros from `spdlog` generate a new error on clang-tidy v20.
An example:
```
 /usr/local/include/spdlog/details/fmt_helper.h:91:54: error: call to consteval function 'fmt::basic_format_string<char, int &>::basic_format_string<FMT_COMPILE_STRING, 0>' is not a constant expression [clang-diagnostic-error]
   91 |         fmt_lib::format_to(std::back_inserter(dest), SPDLOG_FMT_STRING("{:02}"), n);
      |                                                      ^
```

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Test locally and through CI.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the version specification for a key development tool to allow for controlled updates within the 19.x series while maintaining compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->