### PR TITLE
build: Add jq installation needed by check-cmake-version script.

### DIFF
--- a/tools/scripts/lib_install/linux/install-dev.sh
+++ b/tools/scripts/lib_install/linux/install-dev.sh
@@ -21,6 +21,7 @@ DEBIAN_FRONTEND=noninteractive ${privileged_command_prefix} apt-get install --no
     g++ \
     gcc \
     git \
+    jq \
     libcurl4 \
     libcurl4-openssl-dev \
     libssl-dev \


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Dev container cannot build because of unknown `jq` in `check-cmake-version.sh` introduced in #87.

This pr fixes #89 by adding `jq` installation in `install-dev.sh`.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
* [x] Dev container builds
* [x] Project builds inside dev container 

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the development installation process to include the `jq` package for enhanced tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->