### PR TITLE
build(deps): Update yscope-dev-utils and migrate dependencies from submodules to task-based installations.

### DIFF
--- a/.github/workflows/code-linting-checks.yaml
+++ b/.github/workflows/code-linting-checks.yaml
@@ -24,6 +24,8 @@ jobs:
         run: "rm '/usr/local/bin/cmake'"
 
       - uses: "actions/checkout@v4"
+        with:
+          submodules: "recursive"
 
       - uses: "actions/setup-python@v5"
         with:

--- a/.github/workflows/code-linting-checks.yaml
+++ b/.github/workflows/code-linting-checks.yaml
@@ -24,8 +24,6 @@ jobs:
         run: "rm '/usr/local/bin/cmake'"
 
       - uses: "actions/checkout@v4"
-        with:
-          submodules: "recursive"
 
       - uses: "actions/setup-python@v5"
         with:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -27,8 +27,6 @@ jobs:
         run: "rm '/usr/local/bin/cmake'"
 
       - uses: "actions/checkout@v4"
-        with:
-          submodules: "recursive"
 
       - uses: "actions/setup-python@v5"
         with:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -27,6 +27,8 @@ jobs:
         run: "rm '/usr/local/bin/cmake'"
 
       - uses: "actions/checkout@v4"
+        with:
+          submodules: "recursive"
 
       - uses: "actions/setup-python@v5"
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tools/yscope-dev-utils"]
+	path = tools/yscope-dev-utils
+	url = https://github.com/y-scope/yscope-dev-utils.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "tools/yscope-dev-utils"]
-	path = tools/yscope-dev-utils
-	url = https://github.com/y-scope/yscope-dev-utils.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "tools/yscope-dev-utils"]
 	path = tools/yscope-dev-utils
 	url = https://github.com/y-scope/yscope-dev-utils.git
-[submodule "submodules/Catch2"]
-	path = submodules/Catch2
-	url = https://github.com/catchorg/Catch2.git
 [submodule "submodules/abseil-cpp"]
 	path = submodules/abseil-cpp
 	url = https://github.com/abseil/abseil-cpp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "tools/yscope-dev-utils"]
 	path = tools/yscope-dev-utils
 	url = https://github.com/y-scope/yscope-dev-utils.git
-[submodule "submodules/abseil-cpp"]
-	path = submodules/abseil-cpp
-	url = https://github.com/abseil/abseil-cpp.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,11 @@ else()
 endif()
 message(STATUS "Building using ${SPIDER_LIBS_STRING} libraries")
 
+if(PROJECT_IS_TOP_LEVEL)
+    # Include dependency settings if the project isn't being included as a subproject.
+    include("build/deps/cmake-settings/all.cmake")
+endif()
+
 # Find and setup Boost Library
 if(SPIDER_USE_STATIC_LIBS)
     set(Boost_USE_STATIC_LIBS ON)
@@ -155,9 +160,6 @@ if(msgpack-cxx_FOUND)
 else()
     message(FATAL_ERROR "Could not find msgpack-cxx")
 endif()
-
-# Include dependency settings.
-include("build/deps/cmake-settings/all.cmake")
 
 find_package(outcome REQUIRED)
 if(outcome_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,7 @@ else()
 endif()
 
 # Include dependency settings.
-include("build/deps/cmake-settings/settings.cmake")
+include("build/deps/cmake-settings/all.cmake")
 
 find_package(outcome REQUIRED)
 if(outcome_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,12 +156,26 @@ else()
     message(FATAL_ERROR "Could not find msgpack-cxx")
 endif()
 
+# Include dependency settings.
+include("build/deps/cmake-settings/settings.cmake")
+
+find_package(outcome REQUIRED)
+if(outcome_FOUND)
+    message(STATUS "Found outcome.")
+else()
+    message(FATAL_ERROR "Could not find libraries for outcome.")
+endif()
+
+find_package(Catch2 3.8.0 REQUIRED)
+if(Catch2_FOUND)
+    message(STATUS "Found Catch2 ${Catch2_VERSION}.")
+else()
+    message(FATAL_ERROR "Could not find libraries for Catch2.")
+endif()
+
 # Add abseil-cpp
 set(ABSL_PROPAGATE_CXX_STD ON)
 add_subdirectory(submodules/abseil-cpp)
-
-# Add catch2
-add_subdirectory(submodules/Catch2)
 
 find_package(Threads REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,9 +173,14 @@ else()
     message(FATAL_ERROR "Could not find libraries for Catch2.")
 endif()
 
-# Add abseil-cpp
+# Add abseil
 set(ABSL_PROPAGATE_CXX_STD ON)
-add_subdirectory(submodules/abseil-cpp)
+find_package(absl REQUIRED)
+if(absl_FOUND)
+    message(STATUS "Found abseil ${absl_VERSION}.")
+else()
+    message(FATAL_ERROR "Could not find libraries for abseil.")
+endif()
 
 find_package(Threads REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,13 @@ else()
     message(FATAL_ERROR "Could not find libraries for abseil.")
 endif()
 
+# Add ystdlib-cpp
+add_subdirectory(
+    "${SPIDER_YSTDLIB_SOURCE_DIRECTORY}"
+    "${CMAKE_BINARY_DIR}/ystdlib"
+    EXCLUDE_FROM_ALL
+)
+
 find_package(Threads REQUIRED)
 
 add_subdirectory(src/spider)

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Follow the steps below to develop and contribute to the project.
 * [Task] 3.40.0 or higher
 
 ## Set up
-Initialize and update submodules:
+Run dependency installation task:
 ```shell
-git submodule update --init --recursive
+task deps:dep_install
 ```
 
 Set up the config files for our C++ linting tools:

--- a/dep-tasks.yaml
+++ b/dep-tasks.yaml
@@ -11,6 +11,8 @@ vars:
   G_OUTCOME_WORK_DIR: "{{.G_DEPS_DIR}}/{{.G_OUTCOME_LIB_NAME}}"
   G_QUICKCPPLIB_LIB_NAME: "quickcpplib"
   G_QUICKCPPLIB_WORK_DIR: "{{.G_DEPS_DIR}}/{{.G_QUICKCPPLIB_LIB_NAME}}"
+  G_YSTDLIB_LIB_NAME: "ystdlib"
+  G_YSTDLIB_WORK_DIR: "{{.G_DEPS_DIR}}/{{.G_YSTDLIB_LIB_NAME}}"
 
 tasks:
 
@@ -51,6 +53,7 @@ tasks:
       - task: "install-abseil"
       - task: "install-Catch2"
       - task: "install-outcome"
+      - task: "download-ystdlib"
 
   install-all-finish:
     internal: true
@@ -152,3 +155,17 @@ tasks:
         vars:
           NAME: "{{.G_QUICKCPPLIB_LIB_NAME}}"
           INSTALL_PREFIX: "{{.G_QUICKCPPLIB_WORK_DIR}}/{{.G_QUICKCPPLIB_LIB_NAME}}-install"
+
+  download-ystdlib:
+    internal: true
+    run: "once"
+    cmds:
+      - task: ":utils:remote:download-and-extract-tar"
+        vars:
+          FILE_SHA256: "d3fc9804eacb3ee4f156ae0ca37151cb04847580"
+          OUTPUT_DIR: "{{.G_YSTDLIB_WORK_DIR}}/{{.G_YSTDLIB_LIB_NAME}}-src"
+          URL: "https://github.com/y-scope/ystdlib-cpp/archive/d3fc980.tar.gz"
+      - >-
+        echo "set(
+        SPIDER_YSTDLIB_SOURCE_DIRECTORY \"{{.G_YSTDLIB_WORK_DIR}}/{{.G_YSTDLIB_LIB_NAME}}-src\"
+        )" >> "{{.G_DEPS_CMAKE_SETTINGS_DIR}}/{{.G_YSTDLIB_LIB_NAME}}.cmake"

--- a/dep-tasks.yaml
+++ b/dep-tasks.yaml
@@ -3,6 +3,8 @@ version: "3"
 vars:
   G_SCRIPT_DIR: "{{.ROOT_DIR}}/tools/scripts"
 
+  G_ABSEIL_LIB_NAME: "abseil"
+  G_ABSEIL_WORK_DIR: "{{.G_DEPS_DIR}}/{{.G_ABSEIL_LIB_NAME}}"
   G_CATCH2_LIB_NAME: "Catch2"
   G_CATCH2_WORK_DIR: "{{.G_DEPS_DIR}}/{{.G_CATCH2_LIB_NAME}}"
   G_OUTCOME_LIB_NAME: "outcome"
@@ -46,8 +48,9 @@ tasks:
   install-all-run:
     internal: true
     deps:
-      - "install-Catch2"
-      - "install-outcome"
+      - task: "install-abseil"
+      - task: "install-Catch2"
+      - task: "install-outcome"
 
   install-all-finish:
     internal: true
@@ -73,6 +76,21 @@ tasks:
           CACHE PATH
           \"Path to {{.NAME}} settings\"
         )" >> "{{.G_DEPS_CMAKE_SETTINGS_DIR}}/{{.NAME}}.cmake"
+
+  install-abseil:
+    internal: true
+    run: "once"
+    cmds:
+      - task: ":utils:cmake:install-remote-tar"
+        vars:
+          NAME: "{{.G_ABSEIL_LIB_NAME}}"
+          WORK_DIR: "{{.G_ABSEIL_WORK_DIR}}"
+          FILE_SHA256: "b396401fd29e2e679cace77867481d388c807671dc2acc602a0259eeb79b7811"
+          URL: "https://github.com/abseil/abseil-cpp/archive/refs/tags/20250127.1.tar.gz"
+      - task: "add-package-root-to-cmake-settings"
+        vars:
+          NAME: "{{.G_ABSEIL_LIB_NAME}}"
+          INSTALL_PREFIX: "{{.G_ABSEIL_WORK_DIR}}/{{.G_ABSEIL_LIB_NAME}}-install"
 
   install-Catch2:
     internal: true

--- a/dep-tasks.yaml
+++ b/dep-tasks.yaml
@@ -37,15 +37,10 @@ tasks:
 
   dep_install:
     cmds:
-      - task: "install-all-init"
-      - task: "install-all-run"
-      - task: "install-all-finish"
-
-  install-all-init:
-    internal: true
-    cmds:
-      - "rm -rf {{.G_DEPS_CMAKE_SETTINGS_DIR}}"
-      - "mkdir -p {{.G_DEPS_CMAKE_SETTINGS_DIR}}"
+      - task: ":utils:cmake:install-deps-and-generate-settings"
+        vars:
+          CMAKE_SETTINGS_DIR: "{{.G_DEPS_CMAKE_SETTINGS_DIR}}"
+          DEP_TASK: "deps:install-all-run"
 
   install-all-run:
     internal: true
@@ -54,16 +49,6 @@ tasks:
       - task: "install-Catch2"
       - task: "install-outcome"
       - task: "download-ystdlib"
-
-  install-all-finish:
-    internal: true
-    cmds:
-      - >-
-        for file in {{.G_DEPS_CMAKE_SETTINGS_DIR}}/*.cmake; do
-          if [ "$file" != "{{.G_DEPS_CMAKE_SETTINGS_FILE}}" ]; then
-            echo "include(\"$file\")" >> "{{.G_DEPS_CMAKE_SETTINGS_FILE}}";
-          fi
-        done
 
   add-package-root-to-cmake-settings:
     internal: true
@@ -90,12 +75,9 @@ tasks:
           WORK_DIR: "{{.G_ABSEIL_WORK_DIR}}"
           FILE_SHA256: "b396401fd29e2e679cace77867481d388c807671dc2acc602a0259eeb79b7811"
           URL: "https://github.com/abseil/abseil-cpp/archive/refs/tags/20250127.1.tar.gz"
+          CMAKE_SETTINGS_DIR: "{{.G_DEPS_CMAKE_SETTINGS_DIR}}"
           GEN_ARGS:
             - "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
-      - task: "add-package-root-to-cmake-settings"
-        vars:
-          NAME: "{{.G_ABSEIL_LIB_NAME}}"
-          INSTALL_PREFIX: "{{.G_ABSEIL_WORK_DIR}}/{{.G_ABSEIL_LIB_NAME}}-install"
 
   install-Catch2:
     internal: true
@@ -107,12 +89,9 @@ tasks:
           WORK_DIR: "{{.G_CATCH2_WORK_DIR}}"
           FILE_SHA256: "1ab2de20460d4641553addfdfe6acd4109d871d5531f8f519a52ea4926303087"
           URL: "https://github.com/catchorg/Catch2/archive/refs/tags/v3.8.0.tar.gz"
+          CMAKE_SETTINGS_DIR: "{{.G_DEPS_CMAKE_SETTINGS_DIR}}"
           GEN_ARGS:
             - "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
-      - task: "add-package-root-to-cmake-settings"
-        vars:
-          NAME: "{{.G_CATCH2_LIB_NAME}}"
-          INSTALL_PREFIX: "{{.G_CATCH2_WORK_DIR}}/{{.G_CATCH2_LIB_NAME}}-install"
 
   install-outcome:
     internal: true
@@ -126,16 +105,13 @@ tasks:
           WORK_DIR: "{{.G_OUTCOME_WORK_DIR}}"
           FILE_SHA256: "0382248cbb00806ce4b5f3ce6939797dc3b597c85fd3531614959e31ef488b39"
           URL: "https://github.com/ned14/outcome/archive/refs/tags/v2.2.11.tar.gz"
+          CMAKE_SETTINGS_DIR: "{{.G_DEPS_CMAKE_SETTINGS_DIR}}"
           GEN_ARGS:
             - "-C {{.G_DEPS_CMAKE_SETTINGS_DIR}}/{{.G_QUICKCPPLIB_LIB_NAME}}.cmake"
             - "-DBUILD_TESTING=OFF"
             - "-DCMAKE_BUILD_TYPE=Release"
             - "-DCMAKE_POLICY_DEFAULT_CMP0074=NEW"
             - "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
-      - task: "add-package-root-to-cmake-settings"
-        vars:
-          NAME: "{{.G_OUTCOME_LIB_NAME}}"
-          INSTALL_PREFIX: "{{.G_OUTCOME_WORK_DIR}}/{{.G_OUTCOME_LIB_NAME}}-install"
 
   install-quickcpplib:
     internal: true
@@ -147,14 +123,11 @@ tasks:
           WORK_DIR: "{{.G_QUICKCPPLIB_WORK_DIR}}"
           FILE_SHA256: "5d4c9b2d6fa177d3fb14f3fe3086867e43b44f4a7a944eb10ee4616b2b0f3c05"
           URL: "https://github.com/ned14/quickcpplib/archive/f3e452e.tar.gz"
+          CMAKE_SETTINGS_DIR: "{{.G_DEPS_CMAKE_SETTINGS_DIR}}"
           GEN_ARGS:
             - "-DBUILD_TESTING=OFF"
             - "-DCMAKE_BUILD_TYPE=Release"
             - "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
-      - task: "add-package-root-to-cmake-settings"
-        vars:
-          NAME: "{{.G_QUICKCPPLIB_LIB_NAME}}"
-          INSTALL_PREFIX: "{{.G_QUICKCPPLIB_WORK_DIR}}/{{.G_QUICKCPPLIB_LIB_NAME}}-install"
 
   download-ystdlib:
     internal: true

--- a/dep-tasks.yaml
+++ b/dep-tasks.yaml
@@ -87,6 +87,8 @@ tasks:
           WORK_DIR: "{{.G_ABSEIL_WORK_DIR}}"
           FILE_SHA256: "b396401fd29e2e679cace77867481d388c807671dc2acc602a0259eeb79b7811"
           URL: "https://github.com/abseil/abseil-cpp/archive/refs/tags/20250127.1.tar.gz"
+          GEN_ARGS:
+            - "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
       - task: "add-package-root-to-cmake-settings"
         vars:
           NAME: "{{.G_ABSEIL_LIB_NAME}}"
@@ -102,6 +104,8 @@ tasks:
           WORK_DIR: "{{.G_CATCH2_WORK_DIR}}"
           FILE_SHA256: "1ab2de20460d4641553addfdfe6acd4109d871d5531f8f519a52ea4926303087"
           URL: "https://github.com/catchorg/Catch2/archive/refs/tags/v3.8.0.tar.gz"
+          GEN_ARGS:
+            - "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
       - task: "add-package-root-to-cmake-settings"
         vars:
           NAME: "{{.G_CATCH2_LIB_NAME}}"
@@ -124,6 +128,7 @@ tasks:
             - "-DBUILD_TESTING=OFF"
             - "-DCMAKE_BUILD_TYPE=Release"
             - "-DCMAKE_POLICY_DEFAULT_CMP0074=NEW"
+            - "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
       - task: "add-package-root-to-cmake-settings"
         vars:
           NAME: "{{.G_OUTCOME_LIB_NAME}}"
@@ -142,6 +147,7 @@ tasks:
           GEN_ARGS:
             - "-DBUILD_TESTING=OFF"
             - "-DCMAKE_BUILD_TYPE=Release"
+            - "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
       - task: "add-package-root-to-cmake-settings"
         vars:
           NAME: "{{.G_QUICKCPPLIB_LIB_NAME}}"

--- a/dep-tasks.yaml
+++ b/dep-tasks.yaml
@@ -21,6 +21,7 @@ tasks:
     dir: "{{.G_SCRIPT_DIR}}/lib_install/macOS"
     cmds:
       - "./install-lib.sh"
+      - task: "dep_install"
 
   lib_install_linux:
     internal: true
@@ -28,6 +29,7 @@ tasks:
     dir: "{{.G_SCRIPT_DIR}}/lib_install/linux"
     cmds:
       - "./install-lib.sh"
+      - task: "dep_install"
 
   dep_install:
     cmds:

--- a/dep-tasks.yaml
+++ b/dep-tasks.yaml
@@ -3,17 +3,6 @@ version: "3"
 vars:
   G_SCRIPT_DIR: "{{.ROOT_DIR}}/tools/scripts"
 
-  G_ABSEIL_LIB_NAME: "absl"
-  G_ABSEIL_WORK_DIR: "{{.G_DEPS_DIR}}/{{.G_ABSEIL_LIB_NAME}}"
-  G_CATCH2_LIB_NAME: "Catch2"
-  G_CATCH2_WORK_DIR: "{{.G_DEPS_DIR}}/{{.G_CATCH2_LIB_NAME}}"
-  G_OUTCOME_LIB_NAME: "outcome"
-  G_OUTCOME_WORK_DIR: "{{.G_DEPS_DIR}}/{{.G_OUTCOME_LIB_NAME}}"
-  G_QUICKCPPLIB_LIB_NAME: "quickcpplib"
-  G_QUICKCPPLIB_WORK_DIR: "{{.G_DEPS_DIR}}/{{.G_QUICKCPPLIB_LIB_NAME}}"
-  G_YSTDLIB_LIB_NAME: "ystdlib"
-  G_YSTDLIB_WORK_DIR: "{{.G_DEPS_DIR}}/{{.G_YSTDLIB_LIB_NAME}}"
-
 tasks:
 
   lib_install:
@@ -56,8 +45,8 @@ tasks:
     cmds:
       - task: ":utils:cmake:install-remote-tar"
         vars:
-          NAME: "{{.G_ABSEIL_LIB_NAME}}"
-          WORK_DIR: "{{.G_ABSEIL_WORK_DIR}}"
+          NAME: "absl"
+          WORK_DIR: "{{.G_DEPS_DIR}}/absl"
           FILE_SHA256: "b396401fd29e2e679cace77867481d388c807671dc2acc602a0259eeb79b7811"
           URL: "https://github.com/abseil/abseil-cpp/archive/refs/tags/20250127.1.tar.gz"
           CMAKE_SETTINGS_DIR: "{{.G_DEPS_CMAKE_SETTINGS_DIR}}"
@@ -70,8 +59,8 @@ tasks:
     cmds:
       - task: ":utils:cmake:install-remote-tar"
         vars:
-          NAME: "{{.G_CATCH2_LIB_NAME}}"
-          WORK_DIR: "{{.G_CATCH2_WORK_DIR}}"
+          NAME: "Catch2"
+          WORK_DIR: "{{.G_DEPS_DIR}}/Catch2"
           FILE_SHA256: "1ab2de20460d4641553addfdfe6acd4109d871d5531f8f519a52ea4926303087"
           URL: "https://github.com/catchorg/Catch2/archive/refs/tags/v3.8.0.tar.gz"
           CMAKE_SETTINGS_DIR: "{{.G_DEPS_CMAKE_SETTINGS_DIR}}"
@@ -86,13 +75,13 @@ tasks:
     cmds:
       - task: ":utils:cmake:install-remote-tar"
         vars:
-          NAME: "{{.G_OUTCOME_LIB_NAME}}"
-          WORK_DIR: "{{.G_OUTCOME_WORK_DIR}}"
+          NAME: "outcome"
+          WORK_DIR: "{{.G_DEPS_DIR}}/outcome"
           FILE_SHA256: "0382248cbb00806ce4b5f3ce6939797dc3b597c85fd3531614959e31ef488b39"
           URL: "https://github.com/ned14/outcome/archive/refs/tags/v2.2.11.tar.gz"
           CMAKE_SETTINGS_DIR: "{{.G_DEPS_CMAKE_SETTINGS_DIR}}"
           GEN_ARGS:
-            - "-C {{.G_DEPS_CMAKE_SETTINGS_DIR}}/{{.G_QUICKCPPLIB_LIB_NAME}}.cmake"
+            - "-C {{.G_DEPS_CMAKE_SETTINGS_DIR}}/quickcpplib.cmake"
             - "-DBUILD_TESTING=OFF"
             - "-DCMAKE_BUILD_TYPE=Release"
             - "-DCMAKE_POLICY_DEFAULT_CMP0074=NEW"
@@ -104,8 +93,8 @@ tasks:
     cmds:
       - task: ":utils:cmake:install-remote-tar"
         vars:
-          NAME: "{{.G_QUICKCPPLIB_LIB_NAME}}"
-          WORK_DIR: "{{.G_QUICKCPPLIB_WORK_DIR}}"
+          NAME: "quickcpplib"
+          WORK_DIR: "{{.G_DEPS_DIR}}/quickcpplib"
           FILE_SHA256: "5d4c9b2d6fa177d3fb14f3fe3086867e43b44f4a7a944eb10ee4616b2b0f3c05"
           URL: "https://github.com/ned14/quickcpplib/archive/f3e452e.tar.gz"
           CMAKE_SETTINGS_DIR: "{{.G_DEPS_CMAKE_SETTINGS_DIR}}"
@@ -121,11 +110,11 @@ tasks:
       - task: ":utils:remote:download-and-extract-tar"
         vars:
           FILE_SHA256: "d3fc9804eacb3ee4f156ae0ca37151cb04847580"
-          OUTPUT_DIR: "{{.G_YSTDLIB_WORK_DIR}}/{{.G_YSTDLIB_LIB_NAME}}-src"
+          OUTPUT_DIR: "{{.G_DEPS_DIR}}/ystdlib/ystdlib-src"
           URL: "https://github.com/y-scope/ystdlib-cpp/archive/d3fc980.tar.gz"
       - |
-        cat <<EOF >> "{{.G_DEPS_CMAKE_SETTINGS_DIR}}/{{.G_YSTDLIB_LIB_NAME}}.cmake"
+        cat <<EOF >> "{{.G_DEPS_CMAKE_SETTINGS_DIR}}/ystdlib.cmake"
         set(
-        SPIDER_YSTDLIB_SOURCE_DIRECTORY "{{.G_YSTDLIB_WORK_DIR}}/{{.G_YSTDLIB_LIB_NAME}}-src"
+        SPIDER_YSTDLIB_SOURCE_DIRECTORY "{{.G_DEPS_DIR}}/ystdlib/ystdlib-src"
         )
         EOF

--- a/dep-tasks.yaml
+++ b/dep-tasks.yaml
@@ -50,21 +50,6 @@ tasks:
       - task: "install-outcome"
       - task: "download-ystdlib"
 
-  add-package-root-to-cmake-settings:
-    internal: true
-    requires:
-      vars:
-        - "NAME"
-        - "INSTALL_PREFIX"
-    cmds:
-      - >-
-        echo "set(
-          {{.NAME}}_ROOT
-          \"{{.INSTALL_PREFIX}}\"
-          CACHE PATH
-          \"Path to {{.NAME}} settings\"
-        )" >> "{{.G_DEPS_CMAKE_SETTINGS_DIR}}/{{.NAME}}.cmake"
-
   install-abseil:
     internal: true
     run: "once"
@@ -138,7 +123,9 @@ tasks:
           FILE_SHA256: "d3fc9804eacb3ee4f156ae0ca37151cb04847580"
           OUTPUT_DIR: "{{.G_YSTDLIB_WORK_DIR}}/{{.G_YSTDLIB_LIB_NAME}}-src"
           URL: "https://github.com/y-scope/ystdlib-cpp/archive/d3fc980.tar.gz"
-      - >-
-        echo "set(
-        SPIDER_YSTDLIB_SOURCE_DIRECTORY \"{{.G_YSTDLIB_WORK_DIR}}/{{.G_YSTDLIB_LIB_NAME}}-src\"
-        )" >> "{{.G_DEPS_CMAKE_SETTINGS_DIR}}/{{.G_YSTDLIB_LIB_NAME}}.cmake"
+      - |
+        cat <<EOF >> "{{.G_DEPS_CMAKE_SETTINGS_DIR}}/{{.G_YSTDLIB_LIB_NAME}}.cmake"
+        set(
+          SPIDER_YSTDLIB_SOURCE_DIRECTORY "{{.G_YSTDLIB_WORK_DIR}}/{{.G_YSTDLIB_LIB_NAME}}-src"
+        )
+        EOF

--- a/dep-tasks.yaml
+++ b/dep-tasks.yaml
@@ -3,6 +3,13 @@ version: "3"
 vars:
   G_SCRIPT_DIR: "{{.ROOT_DIR}}/tools/scripts"
 
+  G_CATCH2_LIB_NAME: "Catch2"
+  G_CATCH2_WORK_DIR: "{{.G_DEPS_DIR}}/{{.G_CATCH2_LIB_NAME}}"
+  G_OUTCOME_LIB_NAME: "outcome"
+  G_OUTCOME_WORK_DIR: "{{.G_DEPS_DIR}}/{{.G_OUTCOME_LIB_NAME}}"
+  G_QUICKCPPLIB_LIB_NAME: "quickcpplib"
+  G_QUICKCPPLIB_WORK_DIR: "{{.G_DEPS_DIR}}/{{.G_QUICKCPPLIB_LIB_NAME}}"
+
 tasks:
 
   lib_install:
@@ -21,3 +28,101 @@ tasks:
     dir: "{{.G_SCRIPT_DIR}}/lib_install/linux"
     cmds:
       - "./install-lib.sh"
+
+  dep_install:
+    cmds:
+      - task: "install-all-init"
+      - task: "install-all-run"
+      - task: "install-all-finish"
+
+  install-all-init:
+    internal: true
+    cmds:
+      - "rm -rf {{.G_DEPS_CMAKE_SETTINGS_DIR}}"
+      - "mkdir -p {{.G_DEPS_CMAKE_SETTINGS_DIR}}"
+
+  install-all-run:
+    internal: true
+    deps:
+      - "install-Catch2"
+      - "install-outcome"
+
+  install-all-finish:
+    internal: true
+    cmds:
+      - >-
+        for file in {{.G_DEPS_CMAKE_SETTINGS_DIR}}/*.cmake; do
+          if [ "$file" != "{{.G_DEPS_CMAKE_SETTINGS_FILE}}" ]; then
+            echo "include(\"$file\")" >> "{{.G_DEPS_CMAKE_SETTINGS_FILE}}";
+          fi
+        done
+
+  add-package-root-to-cmake-settings:
+    internal: true
+    requires:
+      vars:
+        - "NAME"
+        - "INSTALL_PREFIX"
+    cmds:
+      - >-
+        echo "set(
+          {{.NAME}}_ROOT
+          \"{{.INSTALL_PREFIX}}\"
+          CACHE PATH
+          \"Path to {{.NAME}} settings\"
+        )" >> "{{.G_DEPS_CMAKE_SETTINGS_DIR}}/{{.NAME}}.cmake"
+
+  install-Catch2:
+    internal: true
+    run: "once"
+    cmds:
+      - task: ":utils:cmake:install-remote-tar"
+        vars:
+          NAME: "{{.G_CATCH2_LIB_NAME}}"
+          WORK_DIR: "{{.G_CATCH2_WORK_DIR}}"
+          FILE_SHA256: "1ab2de20460d4641553addfdfe6acd4109d871d5531f8f519a52ea4926303087"
+          URL: "https://github.com/catchorg/Catch2/archive/refs/tags/v3.8.0.tar.gz"
+      - task: "add-package-root-to-cmake-settings"
+        vars:
+          NAME: "{{.G_CATCH2_LIB_NAME}}"
+          INSTALL_PREFIX: "{{.G_CATCH2_WORK_DIR}}/{{.G_CATCH2_LIB_NAME}}-install"
+
+  install-outcome:
+    internal: true
+    run: "once"
+    deps:
+      - "install-quickcpplib"
+    cmds:
+      - task: ":utils:cmake:install-remote-tar"
+        vars:
+          NAME: "{{.G_OUTCOME_LIB_NAME}}"
+          WORK_DIR: "{{.G_OUTCOME_WORK_DIR}}"
+          FILE_SHA256: "0382248cbb00806ce4b5f3ce6939797dc3b597c85fd3531614959e31ef488b39"
+          URL: "https://github.com/ned14/outcome/archive/refs/tags/v2.2.11.tar.gz"
+          GEN_ARGS:
+            - "-C {{.G_DEPS_CMAKE_SETTINGS_DIR}}/{{.G_QUICKCPPLIB_LIB_NAME}}.cmake"
+            - "-DBUILD_TESTING=OFF"
+            - "-DCMAKE_BUILD_TYPE=Release"
+            - "-DCMAKE_POLICY_DEFAULT_CMP0074=NEW"
+      - task: "add-package-root-to-cmake-settings"
+        vars:
+          NAME: "{{.G_OUTCOME_LIB_NAME}}"
+          INSTALL_PREFIX: "{{.G_OUTCOME_WORK_DIR}}/{{.G_OUTCOME_LIB_NAME}}-install"
+
+  install-quickcpplib:
+    internal: true
+    run: "once"
+    cmds:
+      - task: ":utils:cmake:install-remote-tar"
+        vars:
+          NAME: "{{.G_QUICKCPPLIB_LIB_NAME}}"
+          WORK_DIR: "{{.G_QUICKCPPLIB_WORK_DIR}}"
+          FILE_SHA256: "5d4c9b2d6fa177d3fb14f3fe3086867e43b44f4a7a944eb10ee4616b2b0f3c05"
+          URL: "https://github.com/ned14/quickcpplib/archive/f3e452e.tar.gz"
+          GEN_ARGS:
+            - "-DBUILD_TESTING=OFF"
+            - "-DCMAKE_BUILD_TYPE=Release"
+      - task: "add-package-root-to-cmake-settings"
+        vars:
+          NAME: "{{.G_QUICKCPPLIB_LIB_NAME}}"
+          INSTALL_PREFIX: "{{.G_QUICKCPPLIB_WORK_DIR}}/{{.G_QUICKCPPLIB_LIB_NAME}}-install"

--- a/dep-tasks.yaml
+++ b/dep-tasks.yaml
@@ -126,6 +126,6 @@ tasks:
       - |
         cat <<EOF >> "{{.G_DEPS_CMAKE_SETTINGS_DIR}}/{{.G_YSTDLIB_LIB_NAME}}.cmake"
         set(
-          SPIDER_YSTDLIB_SOURCE_DIRECTORY "{{.G_YSTDLIB_WORK_DIR}}/{{.G_YSTDLIB_LIB_NAME}}-src"
+        SPIDER_YSTDLIB_SOURCE_DIRECTORY "{{.G_YSTDLIB_WORK_DIR}}/{{.G_YSTDLIB_LIB_NAME}}-src"
         )
         EOF

--- a/dep-tasks.yaml
+++ b/dep-tasks.yaml
@@ -3,7 +3,7 @@ version: "3"
 vars:
   G_SCRIPT_DIR: "{{.ROOT_DIR}}/tools/scripts"
 
-  G_ABSEIL_LIB_NAME: "abseil"
+  G_ABSEIL_LIB_NAME: "absl"
   G_ABSEIL_WORK_DIR: "{{.G_DEPS_DIR}}/{{.G_ABSEIL_LIB_NAME}}"
   G_CATCH2_LIB_NAME: "Catch2"
   G_CATCH2_WORK_DIR: "{{.G_DEPS_DIR}}/{{.G_CATCH2_LIB_NAME}}"

--- a/examples/quick-start/CMakeLists.txt
+++ b/examples/quick-start/CMakeLists.txt
@@ -3,7 +3,7 @@ project(spider_getting_started)
 
 if(PROJECT_IS_TOP_LEVEL)
     # Include dependency settings if the project isn't being included as a subproject.
-    include("../../build/deps/cmake-settings/all.cmake")
+    include("${CMAKE_SOURCE_DIR}/../../build/deps/cmake-settings/all.cmake")
 endif()
 
 # Add the Spider library

--- a/examples/quick-start/CMakeLists.txt
+++ b/examples/quick-start/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.22.1)
 project(spider_getting_started)
 
+if(PROJECT_IS_TOP_LEVEL)
+    # Include dependency settings if the project isn't being included as a subproject.
+    include("../../build/deps/cmake-settings/all.cmake")
+endif()
+
 # Add the Spider library
 add_subdirectory(../../ spider EXCLUDE_FROM_ALL)
 

--- a/lint-tasks.yaml
+++ b/lint-tasks.yaml
@@ -88,9 +88,18 @@ tasks:
             - "--config-file '{{.ROOT_DIR}}/.clang-tidy'"
             - "-p '{{.G_SPIDER_COMPILE_COMMANDS_DB}}'"
           INCLUDE_PATTERNS:
-            - "{{.G_EXAMPLES_DIR}}/**"
             - "{{.G_SRC_SPIDER_DIR}}/**"
             - "{{.G_TEST_DIR}}/**"
+          OUTPUT_DIR: "{{.G_LINT_CLANG_TIDY_DIR}}"
+          ROOT_PATHS: *cpp_source_files
+          VENV_DIR: "{{.G_LINT_VENV_DIR}}"
+      - task: ":utils:cpp-lint:clang-tidy-find"
+        vars:
+          FLAGS:
+            - "--config-file '{{.ROOT_DIR}}/.clang-tidy'"
+            - "-p '{{.G_EXAMPLES_COMPILE_COMMANDS_DB}}'"
+          INCLUDE_PATTERNS:
+            - "{{.G_EXAMPLES_DIR}}/**"
           OUTPUT_DIR: "{{.G_LINT_CLANG_TIDY_DIR}}"
           ROOT_PATHS: *cpp_source_files
           VENV_DIR: "{{.G_LINT_VENV_DIR}}"

--- a/src/spider/.clang-format
+++ b/src/spider/.clang-format
@@ -10,7 +10,7 @@ IncludeCategories:
   # Ex:
   # - Regex: "<(fmt|spdlog)"
   #   Priority: 3
-  - Regex: "^<(absl|boost|catch2|fmt|mariadb|msgpack|spdlog)"
+  - Regex: "^<(absl|boost|catch2|fmt|mariadb|msgpack|spdlog|ystdlib)"
     Priority: 3
   # C system headers
   - Regex: "^<.+\\.h>"

--- a/src/spider/CMakeLists.txt
+++ b/src/spider/CMakeLists.txt
@@ -52,6 +52,7 @@ target_link_libraries(
         MariaDBClientCpp::MariaDBClientCpp
         msgpack-cxx
         spdlog::spdlog
+        ystdlib::error_handling
 )
 target_link_libraries(spider_core PRIVATE fmt::fmt)
 

--- a/src/spider/worker/DllLoader.cpp
+++ b/src/spider/worker/DllLoader.cpp
@@ -39,7 +39,7 @@ auto DllLoader::load_dll(std::string const& path_str) -> bool {
         auto const function_name_manager_func
                 = boost::dll::import_alias<core::FunctionNameManager&()>(
                         library,
-                        "function_name_manager_get_instance"
+                        "g_function_name_manager_get_instance"
                 );
         core::FunctionNameManager const& function_name_manager = function_name_manager_func();
         core::FunctionNameMap const& function_name_map

--- a/src/spider/worker/DllLoader.cpp
+++ b/src/spider/worker/DllLoader.cpp
@@ -25,7 +25,7 @@ auto DllLoader::load_dll(std::string const& path_str) -> bool {
 
         auto const function_manager_func = boost::dll::import_alias<core::FunctionManager&()>(
                 library,
-                "function_manager_get_instance"
+                "g_function_manager_get_instance"
         );
         core::FunctionManager const& function_manager = function_manager_func();
         core::FunctionMap const& function_map = function_manager.get_function_map();

--- a/src/spider/worker/FunctionManager.cpp
+++ b/src/spider/worker/FunctionManager.cpp
@@ -115,4 +115,4 @@ auto FunctionManager::get_function(std::string const& name) const -> Function co
 }  // namespace spider::core
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-BOOST_DLL_ALIAS(spider::core::FunctionManager::get_instance, function_manager_get_instance)
+BOOST_DLL_ALIAS(spider::core::FunctionManager::get_instance, g_function_manager_get_instance)

--- a/src/spider/worker/FunctionNameManager.cpp
+++ b/src/spider/worker/FunctionNameManager.cpp
@@ -22,5 +22,5 @@ auto FunctionNameManager::get_function_name(void const* ptr) const -> std::optio
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 BOOST_DLL_ALIAS(
         spider::core::FunctionNameManager::get_instance,
-        function_name_manager_get_instance
+        g_function_name_manager_get_instance
 );

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -20,6 +20,11 @@ vars:
   G_TEST_DIR: "{{.ROOT_DIR}}/tests"
   G_EXAMPLES_DIR: "{{.ROOT_DIR}}/examples"
 
+  G_DEPS_DIR: "{{.G_BUILD_DIR}}/deps"
+  # These should be kept in-sync with its usage in CMakeLists.txt
+  G_DEPS_CMAKE_SETTINGS_DIR: "{{.G_DEPS_DIR}}/cmake-settings"
+  G_DEPS_CMAKE_SETTINGS_FILE: "{{.G_DEPS_CMAKE_SETTINGS_DIR}}/settings.cmake"
+
 tasks:
   clean:
     cmds:


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description

`Spider` now uses git submodule to include dependencies, i.e. abseil and catch2. Adding dependencies uses `add_subdirectory` is not ideal, and it make build longer.

This pr uses tasks in [`yscope-dev-utils`](https://github.com/y-scope/yscope-dev-utils/) to install these dependencies.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* [x] Running `task:dep_install` installs the dependencies.
* [x] `Spider` builds and pass all unit tests and integration tests with new dependencies.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209987688828842

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated dependency management to use automated installation tasks instead of git submodules.
	- Removed abseil-cpp and Catch2 as submodules; dependencies are now handled via a new installation workflow.
	- Updated setup instructions in the documentation to reflect the new dependency installation process.
	- Added new dependency variables and settings for improved build configuration.
- **Style**
	- Updated code formatting rules to recognize ystdlib headers.
- **New Features**
	- Added ystdlib as a linked dependency for the core library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->