### PR TITLE
refactor(worker): Use `std::vector` for function maps and fix static function throwing error.

### DIFF
--- a/examples/quick-start/src/tasks.cpp
+++ b/examples/quick-start/src/tasks.cpp
@@ -8,5 +8,4 @@ auto sum(spider::TaskContext& /*context*/, int x, int y) -> int {
 }
 
 // Register the task with Spider
-// NOLINTNEXTLINE(cert-err58-cpp)
 SPIDER_REGISTER_TASK(sum);

--- a/src/spider/core/TaskGraphImpl.hpp
+++ b/src/spider/core/TaskGraphImpl.hpp
@@ -138,7 +138,7 @@ public:
         // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast)
         std::optional<std::string> const function_name
                 = FunctionNameManager::get_instance().get_function_name(
-                        reinterpret_cast<void const*>(task_function)
+                        reinterpret_cast<uintptr_t>(task_function)
                 );
         // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)
         if (!function_name.has_value()) {

--- a/src/spider/worker/FunctionManager.cpp
+++ b/src/spider/worker/FunctionManager.cpp
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <type_traits>
 #include <vector>
@@ -101,14 +102,16 @@ auto response_get_result_buffers(msgpack::sbuffer const& buffer)
     // NOLINTEND(cppcoreguidelines-pro-type-union-access,cppcoreguidelines-pro-bounds-pointer-arithmetic)
 }
 
-auto FunctionManager::get_instance() -> FunctionManager& {
+auto FunctionManager::get_instance() noexcept -> FunctionManager& {
     static FunctionManager instance;
     return instance;
 }
 
-auto FunctionManager::get_function(std::string const& name) const -> Function const* {
-    if (auto const func_iter = m_function_map.find(name); func_iter != m_function_map.end()) {
-        return &(func_iter->second);
+auto FunctionManager::get_function(std::string_view name) const -> Function const* {
+    for (auto const& pair : m_function_map) {
+        if (pair.first == name) {
+            return &pair.second;
+        }
     }
     return nullptr;
 }

--- a/src/spider/worker/FunctionManager.hpp
+++ b/src/spider/worker/FunctionManager.hpp
@@ -6,14 +6,15 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <type_traits>
 #include <utility>
 #include <variant>
 #include <vector>
 
-#include <absl/container/flat_hash_map.h>
 #include <boost/uuid/uuid.hpp>
 #include <fmt/format.h>
 
@@ -46,7 +47,7 @@ using ResultBuffer = msgpack::sbuffer;
 
 using Function = std::function<ResultBuffer(TaskContext& context, ArgsBuffer const&)>;
 
-using FunctionMap = absl::flat_hash_map<std::string, Function>;
+using FunctionMap = std::vector<std::pair<std::string_view, Function>>;
 
 template <class T>
 struct TemplateParameter;
@@ -358,35 +359,44 @@ public:
 
     auto operator=(FunctionManager&&) -> FunctionManager& = delete;
 
-    static auto get_instance() -> FunctionManager&;
+    static auto get_instance() noexcept -> FunctionManager&;
 
     template <class F>
-    auto register_function(std::string const& name, F f) -> bool {
-        if (m_function_map.contains(name)) {
+    auto register_function(std::string_view name, F f) noexcept -> bool {
+        if (contains(name)) {
             return false;
         }
-        return m_function_map
-                .emplace(
-                        name,
-                        std::bind(
-                                &FunctionInvoker<F>::apply,
-                                std::move(f),
-                                std::placeholders::_1,
-                                std::placeholders::_2
-                        )
+        m_function_map.emplace_back(
+                name,
+                std::bind(
+                        &FunctionInvoker<F>::apply,
+                        std::move(f),
+                        std::placeholders::_1,
+                        std::placeholders::_2
                 )
-                .second;
+        );
+        return true;
     }
 
-    auto register_function_invoker(std::string const& name, Function f) -> bool {
-        return m_function_map.emplace(name, f).second;
+    auto register_function_invoker(std::string_view name, Function f) -> bool {
+        if (contains(name)) {
+            return false;
+        }
+        m_function_map.emplace_back(name, f);
+        return true;
     }
 
-    [[nodiscard]] auto get_function(std::string const& name) const -> Function const*;
+    [[nodiscard]] auto get_function(std::string_view name) const -> Function const*;
 
     [[nodiscard]] auto get_function_map() const -> FunctionMap const& { return m_function_map; }
 
 private:
+    [[nodiscard]] auto contains(std::string_view name) const -> bool {
+        return std::ranges::any_of(m_function_map, [&name](auto const& pair) {
+            return pair.first == name;
+        });
+    }
+
     FunctionManager() = default;
 
     ~FunctionManager() = default;

--- a/src/spider/worker/FunctionManager.hpp
+++ b/src/spider/worker/FunctionManager.hpp
@@ -1,12 +1,12 @@
 #ifndef SPIDER_WORKER_FUNCTIONMANAGER_HPP
 #define SPIDER_WORKER_FUNCTIONMANAGER_HPP
 
+#include <algorithm>
 #include <cstdint>
 #include <exception>
 #include <functional>
 #include <memory>
 #include <optional>
-#include <ranges>
 #include <string>
 #include <string_view>
 #include <tuple>
@@ -378,7 +378,7 @@ public:
         return true;
     }
 
-    auto register_function_invoker(std::string_view name, Function f) -> bool {
+    auto register_function_invoker(std::string_view name, Function const& f) -> bool {
         if (contains(name)) {
             return false;
         }

--- a/src/spider/worker/FunctionNameManager.cpp
+++ b/src/spider/worker/FunctionNameManager.cpp
@@ -6,14 +6,16 @@
 #include <boost/dll/alias.hpp>
 
 namespace spider::core {
-auto FunctionNameManager::get_instance() -> FunctionNameManager& {
+auto FunctionNameManager::get_instance() noexcept -> FunctionNameManager& {
     static FunctionNameManager instance;
     return instance;
 }
 
 auto FunctionNameManager::get_function_name(void const* ptr) const -> std::optional<std::string> {
-    if (auto const& it = m_name_map.find(ptr); it != m_name_map.end()) {
-        return it->second;
+    for (auto const& it : m_name_map) {
+        if (it.first == ptr) {
+            return std::string{it.second};
+        }
     }
     return std::nullopt;
 }

--- a/src/spider/worker/FunctionNameManager.cpp
+++ b/src/spider/worker/FunctionNameManager.cpp
@@ -1,5 +1,6 @@
 #include "FunctionNameManager.hpp"
 
+#include <cstdint>
 #include <optional>
 #include <string>
 
@@ -11,7 +12,8 @@ auto FunctionNameManager::get_instance() noexcept -> FunctionNameManager& {
     return instance;
 }
 
-auto FunctionNameManager::get_function_name(void const* ptr) const -> std::optional<std::string> {
+auto FunctionNameManager::get_function_name(uintptr_t const ptr) const
+        -> std::optional<std::string> {
     for (auto const& it : m_name_map) {
         if (it.first == ptr) {
             return std::string{it.second};

--- a/src/spider/worker/FunctionNameManager.hpp
+++ b/src/spider/worker/FunctionNameManager.hpp
@@ -1,8 +1,8 @@
 #ifndef SPIDER_CORE_FUNCTIONNAMEMANAGER_HPP
 #define SPIDER_CORE_FUNCTIONNAMEMANAGER_HPP
 
+#include <algorithm>
 #include <optional>
-#include <ranges>
 #include <string>
 #include <string_view>
 #include <utility>

--- a/src/spider/worker/FunctionNameManager.hpp
+++ b/src/spider/worker/FunctionNameManager.hpp
@@ -2,6 +2,7 @@
 #define SPIDER_CORE_FUNCTIONNAMEMANAGER_HPP
 
 #include <algorithm>
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -19,7 +20,7 @@
             = spider::core::FunctionNameManager::get_instance().register_function(#func, func);
 
 namespace spider::core {
-using FunctionNameMap = std::vector<std::pair<void*, std::string_view>>;
+using FunctionNameMap = std::vector<std::pair<std::uintptr_t, std::string_view>>;
 
 class FunctionNameManager {
 public:
@@ -39,7 +40,7 @@ public:
                     m_name_map,
                     [function_pointer](auto const& pair) {
                         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-                        return pair.first == reinterpret_cast<void*>(function_pointer);
+                        return pair.first == reinterpret_cast<uintptr_t>(function_pointer);
                     }
             )
             != m_name_map.end())
@@ -47,11 +48,11 @@ public:
             return false;
         }
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-        m_name_map.emplace_back(reinterpret_cast<void*>(function_pointer), name);
+        m_name_map.emplace_back(reinterpret_cast<uintptr_t>(function_pointer), name);
         return true;
     }
 
-    [[nodiscard]] auto get_function_name(void const* ptr) const -> std::optional<std::string>;
+    [[nodiscard]] auto get_function_name(uintptr_t ptr) const -> std::optional<std::string>;
 
     [[nodiscard]] auto get_function_name_map() const -> FunctionNameMap const& {
         return m_name_map;

--- a/src/spider/worker/FunctionNameManager.hpp
+++ b/src/spider/worker/FunctionNameManager.hpp
@@ -8,8 +8,6 @@
 #include <utility>
 #include <vector>
 
-#include <absl/container/flat_hash_map.h>
-
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)
 #define NAME_CONCAT_DIRECT(s1, s2) s1##s2
 #define NAME_CONCAT(s1, s2) NAME_CONCAT_DIRECT(s1, s2)
@@ -40,6 +38,7 @@ public:
         if (std::ranges::find_if(
                     m_name_map,
                     [function_pointer](auto const& pair) {
+                        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
                         return pair.first == reinterpret_cast<void*>(function_pointer);
                     }
             )
@@ -47,6 +46,7 @@ public:
         {
             return false;
         }
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
         m_name_map.emplace_back(reinterpret_cast<void*>(function_pointer), name);
         return true;
     }

--- a/tests/worker/signal-test.cpp
+++ b/tests/worker/signal-test.cpp
@@ -48,7 +48,5 @@ auto sleep_test(spider::TaskContext&, int const seconds) -> int {
     return 0;
 }
 
-// NOLINTNEXTLINE(cert-err58-cpp)
 SPIDER_REGISTER_TASK(signal_handler_test);
-// NOLINTNEXTLINE(cert-err58-cpp)
 SPIDER_REGISTER_TASK(sleep_test);

--- a/tests/worker/test-FunctionManager.cpp
+++ b/tests/worker/test-FunctionManager.cpp
@@ -1,4 +1,5 @@
 // NOLINTBEGIN(cert-err58-cpp,cppcoreguidelines-avoid-do-while,readability-function-cognitive-complexity,cppcoreguidelines-avoid-non-const-global-variables,cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
@@ -56,11 +57,11 @@ TEST_CASE("Register and get function name", "[core]") {
 
     // Get the function name of non-registered function should return std::nullopt
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    REQUIRE(!manager.get_function_name(reinterpret_cast<void*>(not_registered)).has_value());
+    REQUIRE(!manager.get_function_name(reinterpret_cast<uintptr_t>(not_registered)).has_value());
     // Get the function name of registered function should return the name
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    REQUIRE("int_test" == manager.get_function_name(reinterpret_cast<void*>(int_test)).value_or("")
-    );
+    REQUIRE("int_test"
+            == manager.get_function_name(reinterpret_cast<uintptr_t>(int_test)).value_or(""));
 }
 
 TEMPLATE_LIST_TEST_CASE(

--- a/tests/worker/worker-test.cpp
+++ b/tests/worker/worker-test.cpp
@@ -70,7 +70,6 @@ auto join_string_test(
     return input_1 + input_2;
 }
 
-// NOLINTBEGIN(cert-err58-cpp)
 SPIDER_REGISTER_TASK(sum_test);
 SPIDER_REGISTER_TASK(swap_test);
 SPIDER_REGISTER_TASK(error_test);
@@ -79,4 +78,3 @@ SPIDER_REGISTER_TASK(random_fail_test);
 SPIDER_REGISTER_TASK(create_data_test);
 SPIDER_REGISTER_TASK(create_task_test);
 SPIDER_REGISTER_TASK(join_string_test);
-// NOLINTEND(cert-err58-cpp)


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description

This pr replaces `absl::flat_hash_map` with `std::vector` to fix the crash caused by differences in memory layout across different `abseil` versions.

This pr also replaces `std::string const&` with `std::string_view` and adds `noexcept` in functions called during static variable initialization to fix #113.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* [x] Integration tests using task libraries compiled in different version of `g++` succeeds.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling of function registration and lookup for enhanced efficiency and reliability.
  - Updated string handling to use more efficient types for function management.
  - Marked certain methods as non-throwing for improved robustness.
  - Replaced hash map storage with vector-based storage for function and function name management.
  - Enhanced function pointer handling by using integer representations for lookups.
- **Style**
  - Removed linter directive comments from example and test files for cleaner code presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210104031287384