### PR TITLE
fix(lint): Correct glob pattern to recursively match all files.

### DIFF
--- a/lint-tasks.yaml
+++ b/lint-tasks.yaml
@@ -50,9 +50,9 @@ tasks:
       - "{{.ROOT_DIR}}/.clang-tidy"
       - "{{.TASKFILE}}"
       - "{{.G_SRC_SPIDER_DIR}}/.clang-format"
-      - "{{.G_EXAMPLES_DIR}}/**"
-      - "{{.G_SRC_SPIDER_DIR}}/**"
-      - "{{.G_TEST_DIR}}/**"
+      - "{{.G_EXAMPLES_DIR}}/**/*"
+      - "{{.G_SRC_SPIDER_DIR}}/**/*"
+      - "{{.G_TEST_DIR}}/**/*"
     deps: ["cpp-configs", "venv"]
     cmds:
       - task: ":utils:cpp-lint:clang-format"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description

This pr fixes the bug that `cpp-format-check` and `cpp-format-fix` tasks are not re-executed on source file change.

The current `sources` for `cpp-format-check` uses `dir/**` to match for all files recursively under `dir`. However, in [`go-zglob`](https://github.com/mattn/go-zglob), used by [`go-task`](https://taskfile.dev/), this glob only matches all first level entries under `dir`, while `dir/**/*` matches entries of all levels under `dir`.

This pr changes the glob matching so that all source files are included as `sources` of the tasks.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
* [x] `cpp-format-check` and `cpp-format-fix` are re-executed on source file change.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced file scanning within nested directories for automated quality checks, ensuring more comprehensive coverage without impacting user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->