### PR TITLE
fix: Increse size of type and value in task input/output and size of data

### DIFF
--- a/src/spider/storage/mysql/mysql_stmt.hpp
+++ b/src/spider/storage/mysql/mysql_stmt.hpp
@@ -67,10 +67,10 @@ std::string const cCreateOutputTaskTable = R"(CREATE TABLE IF NOT EXISTS output_
 std::string const cCreateTaskInputTable = R"(CREATE TABLE IF NOT EXISTS `task_inputs` (
     `task_id` BINARY(16) NOT NULL,
     `position` INT UNSIGNED NOT NULL,
-    `type` VARCHAR(64) NOT NULL,
+    `type` VARCHAR(256) NOT NULL,
     `output_task_id` BINARY(16),
     `output_task_position` INT UNSIGNED,
-    `value` VARBINARY(64), -- Use VARBINARY for all types of values
+    `value` VARBINARY(999), -- Use VARBINARY for all types of values
     `data_id` BINARY(16),
     CONSTRAINT `input_task_id` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
     CONSTRAINT `input_task_output_match` FOREIGN KEY (`output_task_id`, `output_task_position`) REFERENCES task_outputs (`task_id`, `position`) ON UPDATE NO ACTION ON DELETE SET NULL,
@@ -81,8 +81,8 @@ std::string const cCreateTaskInputTable = R"(CREATE TABLE IF NOT EXISTS `task_in
 std::string const cCreateTaskOutputTable = R"(CREATE TABLE IF NOT EXISTS `task_outputs` (
     `task_id` BINARY(16) NOT NULL,
     `position` INT UNSIGNED NOT NULL,
-    `type` VARCHAR(64) NOT NULL,
-    `value` VARBINARY(64),
+    `type` VARCHAR(256) NOT NULL,
+    `value` VARBINARY(999),
     `data_id` BINARY(16),
     CONSTRAINT `output_task_id` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
     CONSTRAINT `output_data_id` FOREIGN KEY (`data_id`) REFERENCES `data` (`id`) ON UPDATE NO ACTION ON DELETE NO ACTION,

--- a/src/spider/storage/mysql/mysql_stmt.hpp
+++ b/src/spider/storage/mysql/mysql_stmt.hpp
@@ -67,7 +67,7 @@ std::string const cCreateOutputTaskTable = R"(CREATE TABLE IF NOT EXISTS output_
 std::string const cCreateTaskInputTable = R"(CREATE TABLE IF NOT EXISTS `task_inputs` (
     `task_id` BINARY(16) NOT NULL,
     `position` INT UNSIGNED NOT NULL,
-    `type` VARCHAR(256) NOT NULL,
+    `type` VARCHAR(999) NOT NULL,
     `output_task_id` BINARY(16),
     `output_task_position` INT UNSIGNED,
     `value` VARBINARY(999), -- Use VARBINARY for all types of values
@@ -81,7 +81,7 @@ std::string const cCreateTaskInputTable = R"(CREATE TABLE IF NOT EXISTS `task_in
 std::string const cCreateTaskOutputTable = R"(CREATE TABLE IF NOT EXISTS `task_outputs` (
     `task_id` BINARY(16) NOT NULL,
     `position` INT UNSIGNED NOT NULL,
-    `type` VARCHAR(256) NOT NULL,
+    `type` VARCHAR(999) NOT NULL,
     `value` VARBINARY(999),
     `data_id` BINARY(16),
     CONSTRAINT `output_task_id` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
@@ -108,7 +108,7 @@ std::string const cCreateTaskInstanceTable = R"(CREATE TABLE IF NOT EXISTS `task
 
 std::string const cCreateDataTable = R"(CREATE TABLE IF NOT EXISTS `data` (
     `id` BINARY(16) NOT NULL,
-    `value` VARBINARY(256) NOT NULL,
+    `value` VARBINARY(999) NOT NULL,
     `hard_locality` BOOL DEFAULT FALSE,
     `persisted` BOOL DEFAULT FALSE,
     PRIMARY KEY (`id`)
@@ -141,14 +141,14 @@ std::string const cCreateDataRefTaskTable = R"(CREATE TABLE IF NOT EXISTS `data_
 
 std::string const cCreateClientKVDataTable = R"(CREATE TABLE IF NOT EXISTS `client_kv_data` (
     `kv_key` VARCHAR(64) NOT NULL,
-    `value` VARBINARY(128) NOT NULL,
+    `value` VARBINARY(999) NOT NULL,
     `client_id` BINARY(16) NOT NULL,
     PRIMARY KEY (`client_id`, `kv_key`)
 ))";
 
 std::string const cCreateTaskKVDataTable = R"(CREATE TABLE IF NOT EXISTS `task_kv_data` (
     `kv_key` VARCHAR(64) NOT NULL,
-    `value` VARBINARY(128) NOT NULL,
+    `value` VARBINARY(999) NOT NULL,
     `task_id` BINARY(16) NOT NULL,
     PRIMARY KEY (`task_id`, `kv_key`),
     CONSTRAINT `kv_data_task_id` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE

--- a/tools/scripts/storage/init_db.sql
+++ b/tools/scripts/storage/init_db.sql
@@ -58,7 +58,7 @@ CREATE TABLE IF NOT EXISTS output_tasks
 CREATE TABLE IF NOT EXISTS `data`
 (
     `id`            BINARY(16)     NOT NULL,
-    `value`         VARBINARY(256) NOT NULL,
+    `value`         VARBINARY(999) NOT NULL,
     `hard_locality` BOOL DEFAULT FALSE,
     `persisted`     BOOL DEFAULT FALSE,
     PRIMARY KEY (`id`)
@@ -67,7 +67,7 @@ CREATE TABLE IF NOT EXISTS `task_outputs`
 (
     `task_id`  BINARY(16)   NOT NULL,
     `position` INT UNSIGNED NOT NULL,
-    `type`     VARCHAR(256)  NOT NULL,
+    `type`     VARCHAR(999)  NOT NULL,
     `value`    VARBINARY(999),
     `data_id`  BINARY(16),
     CONSTRAINT `output_task_id` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
@@ -78,7 +78,7 @@ CREATE TABLE IF NOT EXISTS `task_inputs`
 (
     `task_id`              BINARY(16)   NOT NULL,
     `position`             INT UNSIGNED NOT NULL,
-    `type`                 VARCHAR(256)  NOT NULL,
+    `type`                 VARCHAR(999)  NOT NULL,
     `output_task_id`       BINARY(16),
     `output_task_position` INT UNSIGNED,
     `value`                VARBINARY(999), -- Use VARBINARY for all types of values
@@ -135,14 +135,14 @@ CREATE TABLE IF NOT EXISTS `data_ref_task`
 CREATE TABLE IF NOT EXISTS `client_kv_data`
 (
     `kv_key`    VARCHAR(64)    NOT NULL,
-    `value`     VARBINARY(128) NOT NULL,
+    `value`     VARBINARY(999) NOT NULL,
     `client_id` BINARY(16)     NOT NULL,
     PRIMARY KEY (`client_id`, `kv_key`)
 );
 CREATE TABLE IF NOT EXISTS `task_kv_data`
 (
     `kv_key`  VARCHAR(64)    NOT NULL,
-    `value`   VARBINARY(128) NOT NULL,
+    `value`   VARBINARY(999) NOT NULL,
     `task_id` BINARY(16)     NOT NULL,
     PRIMARY KEY (`task_id`, `kv_key`),
     CONSTRAINT `kv_data_task_id` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE

--- a/tools/scripts/storage/init_db.sql
+++ b/tools/scripts/storage/init_db.sql
@@ -67,8 +67,8 @@ CREATE TABLE IF NOT EXISTS `task_outputs`
 (
     `task_id`  BINARY(16)   NOT NULL,
     `position` INT UNSIGNED NOT NULL,
-    `type`     VARCHAR(64)  NOT NULL,
-    `value`    VARBINARY(64),
+    `type`     VARCHAR(256)  NOT NULL,
+    `value`    VARBINARY(999),
     `data_id`  BINARY(16),
     CONSTRAINT `output_task_id` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
     CONSTRAINT `output_data_id` FOREIGN KEY (`data_id`) REFERENCES `data` (`id`) ON UPDATE NO ACTION ON DELETE NO ACTION,
@@ -78,10 +78,10 @@ CREATE TABLE IF NOT EXISTS `task_inputs`
 (
     `task_id`              BINARY(16)   NOT NULL,
     `position`             INT UNSIGNED NOT NULL,
-    `type`                 VARCHAR(64)  NOT NULL,
+    `type`                 VARCHAR(256)  NOT NULL,
     `output_task_id`       BINARY(16),
     `output_task_position` INT UNSIGNED,
-    `value`                VARBINARY(64), -- Use VARBINARY for all types of values
+    `value`                VARBINARY(999), -- Use VARBINARY for all types of values
     `data_id`              BINARY(16),
     CONSTRAINT `input_task_id` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
     CONSTRAINT `input_task_output_match` FOREIGN KEY (`output_task_id`, `output_task_position`) REFERENCES task_outputs (`task_id`, `position`) ON UPDATE NO ACTION ON DELETE SET NULL,


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description

The size of type and value task input/output is set to 64 and 256, while size of data is set to 256. These numbers are too small for real-world production.

This pr also increases the above mentioned sizes. Fixes #68.



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* [ ] GitHub workflows pass
* [x] Unit tests pass in dev container
* [x] Integration tests pass in dev container



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased the storage capacity for various data fields, allowing the system to handle larger data entries and improve overall flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->