### PR TITLE
docs: Add instructions for installing dependencies and change build directory to avoid mixing Spider & dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Follow the steps below to develop and contribute to the project.
 ## Set up
 Run dependency installation task:
 ```shell
-task deps:dep_install
+task deps:lib_install
 ```
 
 Set up the config files for our C++ linting tools:

--- a/docs/src/user-docs/guides-quick-start.md
+++ b/docs/src/user-docs/guides-quick-start.md
@@ -179,7 +179,7 @@ cmake --build build/spider --parallel $(nproc) --target spider_scheduler
 To start the scheduler, run:
 
 ```shell
-build/spider/src/spider/spider_scheduler \
+build/spider/spider/src/spider/spider_scheduler \
         --storage_url \
         "jdbc:mariadb://localhost:3306/spider-storage?user=spider&password=password" \
         --host "127.0.0.1" \
@@ -204,11 +204,11 @@ cmake --build build/spider --parallel $(nproc) --target spider_worker
 To start a worker, run:
 
 ```shell
-build/spider/src/spider/spider_worker \
+build/spider/spider/src/spider/spider_worker \
         --storage_url \
         "jdbc:mariadb://localhost:3306/spider-storage?user=spider&password=password" \
         --host "127.0.0.1" \
-        --libs "build/libtasks.so"
+        --libs "build/spider/libtasks.so"
 ```
 
 NOTE:

--- a/docs/src/user-docs/guides-quick-start.md
+++ b/docs/src/user-docs/guides-quick-start.md
@@ -229,7 +229,7 @@ cluster.
 To run the client:
 
 ```shell
-build/spider/client "jdbc:mariadb://localhost:3307/spider-storage?user=spider&password=password"
+build/spider/client "jdbc:mariadb://localhost:3306/spider-storage?user=spider&password=password"
 ```
 
 NOTE:

--- a/docs/src/user-docs/guides-quick-start.md
+++ b/docs/src/user-docs/guides-quick-start.md
@@ -257,6 +257,8 @@ task, and the worker handles the task output as usual. Then the worker exits wit
 In future guides, we'll explain how to write more complex tasks, as well as how to leverage Spider's
 support for fault tolerance.
 
+[deps-task.yaml]: https://github.com/y-scope/spider/blob/main/dep-tasks.yaml
 [Docker]: https://docs.docker.com/engine/install/
 [docker-non-root]: https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user
 [examples/quick-start]: https://github.com/y-scope/spider/tree/main/examples/quick-start
+[Task]: https://taskfile.dev/

--- a/docs/src/user-docs/guides-quick-start.md
+++ b/docs/src/user-docs/guides-quick-start.md
@@ -4,7 +4,7 @@ The guide below briefly describes how to get started with running a task on Spid
 you'll need to:
 
 * Write a task
-* (Optional) Install Dependencies
+* Install Spider's dependencies
 * Build the task into a shared library
 * Write a client to manage the task
 * Build the client
@@ -29,7 +29,7 @@ In the guide below, you'll need:
 * [Docker] 20.10+
   * If you're not running as root, ensure `docker` can be run
     [without superuser privileges][docker-non-root].
-* [Task](https://taskfile.dev/) v3.30.0+ if you want to install dependencies locally.
+* [Task] v3.30.0+ if you want to install Spider's dependencies within its build directory.
 
 # Writing a task
 
@@ -66,9 +66,9 @@ The integer parameters and return value are `Serializable` values.
 The `SPIDER_REGISTER_TASK` macro at the bottom of `src/tasks.cpp` is how we inform Spider that a
 function should be treated as a task.
 
-# (Optional) Installing dependencies
+# Installing dependencies
 
-You can install `Spider` dependencies locally using the `task` command by running:
+You can install `Spider` dependencies within its build directory by running:
 
 ```shell
 task deps:lib_install
@@ -76,8 +76,8 @@ task deps:lib_install
 
 This will install all dependencies in the `build/deps` directory.
 
-Alternatively, you can install the dependencies yourself. Check the `CMakeLists.txt` file for the
-list of dependencies.
+Alternatively, you can install the dependencies to the system. See the `install-all-run` task in
+[deps-task.yaml] for the list of dependencies to install.
 
 # Building the task into a shared library
 

--- a/docs/src/user-docs/guides-quick-start.md
+++ b/docs/src/user-docs/guides-quick-start.md
@@ -4,6 +4,7 @@ The guide below briefly describes how to get started with running a task on Spid
 you'll need to:
 
 * Write a task
+* (Optional) Install Dependencies
 * Build the task into a shared library
 * Write a client to manage the task
 * Build the client
@@ -28,6 +29,7 @@ In the guide below, you'll need:
 * [Docker] 20.10+
   * If you're not running as root, ensure `docker` can be run
     [without superuser privileges][docker-non-root].
+* [Task](https://taskfile.dev/) v3.30.0+ if you want to install dependencies locally.
 
 # Writing a task
 
@@ -64,6 +66,19 @@ The integer parameters and return value are `Serializable` values.
 The `SPIDER_REGISTER_TASK` macro at the bottom of `src/tasks.cpp` is how we inform Spider that a
 function should be treated as a task.
 
+# (Optional) Installing dependencies
+
+You can install `Spider` dependencies locally using the `task` command by running:
+
+```shell
+task deps:lib_install
+```
+
+This will install all dependencies in the `build/deps` directory.
+
+Alternatively, you can install the dependencies yourself. Check the `CMakeLists.txt` file for the
+list of dependencies.
+
 # Building the task into a shared library
 
 In order for Spider to run a task, the task needs to be compiled into a shared library that Spider
@@ -72,8 +87,8 @@ can load. The example's `CMakeLists.txt` demonstrates how to do this.
 To build the shared library, run:
 
 ```shell
-cmake -S . -B build
-cmake --build build --parallel $(nproc) --target tasks
+cmake -S . -B build/spider
+cmake --build build/spider --parallel $(nproc) --target tasks
 ```
 
 # Writing a client to manage the task
@@ -112,7 +127,7 @@ this.
 To build the client executable, run:
 
 ```shell
-cmake --build build --parallel $(nproc) --target client
+cmake --build build/spider --parallel $(nproc) --target client
 ```
 
 # Setting up a Spider cluster
@@ -158,7 +173,7 @@ create a database and authorize a user to access it.
 To build the scheduler, run:
 
 ```shell
-cmake --build build --parallel $(nproc) --target spider_scheduler
+cmake --build build/spider --parallel $(nproc) --target spider_scheduler
 ```
 
 To start the scheduler, run:
@@ -183,7 +198,7 @@ NOTE:
 To build the worker, run:
 
 ```shell
-cmake --build build --parallel $(nproc) --target spider_worker
+cmake --build build/spider --parallel $(nproc) --target spider_worker
 ```
 
 To start a worker, run:
@@ -214,7 +229,7 @@ cluster.
 To run the client:
 
 ```shell
-build/client "jdbc:mariadb://localhost:3306/spider-storage?user=spider&password=password"
+build/spider/client "jdbc:mariadb://localhost:3307/spider-storage?user=spider&password=password"
 ```
 
 NOTE:


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description

This pr adds the dependencies building using `task` in quick start guide. This pr also changes the build directory from `build` to `build/spider` to avoid mixing the dependencies in `build/deps` with cmake-related files, fixes #118.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
* [x] Build success with new commands.

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the quick start guide with a new prerequisite for Task v3.30.0+.
  - Added instructions for installing dependencies locally or system-wide.
  - Updated build and run commands to use the `build/spider` directory.
  - Revised README with updated dependency installation command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->