### PR TITLE
fix: Wrong return type in template `for_n`

### DIFF
--- a/src/spider/core/TaskGraphImpl.hpp
+++ b/src/spider/core/TaskGraphImpl.hpp
@@ -290,14 +290,22 @@ private:
         }
         Task const& parent = optional_parent.value();
         if constexpr (cIsSpecializationV<ReturnType, std::tuple>) {
+            bool fail = false;
             for_n<std::tuple_size_v<ReturnType>>([&](auto i) {
+                if (fail) {
+                    return;
+                }
                 if (position >= task.get_num_inputs()) {
-                    return std::nullopt;
+                    fail = true;
+                    return;
                 }
                 TaskInput& input = task.get_input_ref(position);
                 position++;
                 input.set_output(parent.get_id(), i.cValue);
             });
+            if (fail) {
+                return std::nullopt;
+            }
         } else {
             if (position >= task.get_num_inputs()) {
                 return std::nullopt;


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description

`for_n` template requires the lambda function to return void. `task_add_inputs` in `core/TaskGraphImpl.hpp` returns a `std::nullopt` instead.



# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

- [x] GitHub workflows pass



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error handling during input processing to gracefully detect and manage validation issues without disrupting overall execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->