### PR TITLE
fix(docs): Update docs building tasks to use new `yscope-dev-utils` tasks.

### DIFF
--- a/docs/tasks.yaml
+++ b/docs/tasks.yaml
@@ -31,7 +31,7 @@ tasks:
       - task: ":utils:checksum:validate"
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}/**/*"]
+          INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}"]
       - "docs-venv"
     cmds:
       # Call `clean` before building since `sphinx-build --write-all --fresh-env` isn't always
@@ -52,8 +52,8 @@ tasks:
       # This command must be last
       - task: ":utils:checksum:compute"
         vars:
-          INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}/**/*"]
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
+          INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}"]
     sources:
       - "{{.G_DOCS_VENV_CHECKSUM_FILE}}"
       - "{{.ROOT_DIR}}/taskfile.yaml"
@@ -73,7 +73,7 @@ tasks:
       - task: ":utils:checksum:validate"
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}/**/*"]
+          INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}"]
     cmds:
       - task: ":utils:misc:create-venv"
         vars:
@@ -83,8 +83,8 @@ tasks:
       # This command must be last
       - task: ":utils:checksum:compute"
         vars:
-          INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}/**/*"]
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
+          INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}"]
     sources:
       - "{{.REQUIREMENTS_FILE}}"
       - "{{.ROOT_DIR}}/taskfile.yaml"
@@ -101,15 +101,15 @@ tasks:
       - task: ":utils:checksum:validate"
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}/**/*"]
+          INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}"]
     cmds:
       - "rm -rf '{{.OUTPUT_DIR}}'"
       - "npm --prefix '{{.OUTPUT_DIR}}' install http-server"
       # This command must be last
       - task: ":utils:checksum:compute"
         vars:
-          INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}/**/*"]
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
+          INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}"]
     sources:
       - "{{.ROOT_DIR}}/taskfile.yaml"
       - "{{.TASKFILE}}"

--- a/docs/tasks.yaml
+++ b/docs/tasks.yaml
@@ -28,10 +28,10 @@ tasks:
     dir: "{{.TASKFILE_DIR}}"
     deps:
       - ":init"
-      - task: ":utils:validate-checksum"
+      - task: ":utils:checksum:validate"
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          DATA_DIR: "{{.OUTPUT_DIR}}"
+          INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}/**/*"]
       - "docs-venv"
     cmds:
       # Call `clean` before building since `sphinx-build --write-all --fresh-env` isn't always
@@ -50,10 +50,10 @@ tasks:
           --builder html \
           src "{{.OUTPUT_DIR}}"
       # This command must be last
-      - task: ":utils:compute-checksum"
+      - task: ":utils:checksum:compute"
         vars:
-          DATA_DIR: "{{.OUTPUT_DIR}}"
-          OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
+          INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}/**/*"]
+          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
     sources:
       - "{{.G_DOCS_VENV_CHECKSUM_FILE}}"
       - "{{.ROOT_DIR}}/taskfile.yaml"
@@ -70,21 +70,21 @@ tasks:
       REQUIREMENTS_FILE: "docs/requirements.txt"
     deps:
       - ":init"
-      - task: ":utils:validate-checksum"
+      - task: ":utils:checksum:validate"
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          DATA_DIR: "{{.OUTPUT_DIR}}"
+          INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}/**/*"]
     cmds:
-      - task: ":utils:create-venv"
+      - task: ":utils:misc:create-venv"
         vars:
           LABEL: "docs"
           OUTPUT_DIR: "{{.OUTPUT_DIR}}"
           REQUIREMENTS_FILE: "{{.REQUIREMENTS_FILE}}"
       # This command must be last
-      - task: ":utils:compute-checksum"
+      - task: ":utils:checksum:compute"
         vars:
-          DATA_DIR: "{{.OUTPUT_DIR}}"
-          OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
+          INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}/**/*"]
+          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
     sources:
       - "{{.REQUIREMENTS_FILE}}"
       - "{{.ROOT_DIR}}/taskfile.yaml"
@@ -98,18 +98,18 @@ tasks:
       OUTPUT_DIR: "{{.G_NODE_DEPS_DIR}}"
     deps:
       - ":init"
-      - task: ":utils:validate-checksum"
+      - task: ":utils:checksum:validate"
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          DATA_DIR: "{{.OUTPUT_DIR}}"
+          INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}/**/*"]
     cmds:
       - "rm -rf '{{.OUTPUT_DIR}}'"
       - "npm --prefix '{{.OUTPUT_DIR}}' install http-server"
       # This command must be last
-      - task: ":utils:compute-checksum"
+      - task: ":utils:checksum:compute"
         vars:
-          DATA_DIR: "{{.OUTPUT_DIR}}"
-          OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
+          INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}/**/*"]
+          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
     sources:
       - "{{.ROOT_DIR}}/taskfile.yaml"
       - "{{.TASKFILE}}"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description

#108 updated `yscope-dev-utils` versions, whith changes to the tasks' names and parameters. This pr updates doc building tasks to use the new tasks.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
* [x] `docs:site` and `docs:serve` succeed.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
	- Updated task names and variable names in documentation build tasks for improved clarity and consistency. No changes to overall workflow or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->