### PR TITLE
ci: Use parallelized clang-tidy task from `yscope-dev-utils`.

### DIFF
--- a/.github/workflows/code-linting-checks.yaml
+++ b/.github/workflows/code-linting-checks.yaml
@@ -49,4 +49,4 @@ jobs:
         timeout-minutes: 10
         run: "task deps:lib_install"
 
-      - run: "task lint:check"
+      - run: "task lint:check -C $(nproc)"

--- a/lint-tasks.yaml
+++ b/lint-tasks.yaml
@@ -79,36 +79,21 @@ tasks:
     # When we eventually determine which errors can be safely fixed, we'll allow clang-tidy to
     # fix them.
     aliases: ["cpp-static-fix"]
-    sources:
-      - "{{.G_LINT_VENV_CHECKSUM_FILE}}"
-      - "{{.G_EXAMPLES_DIR}}/**/*.cpp"
-      - "{{.G_EXAMPLES_DIR}}/**/*.h"
-      - "{{.G_EXAMPLES_DIR}}/**/*.hpp"
-      - "{{.G_SRC_SPIDER_DIR}}/**/*.cpp"
-      - "{{.G_SRC_SPIDER_DIR}}/**/*.h"
-      - "{{.G_SRC_SPIDER_DIR}}/**/*.hpp"
-      - "{{.G_TEST_DIR}}/**/*.cpp"
-      - "{{.G_TEST_DIR}}/**/*.h"
-      - "{{.G_TEST_DIR}}/**/*.hpp"
-      - "{{.G_SPIDER_CMAKE_CACHE}}"
-      - "{{.G_SPIDER_COMPILE_COMMANDS_DB}}"
-      - "{{.TASKFILE}}"
-      - "taskfile.yaml"
-      - "tools/yscope-dev-utils/exports/lint-configs/.clang-tidy"
+    sources: *cpp_source_files
     deps: [":config-cmake-project", "cpp-configs", "venv"]
     cmds:
-      - task: "clang-tidy"
+      - task: ":utils:cpp-lint:clang-tidy-find"
         vars:
-          FLAGS: "--config-file=.clang-tidy -p {{.G_SPIDER_COMPILE_COMMANDS_DB}}"
-          SRC_DIR: "{{.G_SRC_SPIDER_DIR}}"
-      - task: "clang-tidy"
-        vars:
-          FLAGS: "--config-file=.clang-tidy -p {{.G_SPIDER_COMPILE_COMMANDS_DB}}"
-          SRC_DIR: "{{.G_TEST_DIR}}"
-      - task: "clang-tidy"
-        vars:
-          FLAGS: "--config-file=.clang-tidy -p {{.G_EXAMPLES_COMPILE_COMMANDS_DB}}"
-          SRC_DIR: "{{.G_EXAMPLES_DIR}}"
+          FLAGS:
+            - "--config-file '{{.ROOT_DIR}}/.clang-tidy'"
+            - "-p '{{.G_SPIDER_COMPILE_COMMANDS_DB}}'"
+          INCLUDE_PATTERNS:
+            - "{{.G_EXAMPLES_DIR}}/**"
+            - "{{.G_SRC_SPIDER_DIR}}/**"
+            - "{{.G_TEST_DIR}}/**"
+          OUTPUT_DIR: "{{.G_LINT_CLANG_TIDY_DIR}}"
+          ROOT_PATHS: *cpp_source_files
+          VENV_DIR: "{{.G_LINT_VENV_DIR}}"
 
   py-check:
     cmds:


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description

Currently a run of clang-tidy on all files take at least 70 minutes in GitHub workflow. This pr change the lint task file to use the parallelized clang-tidy provided by latest `yscope-dev-utils`.



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* [ ] GitHub workflows pass



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced internal quality assurance by optimising concurrent execution to better utilise system resources.
  - Streamlined configuration of automated inspections to improve overall efficiency and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->