### PR TITLE
refactor: Remove unused scheduler state

### DIFF
--- a/src/spider/scheduler/scheduler.cpp
+++ b/src/spider/scheduler/scheduler.cpp
@@ -111,10 +111,8 @@ auto heartbeat_loop(
 
 auto cleanup_loop(
         std::shared_ptr<spider::core::StorageFactory> const& storage_factory,
-        std::shared_ptr<spider::core::MetadataStorage> const& metadata_store,
         std::shared_ptr<spider::core::DataStorage> const& data_store,
-        spider::core::Scheduler const& scheduler,
-        spider::core::StopToken& stop_token
+        spider::core::StopToken const& stop_token
 ) -> void {
     while (!stop_token.stop_requested()) {
         std::this_thread::sleep_for(std::chrono::seconds(cCleanupInterval));
@@ -131,25 +129,7 @@ auto cleanup_loop(
         auto conn = std::move(std::get<std::unique_ptr<spider::core::StorageConnection>>(conn_result
         ));
 
-        spider::core::StorageErr err
-                = metadata_store->set_scheduler_state(*conn, scheduler.get_id(), "gc");
-        if (!err.success()) {
-            spdlog::error("Failed to set scheduler state to gc: {}", err.description);
-            continue;
-        }
         data_store->remove_dangling_data(*conn);
-        for (size_t i = 0; i < cRetryCount; ++i) {
-            err = metadata_store->set_scheduler_state(*conn, scheduler.get_id(), "normal");
-            if (!err.success()) {
-                spdlog::error("Failed to set scheduler state to normal: {}", err.description);
-                if (i >= cRetryCount - 1) {
-                    stop_token.request_stop();
-                    return;
-                }
-            } else {
-                break;
-            }
-        }
         spdlog::debug("Finished cleanup");
     }
 }
@@ -255,9 +235,7 @@ auto main(int argc, char** argv) -> int {
         std::thread cleanup_thread{
                 cleanup_loop,
                 std::cref(storage_factory),
-                std::cref(metadata_store),
                 std::cref(data_store),
-                std::cref(scheduler),
                 std::ref(stop_token)
         };
 

--- a/src/spider/storage/MetadataStorage.hpp
+++ b/src/spider/storage/MetadataStorage.hpp
@@ -116,21 +116,12 @@ public:
             double timeout,
             std::vector<boost::uuids::uuid>* ids
     ) -> StorageErr = 0;
-    virtual auto get_scheduler_state(
-            StorageConnection& conn,
-            boost::uuids::uuid id,
-            std::string* state
-    ) -> StorageErr = 0;
+
     virtual auto get_scheduler_addr(
             StorageConnection& conn,
             boost::uuids::uuid id,
             std::string* addr,
             int* port
-    ) -> StorageErr = 0;
-    virtual auto set_scheduler_state(
-            StorageConnection& conn,
-            boost::uuids::uuid id,
-            std::string const& state
     ) -> StorageErr = 0;
 };
 

--- a/src/spider/storage/mysql/MySqlStorage.cpp
+++ b/src/spider/storage/mysql/MySqlStorage.cpp
@@ -1845,37 +1845,6 @@ auto MySqlMetadataStorage::heartbeat_timeout(
     return StorageErr{};
 }
 
-auto MySqlMetadataStorage::get_scheduler_state(
-        StorageConnection& conn,
-        boost::uuids::uuid id,
-        std::string* state
-) -> StorageErr {
-    try {
-        std::unique_ptr<sql::PreparedStatement> statement(
-                static_cast<MySqlConnection&>(conn)->prepareStatement(
-                        "SELECT `state` FROM `schedulers` WHERE `id` = ?"
-                )
-        );
-        sql::bytes id_bytes = uuid_get_bytes(id);
-        statement->setBytes(1, &id_bytes);
-        std::unique_ptr<sql::ResultSet> res(statement->executeQuery());
-        if (res->rowsCount() == 0) {
-            static_cast<MySqlConnection&>(conn)->rollback();
-            return StorageErr{
-                    StorageErrType::KeyNotFoundErr,
-                    fmt::format("no scheduler with id {}", boost::uuids::to_string(id))
-            };
-        }
-        res->next();
-        *state = get_sql_string(res->getString(1));
-    } catch (sql::SQLException& e) {
-        static_cast<MySqlConnection&>(conn)->rollback();
-        return StorageErr{StorageErrType::OtherErr, e.what()};
-    }
-    static_cast<MySqlConnection&>(conn)->commit();
-    return StorageErr{};
-}
-
 auto MySqlMetadataStorage::get_scheduler_addr(
         StorageConnection& conn,
         boost::uuids::uuid id,
@@ -1901,29 +1870,6 @@ auto MySqlMetadataStorage::get_scheduler_addr(
         res->next();
         *addr = get_sql_string(res->getString(1));
         *port = res->getInt(2);
-    } catch (sql::SQLException& e) {
-        static_cast<MySqlConnection&>(conn)->rollback();
-        return StorageErr{StorageErrType::OtherErr, e.what()};
-    }
-    static_cast<MySqlConnection&>(conn)->commit();
-    return StorageErr{};
-}
-
-auto MySqlMetadataStorage::set_scheduler_state(
-        StorageConnection& conn,
-        boost::uuids::uuid id,
-        std::string const& state
-) -> StorageErr {
-    try {
-        std::unique_ptr<sql::PreparedStatement> statement(
-                static_cast<MySqlConnection&>(conn)->prepareStatement(
-                        "UPDATE `schedulers` SET `state` = ? WHERE `id` = ?"
-                )
-        );
-        statement->setString(1, state);
-        sql::bytes id_bytes = uuid_get_bytes(id);
-        statement->setBytes(2, &id_bytes);
-        statement->executeUpdate();
     } catch (sql::SQLException& e) {
         static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};

--- a/src/spider/storage/mysql/MySqlStorage.hpp
+++ b/src/spider/storage/mysql/MySqlStorage.hpp
@@ -111,18 +111,11 @@ public:
             double timeout,
             std::vector<boost::uuids::uuid>* ids
     ) -> StorageErr override;
-    auto get_scheduler_state(StorageConnection& conn, boost::uuids::uuid id, std::string* state)
-            -> StorageErr override;
     auto get_scheduler_addr(
             StorageConnection& conn,
             boost::uuids::uuid id,
             std::string* addr,
             int* port
-    ) -> StorageErr override;
-    auto set_scheduler_state(
-            StorageConnection& conn,
-            boost::uuids::uuid id,
-            std::string const& state
     ) -> StorageErr override;
 
 private:

--- a/src/spider/storage/mysql/mysql_stmt.hpp
+++ b/src/spider/storage/mysql/mysql_stmt.hpp
@@ -17,7 +17,6 @@ std::string const cCreateSchedulerTable = R"(CREATE TABLE IF NOT EXISTS `schedul
     `id` BINARY(16) NOT NULL,
     `address` VARCHAR(40) NOT NULL,
     `port` INT UNSIGNED NOT NULL,
-    `state` ENUM('normal', 'recovery', 'gc') NOT NULL,
     CONSTRAINT `scheduler_driver_id` FOREIGN KEY (`id`) REFERENCES `drivers` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
     PRIMARY KEY (`id`)
 ))";

--- a/tests/storage/test-MetadataStorage.cpp
+++ b/tests/storage/test-MetadataStorage.cpp
@@ -72,11 +72,7 @@ TEMPLATE_LIST_TEST_CASE("Driver heartbeat", "[storage]", spider::test::StorageFa
     }));
 }
 
-TEMPLATE_LIST_TEST_CASE(
-        "Scheduler state and addr",
-        "[storage]",
-        spider::test::StorageFactoryTypeList
-) {
+TEMPLATE_LIST_TEST_CASE("Scheduler addr", "[storage]", spider::test::StorageFactoryTypeList) {
     std::unique_ptr<spider::core::StorageFactory> storage_factory
             = spider::test::create_storage_factory<TestType>();
     std::unique_ptr<spider::core::MetadataStorage> storage
@@ -105,20 +101,6 @@ TEMPLATE_LIST_TEST_CASE(
     // Get non-exist scheduler should fail
     REQUIRE(spider::core::StorageErrType::KeyNotFoundErr
             == storage->get_scheduler_addr(*conn, gen(), &addr_res, &port_res).type);
-
-    // Get default state
-    std::string state_res;
-    REQUIRE(storage->get_scheduler_state(*conn, scheduler_id, &state_res).success());
-    REQUIRE(state_res == "normal");
-    state_res.clear();
-
-    // Update scheduler state should succeed
-    std::string state = "recovery";
-    REQUIRE(storage->set_scheduler_state(*conn, scheduler_id, state).success());
-
-    // Get new state
-    REQUIRE(storage->get_scheduler_state(*conn, scheduler_id, &state_res).success());
-    REQUIRE(state_res == state);
 }
 
 TEMPLATE_LIST_TEST_CASE(

--- a/tools/scripts/storage/init_db.sql
+++ b/tools/scripts/storage/init_db.sql
@@ -9,7 +9,6 @@ CREATE TABLE IF NOT EXISTS `schedulers`
     `id`      BINARY(16)                        NOT NULL,
     `address` VARCHAR(40)                       NOT NULL,
     `port`    INT UNSIGNED                      NOT NULL,
-    `state`   ENUM ('normal', 'recovery', 'gc') NOT NULL,
     CONSTRAINT `scheduler_driver_id` FOREIGN KEY (`id`) REFERENCES `drivers` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
     PRIMARY KEY (`id`)
 );
@@ -105,6 +104,16 @@ CREATE TABLE IF NOT EXISTS `task_instances`
     `start_time` TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     CONSTRAINT `instance_task_id` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
     PRIMARY KEY (`id`)
+);
+
+CREATE TABLE IF NOT EXISTS `scheduler_leases`
+(
+    `scheduler_id` BINARY(16) NOT NULL,
+    `task_id`      BINARY(16) NOT NULL,
+    `lease_time`   TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT `lease_scheduler_id` FOREIGN KEY (`scheduler_id`) REFERENCES `schedulers` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+    CONSTRAINT `lease_task_id` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+    INDEX (`scheduler_id`)
 );
 
 CREATE TABLE IF NOT EXISTS `data_locality`


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description

In early design, scheduler has three states: normal, gc and recovery. However, this design has been ditched a long time ago. Now the scheduler does not have any state so it can serves schedule task request all the time, and gc and recovery are performed in another thread. This pr removes the codes and tests related to the scheduler state.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* [ ] Github workflows pass
* [x] Unite tests pass in dev container
* [x] Integration tests pass in dev container



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
