### PR TITLE
refactor(storage): Add state field to database job table.

### DIFF
--- a/src/spider/storage/mysql/mysql_stmt.hpp
+++ b/src/spider/storage/mysql/mysql_stmt.hpp
@@ -25,8 +25,10 @@ std::string const cCreateJobTable = R"(CREATE TABLE IF NOT EXISTS jobs (
     `id` BINARY(16) NOT NULL,
     `client_id` BINARY(16) NOT NULL,
     `creation_time` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    `state` ENUM('running', 'success', 'cancel', 'fail') NOT NULL DEFAULT 'running',
     KEY (`client_id`) USING BTREE,
     INDEX (`creation_time`),
+    INDEX(`state`),
     PRIMARY KEY (`id`)
 ))";
 
@@ -40,6 +42,8 @@ std::string const cCreateTaskTable = R"(CREATE TABLE IF NOT EXISTS tasks (
     `retry` INT UNSIGNED DEFAULT 0,
     `instance_id` BINARY(16),
     CONSTRAINT `task_job_id` FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+    INDEX (`state`),
+    INDEX (`func_name`),
     PRIMARY KEY (`id`)
 ))";
 

--- a/src/spider/storage/mysql/mysql_stmt.hpp
+++ b/src/spider/storage/mysql/mysql_stmt.hpp
@@ -27,8 +27,8 @@ std::string const cCreateJobTable = R"(CREATE TABLE IF NOT EXISTS jobs (
     `creation_time` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     `state` ENUM('running', 'success', 'cancel', 'fail') NOT NULL DEFAULT 'running',
     KEY (`client_id`) USING BTREE,
-    INDEX (`creation_time`),
-    INDEX(`state`),
+    INDEX idx_jobs_creation_time (`creation_time`),
+    INDEX idx_jobs_state (`state`),
     PRIMARY KEY (`id`)
 ))";
 

--- a/tools/scripts/storage/init_db.sql
+++ b/tools/scripts/storage/init_db.sql
@@ -19,7 +19,8 @@ CREATE TABLE IF NOT EXISTS jobs
     `creation_time` TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     `state`         ENUM ('running', 'success', 'fail', 'cancel') NOT NULL DEFAULT 'running',
     KEY (`client_id`) USING BTREE,
-    INDEX (`creation_time`),
+    INDEX idx_jobs_creation_time (`creation_time`),
+    INDEX idx_jobs_state (`state`),
     PRIMARY KEY (`id`)
 );
 CREATE TABLE IF NOT EXISTS tasks

--- a/tools/scripts/storage/init_db.sql
+++ b/tools/scripts/storage/init_db.sql
@@ -17,6 +17,7 @@ CREATE TABLE IF NOT EXISTS jobs
     `id`            BINARY(16) NOT NULL,
     `client_id`     BINARY(16) NOT NULL,
     `creation_time` TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    `state`         ENUM ('running', 'success', 'fail', 'cancel') NOT NULL DEFAULT 'running',
     KEY (`client_id`) USING BTREE,
     INDEX (`creation_time`),
     PRIMARY KEY (`id`)


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description

In MariaDB, only the `tasks` table stores the states of the tasks. The job status is inferred from the tasks' states. This is inefficient for jobs with large number of tasks.

This pr introduces a `state` column in `jobs` table and the updates and queries of it in storage.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* [x] GitHub workflows pass.
* [x] Unit tests pass in dev container.
* [x] Integration tests pass in dev container.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new job state column to improve job tracking and management.
- **Refactor**
	- Unified job state handling for more consistent and reliable job status updates.
- **Performance**
	- Introduced new database indexes to enhance query performance for job and task states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->