### PR TITLE
fix(worker): Avoid array size check if msgpack buffer is not an array.

### DIFF
--- a/src/spider/worker/FunctionManager.hpp
+++ b/src/spider/worker/FunctionManager.hpp
@@ -261,7 +261,7 @@ public:
                     = msgpack::unpack(args_buffer.data(), args_buffer.size());
             msgpack::object const object = handle.get();
 
-            if (msgpack::type::ARRAY != object.type && object.via.array.size < 1) {
+            if (msgpack::type::ARRAY != object.type || object.via.array.size < 1) {
                 return create_error_response(
                         FunctionInvokeError::ArgumentParsingError,
                         fmt::format("Cannot parse arguments.")


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description

When converting a `msgpack::array` to an array of `TaskIO` objects, Spider first checks if the buffer is of `array` type and then validates the size of the `array`. However, these two checks are composed using `&&`, which has undefined behaviour if the buffer type is not `array`.

This pr fixes the bug by replacing `&&` with `||` so the size check is not performed if the type check fails.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* [x] GitHub workflows pass.
* [x] Unit tests pass in dev container.
* [x] Integration tests pass in dev container.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of invalid argument formats when applying functions, ensuring errors are returned for incorrect input types or empty arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->