### PR TITLE
fix(storage): Always create a reference when getting data from storage (fixes #132).

### DIFF
--- a/src/spider/client/Driver.hpp
+++ b/src/spider/client/Driver.hpp
@@ -228,6 +228,8 @@ public:
 
         return Job<ReturnType>{
                 job_id,
+                Job<ReturnType>::JobSource::Driver,
+                m_id,
                 m_metadata_storage,
                 m_data_storage,
                 m_storage_factory,
@@ -291,6 +293,8 @@ public:
 
         return Job<ReturnType>{
                 job_id,
+                Job<ReturnType>::JobSource::Driver,
+                m_id,
                 m_metadata_storage,
                 m_data_storage,
                 m_storage_factory,

--- a/src/spider/client/Job.hpp
+++ b/src/spider/client/Job.hpp
@@ -256,14 +256,14 @@ private:
                         throw ConnectionException{fmt::format("Output data ID is missing")};
                     }
                     if (m_source == JobSource::Driver) {
-                        err = m_data_storage->get_data_driver(
+                        err = m_data_storage->get_driver_data(
                                 conn,
                                 m_source_id,
                                 optional_data_id.value(),
                                 &data
                         );
                     } else {
-                        err = m_data_storage->get_data_task(
+                        err = m_data_storage->get_task_data(
                                 conn,
                                 m_source_id,
                                 optional_data_id.value(),
@@ -330,14 +330,14 @@ private:
                     throw ConnectionException{fmt::format("Output data ID is missing")};
                 }
                 if (m_source == JobSource::Driver) {
-                    err = m_data_storage->get_data_driver(
+                    err = m_data_storage->get_driver_data(
                             conn,
                             m_source_id,
                             optional_data_id.value(),
                             &data
                     );
                 } else {
-                    err = m_data_storage->get_data_task(
+                    err = m_data_storage->get_task_data(
                             conn,
                             m_source_id,
                             optional_data_id.value(),

--- a/src/spider/client/TaskContext.hpp
+++ b/src/spider/client/TaskContext.hpp
@@ -172,7 +172,14 @@ public:
             throw ConnectionException(fmt::format("Failed to start job: {}", err.description));
         }
 
-        return Job<ReturnType>{job_id, m_metadata_store, m_data_store, m_storage_factory};
+        return Job<ReturnType>{
+                job_id,
+                Job<ReturnType>::JobSource::Task,
+                m_task_id,
+                m_metadata_store,
+                m_data_store,
+                m_storage_factory
+        };
     }
 
     /**
@@ -224,7 +231,14 @@ public:
             throw ConnectionException(fmt::format("Failed to start job: {}", err.description));
         }
 
-        return Job<ReturnType>{job_id, m_metadata_store, m_data_store, m_storage_factory};
+        return Job<ReturnType>{
+                job_id,
+                Job<ReturnType>::JobSource::Task,
+                m_task_id,
+                m_metadata_store,
+                m_data_store,
+                m_storage_factory
+        };
     }
 
     /**

--- a/src/spider/storage/DataStorage.hpp
+++ b/src/spider/storage/DataStorage.hpp
@@ -33,14 +33,15 @@ public:
     virtual auto get_data(StorageConnection& conn, boost::uuids::uuid id, Data* data) -> StorageErr
             = 0;
     /**
-     * Get data and register data reference from a driver in a single transaction.
+     * Get a data object and register a reference for it from the given driver in a single
+     * transaction.
      * @param conn
      * @param driver_id
      * @param data_id
      * @param data output data
      * @return StorageErr::Success if the transaction succeed. Error types otherwise.
      */
-    virtual auto get_data_driver(
+    virtual auto get_driver_data(
             StorageConnection& conn,
             boost::uuids::uuid driver_id,
             boost::uuids::uuid data_id,
@@ -48,14 +49,15 @@ public:
     ) -> StorageErr
             = 0;
     /**
-     * Get data and register data reference from a task in a single transaction.
+     * Get a data object and register a reference for it from the given task in a single
+     * transaction.
      * @param conn
      * @param task_id
      * @param data_id
      * @param data output data
      * @return StorageErr::Success if the transaction succeed. Error types otherwise.
      */
-    virtual auto get_data_task(
+    virtual auto get_task_data(
             StorageConnection& conn,
             boost::uuids::uuid task_id,
             boost::uuids::uuid data_id,

--- a/src/spider/storage/DataStorage.hpp
+++ b/src/spider/storage/DataStorage.hpp
@@ -32,6 +32,20 @@ public:
             = 0;
     virtual auto get_data(StorageConnection& conn, boost::uuids::uuid id, Data* data) -> StorageErr
             = 0;
+    virtual auto get_data_driver(
+            StorageConnection& conn,
+            boost::uuids::uuid driver_id,
+            boost::uuids::uuid data_id,
+            Data* data
+    ) -> StorageErr
+            = 0;
+    virtual auto get_data_task(
+            StorageConnection& conn,
+            boost::uuids::uuid task_id,
+            boost::uuids::uuid data_id,
+            Data* data
+    ) -> StorageErr
+            = 0;
     virtual auto set_data_locality(StorageConnection& conn, Data const& data) -> StorageErr = 0;
     virtual auto remove_data(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr = 0;
     virtual auto

--- a/src/spider/storage/DataStorage.hpp
+++ b/src/spider/storage/DataStorage.hpp
@@ -32,6 +32,14 @@ public:
             = 0;
     virtual auto get_data(StorageConnection& conn, boost::uuids::uuid id, Data* data) -> StorageErr
             = 0;
+    /**
+     * Get data and register data reference from a driver in a single transaction.
+     * @param conn
+     * @param driver_id
+     * @param data_id
+     * @param data output data
+     * @return StorageErr::Success if the transaction succeed. Error types otherwise.
+     */
     virtual auto get_data_driver(
             StorageConnection& conn,
             boost::uuids::uuid driver_id,
@@ -39,6 +47,14 @@ public:
             Data* data
     ) -> StorageErr
             = 0;
+    /**
+     * Get data and register data reference from a task in a single transaction.
+     * @param conn
+     * @param task_id
+     * @param data_id
+     * @param data output data
+     * @return StorageErr::Success if the transaction succeed. Error types otherwise.
+     */
     virtual auto get_data_task(
             StorageConnection& conn,
             boost::uuids::uuid task_id,

--- a/src/spider/storage/mysql/MySqlStorage.cpp
+++ b/src/spider/storage/mysql/MySqlStorage.cpp
@@ -2130,7 +2130,7 @@ auto MySqlDataStorage::get_data(StorageConnection& conn, boost::uuids::uuid cons
     return StorageErr{};
 }
 
-auto MySqlDataStorage::get_data_driver(
+auto MySqlDataStorage::get_driver_data(
         StorageConnection& conn,
         boost::uuids::uuid const driver_id,
         boost::uuids::uuid const data_id,
@@ -2160,7 +2160,7 @@ auto MySqlDataStorage::get_data_driver(
     return StorageErr{};
 }
 
-auto MySqlDataStorage::get_data_task(
+auto MySqlDataStorage::get_task_data(
         StorageConnection& conn,
         boost::uuids::uuid const task_id,
         boost::uuids::uuid const data_id,

--- a/src/spider/storage/mysql/MySqlStorage.cpp
+++ b/src/spider/storage/mysql/MySqlStorage.cpp
@@ -2071,11 +2071,16 @@ auto MySqlDataStorage::get_data_with_locality(
 auto MySqlDataStorage::get_data(StorageConnection& conn, boost::uuids::uuid const id, Data* data)
         -> StorageErr {
     try {
-        return get_data_with_locality(conn, id, data);
+        StorageErr const err = get_data_with_locality(conn, id, data);
+        if (false == err.success()) {
+            return err;
+        }
     } catch (sql::SQLException& e) {
         static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
+    static_cast<MySqlConnection&>(conn)->commit();
+    return StorageErr{};
 }
 
 auto MySqlDataStorage::get_data_driver(
@@ -2104,7 +2109,7 @@ auto MySqlDataStorage::get_data_driver(
         static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    static_cast<MySqlConnection&>(conn)->rollback();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 
@@ -2134,7 +2139,7 @@ auto MySqlDataStorage::get_data_task(
         static_cast<MySqlConnection&>(conn)->rollback();
         return StorageErr{StorageErrType::OtherErr, e.what()};
     }
-    static_cast<MySqlConnection&>(conn)->rollback();
+    static_cast<MySqlConnection&>(conn)->commit();
     return StorageErr{};
 }
 

--- a/src/spider/storage/mysql/MySqlStorage.hpp
+++ b/src/spider/storage/mysql/MySqlStorage.hpp
@@ -148,6 +148,18 @@ public:
             -> StorageErr override;
     auto get_data(StorageConnection& conn, boost::uuids::uuid id, Data* data)
             -> StorageErr override;
+    auto get_data_driver(
+            StorageConnection& conn,
+            boost::uuids::uuid driver_id,
+            boost::uuids::uuid data_id,
+            Data* data
+    ) -> StorageErr override;
+    auto get_data_task(
+            StorageConnection& conn,
+            boost::uuids::uuid task_id,
+            boost::uuids::uuid data_id,
+            Data* data
+    ) -> StorageErr override;
     auto set_data_locality(StorageConnection& conn, Data const& data) -> StorageErr override;
     auto remove_data(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr override;
     auto
@@ -187,6 +199,9 @@ public:
     ) -> StorageErr override;
 
 private:
+    static auto get_data_with_locality(StorageConnection& conn, boost::uuids::uuid id, Data* data)
+            -> StorageErr;
+
     MySqlDataStorage() = default;
 
     friend class MySqlStorageFactory;

--- a/src/spider/storage/mysql/MySqlStorage.hpp
+++ b/src/spider/storage/mysql/MySqlStorage.hpp
@@ -148,13 +148,13 @@ public:
             -> StorageErr override;
     auto get_data(StorageConnection& conn, boost::uuids::uuid id, Data* data)
             -> StorageErr override;
-    auto get_data_driver(
+    auto get_driver_data(
             StorageConnection& conn,
             boost::uuids::uuid driver_id,
             boost::uuids::uuid data_id,
             Data* data
     ) -> StorageErr override;
-    auto get_data_task(
+    auto get_task_data(
             StorageConnection& conn,
             boost::uuids::uuid task_id,
             boost::uuids::uuid data_id,

--- a/src/spider/worker/FunctionManager.hpp
+++ b/src/spider/worker/FunctionManager.hpp
@@ -266,7 +266,7 @@ public:
                     = msgpack::unpack(args_buffer.data(), args_buffer.size());
             msgpack::object const object = handle.get();
 
-            if (msgpack::type::ARRAY != object.type || object.via.array.size < 1) {
+            if (msgpack::type::ARRAY != object.type && object.via.array.size < 1) {
                 return create_error_response(
                         FunctionInvokeError::ArgumentParsingError,
                         fmt::format("Cannot parse arguments.")

--- a/src/spider/worker/FunctionManager.hpp
+++ b/src/spider/worker/FunctionManager.hpp
@@ -306,7 +306,7 @@ public:
                 if constexpr (cIsSpecializationV<T, spider::Data>) {
                     boost::uuids::uuid const data_id = arg.as<boost::uuids::uuid>();
                     std::unique_ptr<Data> data = std::make_unique<Data>();
-                    err = data_store->get_data_task(*conn, task_id, data_id, data.get());
+                    err = data_store->get_task_data(*conn, task_id, data_id, data.get());
                     if (!err.success()) {
                         return;
                     }

--- a/src/spider/worker/FunctionManager.hpp
+++ b/src/spider/worker/FunctionManager.hpp
@@ -266,7 +266,7 @@ public:
                     = msgpack::unpack(args_buffer.data(), args_buffer.size());
             msgpack::object const object = handle.get();
 
-            if (msgpack::type::ARRAY != object.type && object.via.array.size < 1) {
+            if (msgpack::type::ARRAY != object.type || object.via.array.size < 1) {
                 return create_error_response(
                         FunctionInvokeError::ArgumentParsingError,
                         fmt::format("Cannot parse arguments.")

--- a/src/spider/worker/task_executor.cpp
+++ b/src/spider/worker/task_executor.cpp
@@ -172,7 +172,7 @@ auto main(int const argc, char** argv) -> int {
                 metadata_store,
                 storage_factory
         );
-        msgpack::sbuffer const result_buffer = (*function)(task_context, args_buffer);
+        msgpack::sbuffer const result_buffer = (*function)(task_context, task_id, args_buffer);
         spdlog::debug("Function executed");
 
         // Write result buffer to stdout

--- a/tests/worker/test-FunctionManager.cpp
+++ b/tests/worker/test-FunctionManager.cpp
@@ -15,7 +15,9 @@
 #include "../../src/spider/client/TaskContext.hpp"
 #include "../../src/spider/core/Driver.hpp"
 #include "../../src/spider/core/Error.hpp"
+#include "../../src/spider/core/Task.hpp"
 #include "../../src/spider/core/TaskContextImpl.hpp"
+#include "../../src/spider/core/TaskGraph.hpp"
 #include "../../src/spider/io/MsgPack.hpp"  // IWYU pragma: keep
 #include "../../src/spider/storage/DataStorage.hpp"
 #include "../../src/spider/storage/MetadataStorage.hpp"
@@ -76,8 +78,9 @@ TEMPLATE_LIST_TEST_CASE(
             = storage_factory->provide_data_storage();
 
     boost::uuids::random_generator gen;
+    boost::uuids::uuid const task_id = gen();
     spider::TaskContext context = spider::core::TaskContextImpl::create_task_context(
-            gen(),
+            task_id,
             std::move(data_storage),
             std::move(metadata_storage),
             std::move(storage_factory)
@@ -95,14 +98,14 @@ TEMPLATE_LIST_TEST_CASE(
     // Run function with two ints should succeed
     spider::core::ArgsBuffer const args_buffers = spider::core::create_args_buffers(2, 3);
     constexpr int cExpected = 2 + 3;
-    msgpack::sbuffer const result = (*function)(context, args_buffers);
+    msgpack::sbuffer const result = (*function)(context, task_id, args_buffers);
     msgpack::sbuffer buffer{};
     msgpack::pack(buffer, cExpected);
     REQUIRE(cExpected == spider::core::response_get_result<int>(result).value_or(0));
 
     // Run function with wrong number of inputs should fail
     spider::core::ArgsBuffer wrong_args_buffers = spider::core::create_args_buffers(1);
-    msgpack::sbuffer wrong_result = (*function)(context, wrong_args_buffers);
+    msgpack::sbuffer wrong_result = (*function)(context, task_id, wrong_args_buffers);
     std::optional<std::tuple<spider::core::FunctionInvokeError, std::string>> wrong_result_option
             = spider::core::response_get_error(wrong_result);
     REQUIRE(wrong_result_option.has_value());
@@ -113,7 +116,7 @@ TEMPLATE_LIST_TEST_CASE(
 
     // Run function with wrong type of inputs should fail
     wrong_args_buffers = spider::core::create_args_buffers(0, "test");
-    wrong_result = (*function)(context, wrong_args_buffers);
+    wrong_result = (*function)(context, task_id, wrong_args_buffers);
     wrong_result_option = spider::core::response_get_error(wrong_result);
     REQUIRE(wrong_result_option.has_value());
     if (wrong_result_option.has_value()) {
@@ -135,8 +138,9 @@ TEMPLATE_LIST_TEST_CASE(
             = storage_factory->provide_data_storage();
 
     boost::uuids::random_generator gen;
+    boost::uuids::uuid const task_id = gen();
     spider::TaskContext context = spider::core::TaskContextImpl::create_task_context(
-            gen(),
+            task_id,
             std::move(data_storage),
             std::move(metadata_storage),
             std::move(storage_factory)
@@ -147,7 +151,7 @@ TEMPLATE_LIST_TEST_CASE(
     spider::core::Function const* function = manager.get_function("tuple_ret_test");
 
     spider::core::ArgsBuffer const args_buffers = spider::core::create_args_buffers("test", 3);
-    msgpack::sbuffer const result = (*function)(context, args_buffers);
+    msgpack::sbuffer const result = (*function)(context, task_id, args_buffers);
     REQUIRE(std::make_tuple("test", 3)
             == spider::core::response_get_result<std::string, int>(result).value_or(
                     std::make_tuple("", 0)
@@ -180,8 +184,20 @@ TEMPLATE_LIST_TEST_CASE(
     REQUIRE(metadata_storage->add_driver(*conn, driver).success());
     REQUIRE(data_storage->add_driver_data(*conn, driver_id, data).success());
 
+    boost::uuids::uuid const task_id = gen();
+    // Submit a job for valid task id
+    spider::core::Task task{"data_test"};
+    task.set_id(task_id);
+    task.add_input(spider::core::TaskInput{data.get_id()});
+    spider::core::TaskGraph graph;
+    graph.add_task(task);
+    graph.add_input_task(task_id);
+    graph.add_output_task(task_id);
+    boost::uuids::uuid const job_id = gen();
+    REQUIRE(metadata_storage->add_job(*conn, job_id, driver_id, graph).success());
+
     spider::TaskContext context = spider::core::TaskContextImpl::create_task_context(
-            gen(),
+            task_id,
             data_storage,
             metadata_storage,
             storage_factory
@@ -192,9 +208,10 @@ TEMPLATE_LIST_TEST_CASE(
     spider::core::Function const* function = manager.get_function("data_test");
 
     spider::core::ArgsBuffer const args_buffers = spider::core::create_args_buffers(data.get_id());
-    msgpack::sbuffer const result = (*function)(context, args_buffers);
+    msgpack::sbuffer const result = (*function)(context, task_id, args_buffers);
     REQUIRE(3 == spider::core::response_get_result<int>(result).value_or(0));
 
+    REQUIRE(metadata_storage->remove_job(*conn, job_id).success());
     REQUIRE(data_storage->remove_data(*conn, data.get_id()).success());
 }
 }  // namespace

--- a/tests/worker/test-TaskExecutor.cpp
+++ b/tests/worker/test-TaskExecutor.cpp
@@ -19,6 +19,8 @@
 #include "../../src/spider/core/Data.hpp"
 #include "../../src/spider/core/Driver.hpp"
 #include "../../src/spider/core/Error.hpp"
+#include "../../src/spider/core/Task.hpp"
+#include "../../src/spider/core/TaskGraph.hpp"
 #include "../../src/spider/io/BoostAsio.hpp"  // IWYU pragma: keep
 #include "../../src/spider/io/MsgPack.hpp"  // IWYU pragma: keep
 #include "../../src/spider/storage/DataStorage.hpp"
@@ -179,6 +181,18 @@ TEMPLATE_LIST_TEST_CASE(
     REQUIRE(metadata_storage->add_driver(*conn, driver).success());
     REQUIRE(data_storage->add_driver_data(*conn, driver_id, data).success());
 
+    // Submit a job for a valid task id
+    boost::uuids::uuid const task_id = gen();
+    spider::core::Task task{"data_test"};
+    task.set_id(task_id);
+    task.add_input(spider::core::TaskInput{data.get_id()});
+    spider::core::TaskGraph graph;
+    graph.add_task(task);
+    graph.add_input_task(task_id);
+    graph.add_output_task(task_id);
+    boost::uuids::uuid const job_id = gen();
+    REQUIRE(metadata_storage->add_job(*conn, job_id, driver_id, graph).success());
+
     absl::flat_hash_map<
             boost::process::v2::environment::key,
             boost::process::v2::environment::value> const environment_variable
@@ -189,7 +203,7 @@ TEMPLATE_LIST_TEST_CASE(
     spider::worker::TaskExecutor executor{
             context,
             "data_test",
-            gen(),
+            task_id,
             spider::test::get_storage_url<TestType>(),
             get_libraries(),
             environment_variable,
@@ -205,6 +219,7 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     // Clean up
+    REQUIRE(metadata_storage->remove_job(*conn, job_id).success());
     REQUIRE(data_storage->remove_data(*conn, data.get_id()).success());
 }
 


### PR DESCRIPTION
# Description

## Problem
Spider currently only tracks `Data` references when they are created by a task or client. However, if a job returns a `Data` object to a client, Spider does not register that the client is referencing this `Data`. As a result, when the job is removed from storage, the `Data` may be garbage collected, even though the client is still referencing , leading to potential errors.

## Solution
This PR introduces new storage functions that retrieve `Data` and register a reference to it within the same transaction. All existing calls to `get_data` have been replaced with these new functions to ensure proper tracking of Data references. The associated tests have also been updated to reflect and validate the new behavior.

Fixes #132.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* [x] GitHub workflows pass.
* [x] Unit tests pass in dev container.
* [x] Integration tests pass in dev container.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced data retrieval to distinguish between driver and task sources, allowing more precise data association and access.
- **Refactor**
	- Updated job and function handling to explicitly track and propagate the source and ID of jobs and tasks throughout the system.
	- Modularized data retrieval with locality and added explicit transaction handling.
	- Adjusted function invocation signatures and task execution to include explicit task ID propagation.
- **Tests**
	- Improved tests to validate correct handling of task IDs and job associations in function execution and task management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->