### PR TITLE
fix(io): Check correct variable when reading msgpack from a socket.

### DIFF
--- a/src/spider/io/msgpack_message.cpp
+++ b/src/spider/io/msgpack_message.cpp
@@ -242,7 +242,7 @@ auto receive_message_async(std::reference_wrapper<boost::asio::ip::tcp::socket> 
             boost::asio::as_tuple(boost::asio::use_awaitable)
     );
     if (body_ec) {
-        if (boost::asio::error::eof != body_size_ec) {
+        if (boost::asio::error::eof != body_ec) {
             spdlog::error(
                     "Cannot read message body size or body from socket {}: {}",
                     body_ec.value(),


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description

This pr fixes the wrong variable in `msgpack` message error handling.



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* [ ] GitHub workflows pass
* [x] Unit tests pass in dev container
* [x] Integration tests pass in dev container



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error detection and reporting during asynchronous operations, contributing to more reliable processing in error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->