### PR TITLE
fix: Use `uintptr_t` for function pointer.

### DIFF
--- a/src/spider/core/TaskGraphImpl.hpp
+++ b/src/spider/core/TaskGraphImpl.hpp
@@ -138,7 +138,7 @@ public:
         // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast)
         std::optional<std::string> const function_name
                 = FunctionNameManager::get_instance().get_function_name(
-                        reinterpret_cast<void const*>(task_function)
+                        reinterpret_cast<TaskFunctionPointer const>(task_function)
                 );
         // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)
         if (!function_name.has_value()) {

--- a/src/spider/worker/FunctionNameManager.cpp
+++ b/src/spider/worker/FunctionNameManager.cpp
@@ -11,7 +11,8 @@ auto FunctionNameManager::get_instance() -> FunctionNameManager& {
     return instance;
 }
 
-auto FunctionNameManager::get_function_name(void const* ptr) const -> std::optional<std::string> {
+auto FunctionNameManager::get_function_name(TaskFunctionPointer const ptr) const
+        -> std::optional<std::string> {
     if (auto const& it = m_name_map.find(ptr); it != m_name_map.end()) {
         return it->second;
     }

--- a/src/spider/worker/FunctionNameManager.hpp
+++ b/src/spider/worker/FunctionNameManager.hpp
@@ -1,6 +1,7 @@
 #ifndef SPIDER_CORE_FUNCTIONNAMEMANAGER_HPP
 #define SPIDER_CORE_FUNCTIONNAMEMANAGER_HPP
 
+#include <cstdint>
 #include <optional>
 #include <string>
 
@@ -17,7 +18,9 @@
             = spider::core::FunctionNameManager::get_instance().register_function(#func, func);
 
 namespace spider::core {
-using FunctionNameMap = absl::flat_hash_map<void*, std::string>;
+using TaskFunctionPointer = uintptr_t;
+
+using FunctionNameMap = absl::flat_hash_map<TaskFunctionPointer, std::string>;
 
 class FunctionNameManager {
 public:
@@ -34,10 +37,12 @@ public:
     template <typename F>
     auto register_function(std::string const& name, F function_pointer) -> bool {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-        return m_name_map.emplace(reinterpret_cast<void*>(function_pointer), name).second;
+        return m_name_map.emplace(reinterpret_cast<TaskFunctionPointer>(function_pointer), name)
+                .second;
     }
 
-    [[nodiscard]] auto get_function_name(void const* ptr) const -> std::optional<std::string>;
+    [[nodiscard]] auto get_function_name(TaskFunctionPointer ptr) const
+            -> std::optional<std::string>;
 
     [[nodiscard]] auto get_function_name_map() const -> FunctionNameMap const& {
         return m_name_map;

--- a/tests/worker/test-FunctionManager.cpp
+++ b/tests/worker/test-FunctionManager.cpp
@@ -56,11 +56,17 @@ TEST_CASE("Register and get function name", "[core]") {
 
     // Get the function name of non-registered function should return std::nullopt
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    REQUIRE(!manager.get_function_name(reinterpret_cast<void*>(not_registered)).has_value());
+    REQUIRE(!manager.get_function_name(
+                            reinterpret_cast<spider::core::TaskFunctionPointer>(not_registered)
+    )
+                     .has_value());
     // Get the function name of registered function should return the name
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     REQUIRE("int_test"
-            == manager.get_function_name(reinterpret_cast<void*>(int_test)).value_or(""));
+            == manager.get_function_name(
+                              reinterpret_cast<spider::core::TaskFunctionPointer>(int_test)
+            )
+                       .value_or(""));
 }
 
 TEMPLATE_LIST_TEST_CASE(


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description

`FunctionNameManager` uses `void *` for general task function pointers. However, converting from function pointers to `void *` or any object pointers is a UB. This pr uses `uintptr_t` for general function pointers to fix this bug.



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
* [ ] GitHub workflows pass.
* [x] Unit tests pass in dev container.
* [x] Integration tests pass in dev container.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
