### PR TITLE
fix: Scheduler fetch task when no task to schedule

### DIFF
--- a/src/spider/scheduler/FifoPolicy.hpp
+++ b/src/spider/scheduler/FifoPolicy.hpp
@@ -30,6 +30,8 @@ public:
 private:
     auto fetch_tasks() -> void;
 
+    auto pop_next_task(std::string const& worker_addr) -> std::optional<boost::uuids::uuid>;
+
     std::shared_ptr<core::MetadataStorage> m_metadata_store;
     std::shared_ptr<core::DataStorage> m_data_store;
     std::shared_ptr<core::StorageConnection> m_conn;


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description
The FIFO scheduler only fetch tasks when local task queue is empty. However, in the case where idle workers are not assigned tasks due to locality constraints, it is possible that local task queue is not empty but new ready tasks are pushed to storage.

This pr changes the scheduler behavior to fetch task each time there is no task to schedule.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* [x] GitHub workflows pass
* [x] Unit tests pass in dev container
* [x] Integration tests pass in dev container



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the task scheduling process to improve efficiency and responsiveness when processing tasks. These changes help ensure that tasks are allocated more dynamically and reliably, supporting a better overall performance experience for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->