### PR TITLE
build: Add `SPIDER_BUILD_TESTING` flag in cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ project(
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+option(SPIDER_BUILD_TESTING "Build Spider tests" ON)
+
 # Enable exporting compile commands
 set(CMAKE_EXPORT_COMPILE_COMMANDS
     ON
@@ -86,6 +88,13 @@ message(STATUS "Building using ${SPIDER_LIBS_STRING} libraries")
 if(PROJECT_IS_TOP_LEVEL)
     # Include dependency settings if the project isn't being included as a subproject.
     include("build/deps/cmake-settings/all.cmake")
+
+    # If previously undefined, `BUILD_TESTING` will be set to ON.
+    include(CTest)
+endif()
+
+if(BUILD_TESTING AND SPIDER_BUILD_TESTING)
+    set(SPIDER_ENABLE_TESTS ON)
 endif()
 
 # Find and setup Boost Library
@@ -168,11 +177,14 @@ else()
     message(FATAL_ERROR "Could not find libraries for outcome.")
 endif()
 
-find_package(Catch2 3.8.0 REQUIRED)
-if(Catch2_FOUND)
-    message(STATUS "Found Catch2 ${Catch2_VERSION}.")
-else()
-    message(FATAL_ERROR "Could not find libraries for Catch2.")
+if(SPIDER_ENABLE_TESTS)
+    message(WARNING "Building tests: ${SPIDER_ENABLE_TESTS}")
+    find_package(Catch2 3.8.0 REQUIRED)
+    if(Catch2_FOUND)
+        message(STATUS "Found Catch2 ${Catch2_VERSION}.")
+    else()
+        message(FATAL_ERROR "Could not find libraries for Catch2.")
+    endif()
 endif()
 
 # Add abseil
@@ -185,6 +197,10 @@ else()
 endif()
 
 # Add ystdlib-cpp
+if(NOT SPIDER_ENABLE_TESTS)
+    # Turn off testing for ystdlib-cpp if we are not building tests for Spider.
+    set(YSTDLIB_CPP_BUILD_TESTING OFF)
+endif()
 add_subdirectory(
     "${SPIDER_YSTDLIB_SOURCE_DIRECTORY}"
     "${CMAKE_BINARY_DIR}/ystdlib"
@@ -195,4 +211,6 @@ find_package(Threads REQUIRED)
 
 add_subdirectory(src/spider)
 
-add_subdirectory(tests)
+if(SPIDER_ENABLE_TESTS)
+    add_subdirectory(tests)
+endif()


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description

Add `SPIDER_BUILD_TESTING` in cmake so that user can turn off building tests.



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* [x] `cmake -DSPIDER_BUILD_TESTING` does not include `Catch2` or build tests.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
