### PR TITLE
fix: Batch MySQL queries in getting ready tasks

### DIFF
--- a/src/spider/core/Task.hpp
+++ b/src/spider/core/Task.hpp
@@ -1,6 +1,7 @@
 #ifndef SPIDER_CORE_TASK_HPP
 #define SPIDER_CORE_TASK_HPP
 
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <optional>
@@ -107,6 +108,62 @@ enum class TaskState : std::uint8_t {
     Succeed,
     Failed,
     Canceled,
+};
+
+class ScheduleTaskMetadata {
+public:
+    ScheduleTaskMetadata(
+            boost::uuids::uuid id,
+            std::string function_name,
+            boost::uuids::uuid job_id
+    )
+            : m_id(id),
+              m_function_name(std::move(function_name)),
+              m_job_id(job_id) {}
+
+    [[nodiscard]] auto get_id() const -> boost::uuids::uuid { return m_id; }
+
+    [[nodiscard]] auto get_function_name() const -> std::string const& { return m_function_name; }
+
+    [[nodiscard]] auto get_job_id() const -> boost::uuids::uuid { return m_job_id; }
+
+    [[nodiscard]] auto get_client_id() const -> boost::uuids::uuid { return m_client_id; }
+
+    [[nodiscard]] auto get_job_creation_time() const -> std::chrono::system_clock::time_point {
+        return m_job_creation_time;
+    }
+
+    [[nodiscard]] auto get_hard_localities() const -> std::vector<std::string> const& {
+        return m_hard_localities;
+    }
+
+    [[nodiscard]] auto get_soft_localities() const -> std::vector<std::string> const& {
+        return m_soft_localities;
+    }
+
+    auto set_client_id(boost::uuids::uuid const client_id) -> void { m_client_id = client_id; }
+
+    auto set_job_creation_time(std::chrono::system_clock::time_point const job_creation_time
+    ) -> void {
+        m_job_creation_time = job_creation_time;
+    }
+
+    auto add_hard_locality(std::string const& locality) -> void {
+        m_hard_localities.push_back(locality);
+    }
+
+    auto add_soft_locality(std::string const& locality) -> void {
+        m_soft_localities.push_back(locality);
+    }
+
+private:
+    boost::uuids::uuid m_id;
+    std::string m_function_name;
+    boost::uuids::uuid m_job_id;
+    boost::uuids::uuid m_client_id;
+    std::chrono::system_clock::time_point m_job_creation_time;
+    std::vector<std::string> m_hard_localities;
+    std::vector<std::string> m_soft_localities;
 };
 
 class Task {

--- a/src/spider/core/Task.hpp
+++ b/src/spider/core/Task.hpp
@@ -121,6 +121,8 @@ public:
               m_function_name(std::move(function_name)),
               m_job_id(job_id) {}
 
+    ScheduleTaskMetadata() = default;
+
     [[nodiscard]] auto get_id() const -> boost::uuids::uuid { return m_id; }
 
     [[nodiscard]] auto get_function_name() const -> std::string const& { return m_function_name; }

--- a/src/spider/scheduler/FifoPolicy.cpp
+++ b/src/spider/scheduler/FifoPolicy.cpp
@@ -1,64 +1,20 @@
 #include "FifoPolicy.hpp"
 
 #include <algorithm>
-#include <chrono>
 #include <iterator>
 #include <memory>
 #include <optional>
-#include <stdexcept>
 #include <string>
-#include <tuple>
 #include <vector>
 
-#include <absl/container/flat_hash_map.h>
 #include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_io.hpp>
-#include <fmt/format.h>
 
-#include "../core/Data.hpp"
-#include "../core/JobMetadata.hpp"
 #include "../core/Task.hpp"
 #include "../storage/DataStorage.hpp"
 #include "../storage/MetadataStorage.hpp"
 #include "../storage/StorageConnection.hpp"
 
 namespace spider::scheduler {
-
-auto FifoPolicy::task_locality_satisfied(spider::core::Task const& task, std::string const& addr)
-        -> bool {
-    for (auto const& input : task.get_inputs()) {
-        if (input.get_value().has_value()) {
-            continue;
-        }
-        std::optional<boost::uuids::uuid> optional_data_id = input.get_data_id();
-        if (!optional_data_id.has_value()) {
-            continue;
-        }
-        boost::uuids::uuid const data_id = optional_data_id.value();
-        core::Data data;
-        if (m_data_cache.contains(data_id)) {
-            data = m_data_cache[data_id];
-        } else {
-            if (false == m_data_store->get_data(*m_conn, data_id, &data).success()) {
-                throw std::runtime_error(
-                        fmt::format("Data with id {} not exists.", to_string((data_id)))
-                );
-            }
-            m_data_cache.emplace(data_id, data);
-        }
-        if (false == data.is_hard_locality()) {
-            continue;
-        }
-        std::vector<std::string> const& locality = data.get_locality();
-        if (locality.empty()) {
-            continue;
-        }
-        if (std::ranges::find(locality, addr) == locality.end()) {
-            return false;
-        }
-    }
-    return true;
-}
 
 FifoPolicy::FifoPolicy(
         std::shared_ptr<core::MetadataStorage> const& metadata_store,
@@ -81,56 +37,35 @@ auto FifoPolicy::schedule_next(
     }
     auto const reverse_begin = std::reverse_iterator(m_tasks.end());
     auto const reverse_end = std::reverse_iterator(m_tasks.begin());
-    auto const it = std::find_if(reverse_begin, reverse_end, [&](core::Task const& task) {
-        return task_locality_satisfied(task, worker_addr);
-    });
+    auto const it
+            = std::find_if(reverse_begin, reverse_end, [&](core::ScheduleTaskMetadata const& task) {
+                  std::vector<std::string> const& hard_localities = task.get_hard_localities();
+                  if (hard_localities.empty()) {
+                      return true;
+                  }
+                  // If the worker address is in the hard localities, then the task can be
+                  // scheduled.
+                  return std::ranges::find(hard_localities, worker_addr) != hard_localities.end();
+              });
     if (it == reverse_end) {
         return std::nullopt;
     }
     boost::uuids::uuid const task_id = it->get_id();
-    for (core::TaskInput const& input : it->get_inputs()) {
-        std::optional<boost::uuids::uuid> const data_id = input.get_data_id();
-        if (data_id.has_value()) {
-            m_data_cache.erase(data_id.value());
-        }
-    }
     m_tasks.erase(std::next(it).base());
     return task_id;
 }
 
 auto FifoPolicy::fetch_tasks() -> void {
-    m_data_cache.clear();
     m_metadata_store->get_ready_tasks(*m_conn, &m_tasks);
-    std::vector<std::tuple<core::TaskInstance, core::Task>> instances;
-    m_metadata_store->get_task_timeout(*m_conn, &instances);
-    for (auto const& [instance, task] : instances) {
-        m_tasks.emplace_back(task);
-    }
+    m_metadata_store->get_task_timeout(*m_conn, &m_tasks);
 
     // Sort tasks based on job creation time in descending order.
-    // NOLINTNEXTLINE(misc-include-cleaner)
-    absl::flat_hash_map<boost::uuids::uuid, core::JobMetadata, std::hash<boost::uuids::uuid>>
-            job_metadata_map;
-    auto get_task_job_creation_time
-            = [&](boost::uuids::uuid const task_id) -> std::chrono::system_clock::time_point {
-        boost::uuids::uuid job_id;
-        if (false == m_metadata_store->get_task_job_id(*m_conn, task_id, &job_id).success()) {
-            throw std::runtime_error(fmt::format("Task with id {} not exists.", to_string(task_id))
-            );
-        }
-        if (job_metadata_map.contains(job_id)) {
-            return job_metadata_map[job_id].get_creation_time();
-        }
-        core::JobMetadata job_metadata;
-        if (false == m_metadata_store->get_job_metadata(*m_conn, job_id, &job_metadata).success()) {
-            throw std::runtime_error(fmt::format("Job with id {} not exists.", to_string(job_id)));
-        }
-        job_metadata_map[job_id] = job_metadata;
-        return job_metadata.get_creation_time();
-    };
-    std::ranges::sort(m_tasks, [&](core::Task const& a, core::Task const& b) {
-        return get_task_job_creation_time(a.get_id()) > get_task_job_creation_time(b.get_id());
-    });
+    std::ranges::sort(
+            m_tasks,
+            [&](core::ScheduleTaskMetadata const& a, core::ScheduleTaskMetadata const& b) {
+                return a.get_job_creation_time() > b.get_job_creation_time();
+            }
+    );
 }
 
 }  // namespace spider::scheduler

--- a/src/spider/scheduler/FifoPolicy.hpp
+++ b/src/spider/scheduler/FifoPolicy.hpp
@@ -6,7 +6,6 @@
 #include <string>
 #include <vector>
 
-#include <absl/container/flat_hash_map.h>
 #include <boost/uuid/uuid.hpp>
 
 #include "../core/Task.hpp"
@@ -30,15 +29,12 @@ public:
 
 private:
     auto fetch_tasks() -> void;
-    auto task_locality_satisfied(core::Task const& task, std::string const& addr) -> bool;
 
     std::shared_ptr<core::MetadataStorage> m_metadata_store;
     std::shared_ptr<core::DataStorage> m_data_store;
     std::shared_ptr<core::StorageConnection> m_conn;
 
-    std::vector<core::Task> m_tasks;
-    // NOLINTNEXTLINE(misc-include-cleaner)
-    absl::flat_hash_map<boost::uuids::uuid, core::Data, std::hash<boost::uuids::uuid>> m_data_cache;
+    std::vector<core::ScheduleTaskMetadata> m_tasks;
 };
 
 }  // namespace spider::scheduler

--- a/src/spider/storage/MetadataStorage.hpp
+++ b/src/spider/storage/MetadataStorage.hpp
@@ -2,7 +2,6 @@
 #define SPIDER_STORAGE_METADATASTORAGE_HPP
 
 #include <string>
-#include <tuple>
 #include <vector>
 
 #include <boost/uuid/uuid.hpp>
@@ -78,8 +77,8 @@ public:
             boost::uuids::uuid id,
             boost::uuids::uuid* job_id
     ) -> StorageErr = 0;
-    virtual auto get_ready_tasks(StorageConnection& conn, std::vector<Task>* tasks) -> StorageErr
-                                                                                       = 0;
+    virtual auto get_ready_tasks(StorageConnection& conn, std::vector<ScheduleTaskMetadata>* tasks)
+            -> StorageErr = 0;
     virtual auto set_task_state(StorageConnection& conn, boost::uuids::uuid id, TaskState state)
             -> StorageErr = 0;
     virtual auto set_task_running(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr = 0;
@@ -98,10 +97,8 @@ public:
             TaskInstance const& instance,
             std::string const& error
     ) -> StorageErr = 0;
-    virtual auto get_task_timeout(
-            StorageConnection& conn,
-            std::vector<std::tuple<TaskInstance, Task>>* tasks
-    ) -> StorageErr = 0;
+    virtual auto get_task_timeout(StorageConnection& conn, std::vector<ScheduleTaskMetadata>* tasks)
+            -> StorageErr = 0;
     virtual auto get_child_tasks(
             StorageConnection& conn,
             boost::uuids::uuid id,

--- a/src/spider/storage/mysql/MySqlStorage.cpp
+++ b/src/spider/storage/mysql/MySqlStorage.cpp
@@ -14,6 +14,7 @@
 #include <utility>
 #include <vector>
 
+#include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_io.hpp>
@@ -1230,20 +1231,105 @@ auto MySqlMetadataStorage::get_task_job_id(
     return StorageErr{};
 }
 
-auto MySqlMetadataStorage::get_ready_tasks(StorageConnection& conn, std::vector<Task>* tasks)
-        -> StorageErr {
+auto MySqlMetadataStorage::get_ready_tasks(
+        StorageConnection& conn,
+        std::vector<ScheduleTaskMetadata>* tasks
+) -> StorageErr {
     try {
         // Get all ready tasks from job that has not failed or cancelled
         std::unique_ptr<sql::Statement> statement(
                 static_cast<MySqlConnection&>(conn)->createStatement()
         );
-        std::unique_ptr<sql::ResultSet> res(statement->executeQuery(
-                "SELECT `id`, `func_name`, `state`, `timeout` FROM `tasks` WHERE `state` = 'ready' "
+        std::unique_ptr<sql::ResultSet> const res(statement->executeQuery(
+                "SELECT `id`, `func_name`, `job_id` FROM `tasks` WHERE `state` = 'ready' "
                 "AND `job_id` NOT IN (SELECT `job_id` FROM `tasks` WHERE `state` = 'fail' OR "
                 "`state` = 'cancel')"
         ));
+
+        if (res->rowsCount() == 0) {
+            static_cast<MySqlConnection&>(conn)->commit();
+            return StorageErr{};
+        }
+
+        absl::flat_hash_map<boost::uuids::uuid, ScheduleTaskMetadata> new_tasks;
+        absl::flat_hash_map<boost::uuids::uuid, std::vector<boost::uuids::uuid>> job_id_to_task_ids;
         while (res->next()) {
-            tasks->emplace_back(fetch_full_task(static_cast<MySqlConnection&>(conn), res));
+            boost::uuids::uuid const task_id = read_id(res->getBinaryStream("id"));
+            boost::uuids::uuid const job_id = read_id(res->getBinaryStream("job_id"));
+            std::string const function_name = get_sql_string(res->getString("func_name"));
+            new_tasks.emplace(task_id, ScheduleTaskMetadata{task_id, function_name, job_id});
+            if (job_id_to_task_ids.find(job_id) == job_id_to_task_ids.end()) {
+                job_id_to_task_ids[job_id] = std::vector<boost::uuids::uuid>{};
+            } else {
+                job_id_to_task_ids[job_id].emplace_back(task_id);
+            }
+        }
+
+        // Get all job metadata
+        std::unique_ptr<sql::PreparedStatement> job_statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `id`, `client_id`, `creation_time` FROM `jobs` WHERE `id` = ?"
+                )
+        );
+        for (auto const& iter : job_id_to_task_ids) {
+            sql::bytes job_id_bytes = uuid_get_bytes(iter.first);
+            job_statement->setBytes(1, &job_id_bytes);
+            job_statement->addBatch();
+        }
+        job_statement->execute();
+        std::unique_ptr<sql::ResultSet> const job_res(job_statement->getResultSet());
+        while (job_res->next()) {
+            boost::uuids::uuid const job_id = read_id(job_res->getBinaryStream("id"));
+            boost::uuids::uuid const client_id = read_id(job_res->getBinaryStream("client_id"));
+            std::optional<std::chrono::system_clock::time_point> const optional_creation_time
+                    = parse_timestamp(get_sql_string(job_res->getString("creation_time")));
+            if (false == optional_creation_time.has_value()) {
+                static_cast<MySqlConnection&>(conn)->rollback();
+                return StorageErr{
+                        StorageErrType::OtherErr,
+                        fmt::format(
+                                "Cannot parse timestamp {}",
+                                get_sql_string(job_res->getString("creation_time"))
+                        )
+                };
+            }
+            for (boost::uuids::uuid const& task_id : job_id_to_task_ids[job_id]) {
+                new_tasks[task_id].set_client_id(client_id);
+                new_tasks[task_id].set_job_creation_time(optional_creation_time.value());
+            }
+        }
+
+        // Get all data localities
+        std::unique_ptr<sql::PreparedStatement> locality_statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `task_inputs`.`task_id`, `data`.`hard_locality`, "
+                        "`data_locality`.`address` FROM `task_inputs` JOIN `data` ON "
+                        "`task_inputs`.`data_id` = `data`.`id` JOIN `data_locality` ON `data`.`id` "
+                        "= `data_locality`.`id` WHERE `task_inputs`.`task_id` = ? AND "
+                        "`task_inputs`.`task_id` IS NOT NULL"
+                )
+        );
+        for (auto const& iter : new_tasks) {
+            sql::bytes task_id_bytes = uuid_get_bytes(iter.first);
+            locality_statement->setBytes(1, &task_id_bytes);
+            locality_statement->addBatch();
+        }
+        locality_statement->execute();
+        std::unique_ptr<sql::ResultSet> const locality_res(locality_statement->getResultSet());
+        while (locality_res->next()) {
+            boost::uuids::uuid const task_id = read_id(locality_res->getBinaryStream("task_id"));
+            bool const hard_locality = locality_res->getBoolean("hard_locality");
+            std::string const address = get_sql_string(locality_res->getString("address"));
+            if (hard_locality) {
+                new_tasks[task_id].add_hard_locality(address);
+            } else {
+                new_tasks[task_id].add_soft_locality(address);
+            }
+        }
+
+        // Add all tasks to the output
+        for (auto const& ite : new_tasks) {
+            tasks->emplace_back(ite.second);
         }
     } catch (sql::SQLException& e) {
         static_cast<MySqlConnection&>(conn)->rollback();
@@ -1540,18 +1626,23 @@ auto MySqlMetadataStorage::task_fail(
 
 auto MySqlMetadataStorage::get_task_timeout(
         StorageConnection& conn,
-        std::vector<std::tuple<TaskInstance, Task>>* tasks
+        std::vector<ScheduleTaskMetadata>* tasks
 ) -> StorageErr {
     try {
         std::unique_ptr<sql::Statement> statement(
                 static_cast<MySqlConnection&>(conn)->createStatement()
         );
-        std::unique_ptr<sql::ResultSet> res(statement->executeQuery(
-                "SELECT `t1`.`id`, `t1`.`task_id` FROM `task_instances` as `t1` JOIN `tasks` ON "
+        std::unique_ptr<sql::ResultSet> const task_timeout_res(statement->executeQuery(
+                "SELECT `t1`.`task_id` FROM `task_instances` as `t1` JOIN `tasks` ON "
                 "`t1`.`task_id` = `tasks`.`id` WHERE `tasks`.`timeout` > 0.0001 AND "
                 "TIMESTAMPDIFF(MICROSECOND, `t1`.`start_time`, CURRENT_TIMESTAMP()) > "
                 "`tasks`.`timeout` * 1000"
         ));
+        if (task_timeout_res->rowsCount() == 0) {
+            static_cast<MySqlConnection&>(conn)->commit();
+            return StorageErr{};
+        }
+
         std::unique_ptr<sql::PreparedStatement> not_timeout_statement(
                 static_cast<MySqlConnection&>(conn)->prepareStatement(
                         "SELECT FROM `task_instances` as `t1` JOIN `tasks` ON`t1`.`task_id` = "
@@ -1560,29 +1651,121 @@ auto MySqlMetadataStorage::get_task_timeout(
                 )
         );
 
+        absl::flat_hash_set<boost::uuids::uuid> task_ids;
+        while (task_timeout_res->next()) {
+            boost::uuids::uuid const task_id
+                    = read_id(task_timeout_res->getBinaryStream("task_id"));
+            task_ids.insert(task_id);
+            sql::bytes task_id_bytes = uuid_get_bytes(task_id);
+            not_timeout_statement->setBytes(1, &task_id_bytes);
+            not_timeout_statement->addBatch();
+        }
+        not_timeout_statement->execute();
+        std::unique_ptr<sql::ResultSet> const not_timeout_res(not_timeout_statement->getResultSet()
+        );
+        while (not_timeout_res->next()) {
+            boost::uuids::uuid const task_id = read_id(not_timeout_res->getBinaryStream("task_id"));
+            task_ids.erase(task_id);
+        }
+
+        if (task_ids.empty()) {
+            static_cast<MySqlConnection&>(conn)->commit();
+            return StorageErr{};
+        }
+
+        // Get task metadata
         std::unique_ptr<sql::PreparedStatement> task_statement(
                 static_cast<MySqlConnection&>(conn)->prepareStatement(
-                        "SELECT `id`, `func_name`, `state`, `timeout` FROM `tasks` WHERE `id` = ?"
+                        "SELECT `id`, `func_name`, `job_id` FROM `tasks` WHERE `id` = ?"
                 )
         );
-        while (res->next()) {
-            boost::uuids::uuid const task_instance_id = read_id(res->getBinaryStream("id"));
-            boost::uuids::uuid const task_id = read_id(res->getBinaryStream("task_id"));
+        for (boost::uuids::uuid const& task_id : task_ids) {
             sql::bytes task_id_bytes = uuid_get_bytes(task_id);
-            // Check all task instance have timed out
-            not_timeout_statement->setBytes(1, &task_id_bytes);
-            std::unique_ptr<sql::ResultSet> not_timeout_res(not_timeout_statement->executeQuery());
-            if (not_timeout_res->rowsCount() > 0) {
-                continue;
-            }
-
-            // Fetch task
             task_statement->setBytes(1, &task_id_bytes);
-            std::unique_ptr<sql::ResultSet> task_res(task_statement->executeQuery());
-            if (task_res->next()) {
-                Task const task = fetch_full_task(static_cast<MySqlConnection&>(conn), task_res);
-                tasks->emplace_back(TaskInstance{task_instance_id, task_id}, task);
+            task_statement->addBatch();
+        }
+        task_statement->execute();
+        std::unique_ptr<sql::ResultSet> const task_res(task_statement->getResultSet());
+
+        absl::flat_hash_map<boost::uuids::uuid, ScheduleTaskMetadata> new_tasks;
+        absl::flat_hash_map<boost::uuids::uuid, std::vector<boost::uuids::uuid>> job_id_to_task_ids;
+        while (task_res->next()) {
+            boost::uuids::uuid const task_id = read_id(task_res->getBinaryStream("id"));
+            boost::uuids::uuid const job_id = read_id(task_res->getBinaryStream("job_id"));
+            std::string const function_name = get_sql_string(task_res->getString("func_name"));
+            new_tasks.emplace(task_id, ScheduleTaskMetadata{task_id, function_name, job_id});
+            if (job_id_to_task_ids.find(job_id) == job_id_to_task_ids.end()) {
+                job_id_to_task_ids[job_id] = std::vector<boost::uuids::uuid>{};
+            } else {
+                job_id_to_task_ids[job_id].emplace_back(task_id);
             }
+        }
+
+        // Get all job metadata
+        std::unique_ptr<sql::PreparedStatement> job_statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `id`, `client_id`, `creation_time` FROM `jobs` WHERE `id` = ?"
+                )
+        );
+        for (auto const& iter : job_id_to_task_ids) {
+            sql::bytes job_id_bytes = uuid_get_bytes(iter.first);
+            job_statement->setBytes(1, &job_id_bytes);
+            job_statement->addBatch();
+        }
+        job_statement->execute();
+        std::unique_ptr<sql::ResultSet> const job_res(job_statement->getResultSet());
+        while (job_res->next()) {
+            boost::uuids::uuid const job_id = read_id(job_res->getBinaryStream("id"));
+            boost::uuids::uuid const client_id = read_id(job_res->getBinaryStream("client_id"));
+            std::optional<std::chrono::system_clock::time_point> const optional_creation_time
+                    = parse_timestamp(get_sql_string(job_res->getString("creation_time")));
+            if (false == optional_creation_time.has_value()) {
+                static_cast<MySqlConnection&>(conn)->rollback();
+                return StorageErr{
+                        StorageErrType::OtherErr,
+                        fmt::format(
+                                "Cannot parse timestamp {}",
+                                get_sql_string(job_res->getString("creation_time"))
+                        )
+                };
+            }
+            for (boost::uuids::uuid const& task_id : job_id_to_task_ids[job_id]) {
+                new_tasks[task_id].set_client_id(client_id);
+                new_tasks[task_id].set_job_creation_time(optional_creation_time.value());
+            }
+        }
+
+        // Get all data localities
+        std::unique_ptr<sql::PreparedStatement> locality_statement(
+                static_cast<MySqlConnection&>(conn)->prepareStatement(
+                        "SELECT `task_inputs`.`task_id`, `data`.`hard_locality`, "
+                        "`data_locality`.`address` FROM `task_inputs` JOIN `data` ON "
+                        "`task_inputs`.`data_id` = `data`.`id` JOIN `data_locality` ON `data`.`id` "
+                        "= `data_locality`.`id` WHERE `task_inputs`.`task_id` = ? AND "
+                        "`task_inputs`.`task_id` IS NOT NULL"
+                )
+        );
+        for (auto const& iter : new_tasks) {
+            sql::bytes task_id_bytes = uuid_get_bytes(iter.first);
+            locality_statement->setBytes(1, &task_id_bytes);
+            locality_statement->addBatch();
+        }
+        locality_statement->execute();
+        std::unique_ptr<sql::ResultSet> const locality_res(locality_statement->getResultSet());
+        while (locality_res->next()) {
+            boost::uuids::uuid const task_id = read_id(locality_res->getBinaryStream("task_id"));
+            bool const hard_locality = locality_res->getBoolean("hard_locality");
+            std::string const address = get_sql_string(locality_res->getString("address"));
+            if (hard_locality) {
+                new_tasks[task_id].add_hard_locality(address);
+            } else {
+                new_tasks[task_id].add_soft_locality(address);
+            }
+        }
+
+        // Add all tasks to the output
+        for (auto const& iter : new_tasks) {
+            tasks->emplace_back(iter.second);
         }
     } catch (sql::SQLException& e) {
         static_cast<MySqlConnection&>(conn)->rollback();

--- a/src/spider/storage/mysql/MySqlStorage.cpp
+++ b/src/spider/storage/mysql/MySqlStorage.cpp
@@ -1646,7 +1646,7 @@ auto MySqlMetadataStorage::get_task_timeout(
         std::unique_ptr<sql::PreparedStatement> not_timeout_statement(
                 static_cast<MySqlConnection&>(conn)->prepareStatement(
                         "SELECT `t1`.`task_id` FROM `task_instances` as `t1` JOIN `tasks` ON "
-                        "`t1`.`task_id` = `tasks`.`id` WHERE `t1.task_id` = ? AND "
+                        "`t1`.`task_id` = `tasks`.`id` WHERE `t1`.`task_id` = ? AND "
                         "TIMESTAMPDIFF(MICROSECOND, `t1`.`start_time`, CURRENT_TIMESTAMP()) < "
                         "`tasks`.`timeout` * 1000"
                 )

--- a/src/spider/storage/mysql/MySqlStorage.cpp
+++ b/src/spider/storage/mysql/MySqlStorage.cpp
@@ -1645,9 +1645,10 @@ auto MySqlMetadataStorage::get_task_timeout(
 
         std::unique_ptr<sql::PreparedStatement> not_timeout_statement(
                 static_cast<MySqlConnection&>(conn)->prepareStatement(
-                        "SELECT FROM `task_instances` as `t1` JOIN `tasks` ON`t1`.`task_id` = "
-                        "`tasks`.`id` WHERE `t1.task_id` = ? AND TIMESTAMPDIFF(MICROSECOND, "
-                        "`t1`.`start_time`, CURRENT_TIMESTAMP()) < `tasks`.`timeout` * 1000"
+                        "SELECT `t1`.`task_id` FROM `task_instances` as `t1` JOIN `tasks` ON "
+                        "`t1`.`task_id` = `tasks`.`id` WHERE `t1.task_id` = ? AND "
+                        "TIMESTAMPDIFF(MICROSECOND, `t1`.`start_time`, CURRENT_TIMESTAMP()) < "
+                        "`tasks`.`timeout` * 1000"
                 )
         );
 

--- a/src/spider/storage/mysql/MySqlStorage.cpp
+++ b/src/spider/storage/mysql/MySqlStorage.cpp
@@ -1259,7 +1259,7 @@ auto MySqlMetadataStorage::get_ready_tasks(
             std::string const function_name = get_sql_string(res->getString("func_name"));
             new_tasks.emplace(task_id, ScheduleTaskMetadata{task_id, function_name, job_id});
             if (job_id_to_task_ids.find(job_id) == job_id_to_task_ids.end()) {
-                job_id_to_task_ids[job_id] = std::vector<boost::uuids::uuid>{};
+                job_id_to_task_ids[job_id] = std::vector<boost::uuids::uuid>{task_id};
             } else {
                 job_id_to_task_ids[job_id].emplace_back(task_id);
             }
@@ -1696,7 +1696,7 @@ auto MySqlMetadataStorage::get_task_timeout(
             std::string const function_name = get_sql_string(task_res->getString("func_name"));
             new_tasks.emplace(task_id, ScheduleTaskMetadata{task_id, function_name, job_id});
             if (job_id_to_task_ids.find(job_id) == job_id_to_task_ids.end()) {
-                job_id_to_task_ids[job_id] = std::vector<boost::uuids::uuid>{};
+                job_id_to_task_ids[job_id] = std::vector<boost::uuids::uuid>{task_id};
             } else {
                 job_id_to_task_ids[job_id].emplace_back(task_id);
             }

--- a/src/spider/storage/mysql/MySqlStorage.hpp
+++ b/src/spider/storage/mysql/MySqlStorage.hpp
@@ -4,7 +4,6 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <tuple>
 #include <vector>
 
 #include <boost/uuid/uuid.hpp>
@@ -81,7 +80,8 @@ public:
     get_task(StorageConnection& conn, boost::uuids::uuid id, Task* task) -> StorageErr override;
     auto get_task_job_id(StorageConnection& conn, boost::uuids::uuid id, boost::uuids::uuid* job_id)
             -> StorageErr override;
-    auto get_ready_tasks(StorageConnection& conn, std::vector<Task>* tasks) -> StorageErr override;
+    auto get_ready_tasks(StorageConnection& conn, std::vector<ScheduleTaskMetadata>* tasks)
+            -> StorageErr override;
     auto set_task_state(StorageConnection& conn, boost::uuids::uuid id, TaskState state)
             -> StorageErr override;
     auto set_task_running(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr override;
@@ -96,10 +96,8 @@ public:
     ) -> StorageErr override;
     auto task_fail(StorageConnection& conn, TaskInstance const& instance, std::string const& error)
             -> StorageErr override;
-    auto get_task_timeout(
-            StorageConnection& conn,
-            std::vector<std::tuple<TaskInstance, Task>>* tasks
-    ) -> StorageErr override;
+    auto get_task_timeout(StorageConnection& conn, std::vector<ScheduleTaskMetadata>* tasks)
+            -> StorageErr override;
     auto get_child_tasks(
             StorageConnection& conn,
             boost::uuids::uuid id,


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description

MySQL storage currently executes 2 queries for each task in `get_ready_tasks`. Scheduler needs 1 more query for each task to get job id, and 1 more query for each job to get job metadata. If tasks have data, then 1 more query is executed for each data to get locality. Same storage accesses are needed for `get_task_timeout`.

This pr introduces `ScheduleTaskMetadata` to encapsulate all metadata needed by scheduler. `get_ready_tasks` and `get_task_timeout` now returns vector of `ScheduleTaskMetadata` so that scheduler does not need extra storage access.

MySQL storage also batches queries in `get_ready_tasks` and `get_task_time` to reduce number of queries and runtime.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
* [x] GitHub workflows pass
* [x] Unit tests pass in dev container
* [x] Integration tests pass in dev container


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an enhanced task scheduling metadata system to support more detailed task assignment and management.
- **Refactor**
	- Streamlined scheduling logic by simplifying locality checks.
	- Optimised task fetching and sorting for improved performance.
	- Updated storage interactions to align with the enhanced scheduling framework.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->