### PR TITLE
fix: Add data, job and driver removal in descturctor (fixes #135).

### DIFF
--- a/src/spider/CMakeLists.txt
+++ b/src/spider/CMakeLists.txt
@@ -1,6 +1,7 @@
 # set variable as CACHE INTERNAL to access it from other scope
 set(SPIDER_CORE_SOURCES
     core/DataCleaner.cpp
+    core/JobCleaner.cpp
     core/Task.cpp
     storage/mysql/MySqlConnection.cpp
     storage/mysql/MySqlStorageFactory.cpp
@@ -19,6 +20,7 @@ set(SPIDER_CORE_HEADERS
     core/Data.hpp
     core/DataCleaner.hpp
     core/Driver.hpp
+    core/JobCleaner.hpp
     core/KeyValueData.hpp
     core/Task.hpp
     core/TaskGraph.hpp

--- a/src/spider/CMakeLists.txt
+++ b/src/spider/CMakeLists.txt
@@ -13,6 +13,7 @@ set(SPIDER_CORE_SOURCES
 )
 
 set(SPIDER_CORE_HEADERS
+    core/Context.hpp
     core/Error.hpp
     core/Data.hpp
     core/Driver.hpp

--- a/src/spider/CMakeLists.txt
+++ b/src/spider/CMakeLists.txt
@@ -1,5 +1,6 @@
 # set variable as CACHE INTERNAL to access it from other scope
 set(SPIDER_CORE_SOURCES
+    core/DataCleaner.cpp
     core/Task.cpp
     storage/mysql/MySqlConnection.cpp
     storage/mysql/MySqlStorageFactory.cpp
@@ -16,6 +17,7 @@ set(SPIDER_CORE_HEADERS
     core/Context.hpp
     core/Error.hpp
     core/Data.hpp
+    core/DataCleaner.hpp
     core/Driver.hpp
     core/KeyValueData.hpp
     core/Task.hpp

--- a/src/spider/CMakeLists.txt
+++ b/src/spider/CMakeLists.txt
@@ -1,6 +1,7 @@
 # set variable as CACHE INTERNAL to access it from other scope
 set(SPIDER_CORE_SOURCES
     core/DataCleaner.cpp
+    core/DriverCleaner.cpp
     core/JobCleaner.cpp
     core/Task.cpp
     storage/mysql/MySqlConnection.cpp
@@ -20,6 +21,7 @@ set(SPIDER_CORE_HEADERS
     core/Data.hpp
     core/DataCleaner.hpp
     core/Driver.hpp
+    core/DriverCleaner.hpp
     core/JobCleaner.hpp
     core/KeyValueData.hpp
     core/Task.hpp

--- a/src/spider/client/Driver.cpp
+++ b/src/spider/client/Driver.cpp
@@ -44,6 +44,13 @@ Driver::Driver(std::string const& storage_url)
         throw ConnectionException(err.description);
     }
 
+    m_driver_cleaner = std::make_unique<core::DriverCleaner>(
+            m_id,
+            m_metadata_storage,
+            m_storage_factory,
+            m_conn
+    );
+
     // Start a thread to send heartbeats
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     m_heartbeat_thread = std::jthread([this](std::stop_token stoken) {
@@ -84,6 +91,13 @@ Driver::Driver(std::string const& storage_url, boost::uuids::uuid const id)
         }
         throw ConnectionException(err.description);
     }
+
+    m_driver_cleaner = std::make_unique<core::DriverCleaner>(
+            m_id,
+            m_metadata_storage,
+            m_storage_factory,
+            m_conn
+    );
 
     // Start a thread to send heartbeats
     // NOLINTNEXTLINE(performance-unnecessary-value-param)

--- a/src/spider/client/Driver.hpp
+++ b/src/spider/client/Driver.hpp
@@ -14,6 +14,7 @@
 #include <boost/uuid/uuid.hpp>
 #include <fmt/format.h>
 
+#include "../core/DriverCleaner.hpp"
 #include "../core/Error.hpp"
 #include "../core/TaskGraphImpl.hpp"
 #include "../io/Serializer.hpp"
@@ -319,6 +320,7 @@ public:
 
 private:
     boost::uuids::uuid m_id;
+    std::unique_ptr<core::DriverCleaner> m_driver_cleaner;
     std::shared_ptr<core::MetadataStorage> m_metadata_storage;
     std::shared_ptr<core::DataStorage> m_data_storage;
     std::shared_ptr<core::StorageFactory> m_storage_factory;

--- a/src/spider/client/Driver.hpp
+++ b/src/spider/client/Driver.hpp
@@ -83,9 +83,8 @@ public:
     auto get_data_builder() -> Data<T>::Builder {
         using DataBuilder = typename Data<T>::Builder;
         return DataBuilder{
+                core::Context{core::Context::Source::Driver, m_id},
                 m_data_storage,
-                m_id,
-                DataBuilder::DataSource::Driver,
                 m_storage_factory,
                 m_conn
         };
@@ -228,8 +227,7 @@ public:
 
         return Job<ReturnType>{
                 job_id,
-                Job<ReturnType>::JobSource::Driver,
-                m_id,
+                core::Context{core::Context::Source::Driver, m_id},
                 m_metadata_storage,
                 m_data_storage,
                 m_storage_factory,
@@ -293,8 +291,7 @@ public:
 
         return Job<ReturnType>{
                 job_id,
-                Job<ReturnType>::JobSource::Driver,
-                m_id,
+                core::Context{core::Context::Source::Driver, m_id},
                 m_metadata_storage,
                 m_data_storage,
                 m_storage_factory,

--- a/src/spider/client/Job.hpp
+++ b/src/spider/client/Job.hpp
@@ -19,6 +19,7 @@
 #include "../core/Context.hpp"
 #include "../core/DataImpl.hpp"
 #include "../core/Error.hpp"
+#include "../core/JobCleaner.hpp"
 #include "../core/JobMetadata.hpp"
 #include "../io/MsgPack.hpp"  // IWYU pragma: keep
 #include "../storage/MetadataStorage.hpp"
@@ -165,6 +166,12 @@ private:
         std::shared_ptr<core::StorageFactory> storage_factory)
             : m_id{id},
               m_context{context},
+              m_job_cleaner{std::make_unique<core::JobCleaner>(
+                      id,
+                      metadata_storage,
+                      storage_factory,
+                      nullptr
+              )},
               m_metadata_storage{std::move(metadata_storage)},
               m_data_storage{std::move(data_storage)},
               m_storage_factory{std::move(storage_factory)} {}
@@ -177,6 +184,12 @@ private:
         std::shared_ptr<core::StorageConnection> conn)
             : m_id{id},
               m_context{context},
+              m_job_cleaner{std::make_unique<core::JobCleaner>(
+                      id,
+                      metadata_storage,
+                      storage_factory,
+                      conn
+              )},
               m_metadata_storage{std::move(metadata_storage)},
               m_data_storage{std::move(data_storage)},
               m_storage_factory{std::move(storage_factory)},
@@ -374,6 +387,7 @@ private:
 
     boost::uuids::uuid m_id;
     core::Context m_context;
+    std::unique_ptr<core::JobCleaner> m_job_cleaner;
     std::shared_ptr<core::MetadataStorage> m_metadata_storage;
     std::shared_ptr<core::DataStorage> m_data_storage;
     std::shared_ptr<core::StorageFactory> m_storage_factory;

--- a/src/spider/client/Job.hpp
+++ b/src/spider/client/Job.hpp
@@ -164,7 +164,7 @@ private:
         std::shared_ptr<core::DataStorage> data_storage,
         std::shared_ptr<core::StorageFactory> storage_factory)
             : m_id{id},
-              m_context{std::move(context)},
+              m_context{context},
               m_metadata_storage{std::move(metadata_storage)},
               m_data_storage{std::move(data_storage)},
               m_storage_factory{std::move(storage_factory)} {}
@@ -176,7 +176,7 @@ private:
         std::shared_ptr<core::StorageFactory> storage_factory,
         std::shared_ptr<core::StorageConnection> conn)
             : m_id{id},
-              m_context{std::move(context)},
+              m_context{context},
               m_metadata_storage{std::move(metadata_storage)},
               m_data_storage{std::move(data_storage)},
               m_storage_factory{std::move(storage_factory)},

--- a/src/spider/client/TaskContext.hpp
+++ b/src/spider/client/TaskContext.hpp
@@ -15,6 +15,7 @@
 #include <boost/uuid/uuid.hpp>
 #include <fmt/format.h>
 
+#include "../core/Context.hpp"
 #include "../core/Error.hpp"
 #include "../core/TaskGraph.hpp"
 #include "../core/TaskGraphImpl.hpp"
@@ -61,9 +62,8 @@ public:
     auto get_data_builder() -> Data<T>::Builder {
         using DataBuilder = typename Data<T>::Builder;
         return DataBuilder{
+                core::Context{core::Context::Source::Task, m_task_id},
                 m_data_store,
-                m_task_id,
-                DataBuilder::DataSource::TaskContext,
                 m_storage_factory
         };
     }
@@ -174,8 +174,7 @@ public:
 
         return Job<ReturnType>{
                 job_id,
-                Job<ReturnType>::JobSource::Task,
-                m_task_id,
+                core::Context{core::Context::Source::Task, m_task_id},
                 m_metadata_store,
                 m_data_store,
                 m_storage_factory
@@ -233,8 +232,7 @@ public:
 
         return Job<ReturnType>{
                 job_id,
-                Job<ReturnType>::JobSource::Task,
-                m_task_id,
+                core::Context{core::Context::Source::Task, m_task_id},
                 m_metadata_store,
                 m_data_store,
                 m_storage_factory

--- a/src/spider/core/Context.hpp
+++ b/src/spider/core/Context.hpp
@@ -19,9 +19,9 @@ public:
 
     Context(Source const source, boost::uuids::uuid const id) : m_source{source}, m_id{id} {}
 
-    auto get_source() const -> Source { return m_source; }
+    [[nodiscard]] auto get_source() const -> Source { return m_source; }
 
-    auto get_id() const -> boost::uuids::uuid { return m_id; }
+    [[nodiscard]] auto get_id() const -> boost::uuids::uuid { return m_id; }
 
 private:
     Source m_source;

--- a/src/spider/core/Context.hpp
+++ b/src/spider/core/Context.hpp
@@ -1,0 +1,32 @@
+#ifndef SPIDER_CORE_CONTEXT_HPP
+#define SPIDER_CORE_CONTEXT_HPP
+
+#include <cstdint>
+
+#include <boost/uuid/uuid.hpp>
+
+namespace spider::core {
+/**
+ *  Context class wraps the information about the execution context.
+ *  Context could be either a driver (i.e. client) or a task.
+ */
+class Context {
+public:
+    enum class Source : uint8_t {
+        Driver,
+        Task,
+    };
+
+    Context(Source const source, boost::uuids::uuid const id) : m_source{source}, m_id{id} {}
+
+    auto get_source() const -> Source { return m_source; }
+
+    auto get_id() const -> boost::uuids::uuid { return m_id; }
+
+private:
+    Source m_source;
+    boost::uuids::uuid m_id;
+};
+}  // namespace spider::core
+
+#endif

--- a/src/spider/core/DataCleaner.cpp
+++ b/src/spider/core/DataCleaner.cpp
@@ -1,0 +1,53 @@
+#include "DataCleaner.hpp"
+
+#include <exception>
+#include <memory>
+#include <utility>
+#include <variant>
+
+#include <boost/uuid/uuid.hpp>
+
+#include "../core/Error.hpp"
+#include "../storage/DataStorage.hpp"
+#include "../storage/StorageConnection.hpp"
+#include "../storage/StorageFactory.hpp"
+#include "Context.hpp"
+
+namespace spider::core {
+DataCleaner::DataCleaner(
+        boost::uuids::uuid data_id,
+        Context const& context,
+        std::shared_ptr<DataStorage> data_storage,
+        std::shared_ptr<StorageFactory> storage_factory,
+        std::shared_ptr<StorageConnection> storage_connection
+)
+        : m_data_id{data_id},
+          m_context{context},
+          m_data_store{std::move(data_storage)},
+          m_storage_factory{std::move(storage_factory)},
+          m_connection{std::move(storage_connection)} {}
+
+DataCleaner::~DataCleaner() {
+    int const num_exceptions = std::uncaught_exceptions();
+    // If destructor is called during stack unwinding, do not remove data reference.
+    if (num_exceptions > m_num_exceptions) {
+        return;
+    }
+    std::shared_ptr<StorageConnection> conn = m_connection;
+    if (nullptr == conn) {
+        std::variant<std::unique_ptr<StorageConnection>, StorageErr> conn_result
+                = m_storage_factory->provide_storage_connection();
+        // If we cannot get the connection, that means we are in a worker.
+        // Just let the reference stays until the job is removed.
+        if (std::holds_alternative<StorageErr>(conn_result)) {
+            return;
+        }
+        conn = std::move(std::get<std::unique_ptr<StorageConnection>>(conn_result));
+    }
+    if (m_context.get_source() == Context::Source::Driver) {
+        m_data_store->remove_driver_reference(*conn, m_data_id, m_context.get_id());
+    } else {
+        m_data_store->remove_task_reference(*conn, m_data_id, m_context.get_id());
+    }
+}
+}  // namespace spider::core

--- a/src/spider/core/DataCleaner.hpp
+++ b/src/spider/core/DataCleaner.hpp
@@ -1,0 +1,52 @@
+#ifndef SPIDER_CORE_DATACLEANER_HPP
+#define SPIDER_CORE_DATACLEANER_HPP
+
+#include <exception>
+#include <memory>
+
+#include <boost/uuid/uuid.hpp>
+
+#include "../storage/DataStorage.hpp"
+#include "../storage/StorageConnection.hpp"
+#include "../storage/StorageFactory.hpp"
+#include "Context.hpp"
+
+namespace spider::core {
+/*
+ * Keep tracks of the number of exceptions and clean up the data if the `Data`
+ * holding `unique_ptr` to this class is destructed.
+ *
+ * We cannot use custom destructor directly inside `Data` in case of moved
+ * `Data` object being destructed, so we work around by using a `unique_ptr`
+ * so the destructor is not called by moved object.
+ */
+class DataCleaner {
+public:
+    DataCleaner(
+            boost::uuids::uuid data_id,
+            Context const& context,
+            std::shared_ptr<DataStorage> data_storage,
+            std::shared_ptr<StorageFactory> storage_factory,
+            std::shared_ptr<StorageConnection> storage_connection
+    );
+    ~DataCleaner();
+
+    // Default copy constructor and assignment operator
+    DataCleaner(DataCleaner const&) = default;
+    auto operator=(DataCleaner const&) -> DataCleaner& = default;
+    // Default move constructor and assignment operator
+    DataCleaner(DataCleaner&&) = default;
+    auto operator=(DataCleaner&&) -> DataCleaner& = default;
+
+private:
+    int m_num_exceptions = std::uncaught_exceptions();
+
+    boost::uuids::uuid m_data_id;
+    Context m_context;
+    std::shared_ptr<DataStorage> m_data_store;
+    std::shared_ptr<StorageFactory> m_storage_factory;
+    std::shared_ptr<StorageConnection> m_connection = nullptr;
+};
+}  // namespace spider::core
+
+#endif

--- a/src/spider/core/DataImpl.hpp
+++ b/src/spider/core/DataImpl.hpp
@@ -6,6 +6,7 @@
 
 #include "../client/Data.hpp"
 #include "../storage/StorageFactory.hpp"
+#include "Context.hpp"
 #include "Data.hpp"
 
 namespace spider::core {
@@ -14,10 +15,11 @@ public:
     template <class T>
     static auto create_data(
             std::unique_ptr<Data> data,
+            Context const& context,
             std::shared_ptr<DataStorage> data_store,
             std::shared_ptr<StorageFactory> storage_factory
     ) -> spider::Data<T> {
-        return spider::Data<T>{std::move(data), data_store, storage_factory};
+        return spider::Data<T>{std::move(data), context, data_store, storage_factory};
     }
 
     template <class T>

--- a/src/spider/core/DriverCleaner.cpp
+++ b/src/spider/core/DriverCleaner.cpp
@@ -1,0 +1,46 @@
+#include "DriverCleaner.hpp"
+
+#include <exception>
+#include <memory>
+#include <utility>
+#include <variant>
+
+#include <boost/uuid/uuid.hpp>
+
+#include "../core/Error.hpp"
+#include "../storage/MetadataStorage.hpp"
+#include "../storage/StorageConnection.hpp"
+#include "../storage/StorageFactory.hpp"
+
+namespace spider::core {
+DriverCleaner::DriverCleaner(
+        boost::uuids::uuid driver_id,
+        std::shared_ptr<MetadataStorage> metadata_store,
+        std::shared_ptr<StorageFactory> storage_factory,
+        std::shared_ptr<StorageConnection> connection
+)
+        : m_driver_id{driver_id},
+          m_metadata_store{std::move(metadata_store)},
+          m_storage_factory{std::move(storage_factory)},
+          m_connection{std::move(connection)} {}
+
+DriverCleaner::~DriverCleaner() {
+    int const num_exceptions = std::uncaught_exceptions();
+    // If destructor is called during stack unwinding, do not remove data reference.
+    if (num_exceptions > m_num_exceptions) {
+        return;
+    }
+    std::shared_ptr<StorageConnection> conn = m_connection;
+    if (nullptr == conn) {
+        std::variant<std::unique_ptr<StorageConnection>, StorageErr> conn_result
+                = m_storage_factory->provide_storage_connection();
+        // If we cannot get the connection, that means we are in a worker.
+        // Just let the reference stays until the job is removed.
+        if (std::holds_alternative<StorageErr>(conn_result)) {
+            return;
+        }
+        conn = std::move(std::get<std::unique_ptr<StorageConnection>>(conn_result));
+    }
+    m_metadata_store->remove_driver(*conn, m_driver_id);
+}
+}  // namespace spider::core

--- a/src/spider/core/DriverCleaner.hpp
+++ b/src/spider/core/DriverCleaner.hpp
@@ -1,0 +1,50 @@
+#ifndef SPIDER_CORE_DRIVERCLEANER_HPP
+#define SPIDER_CORE_DRIVERCLEANER_HPP
+
+#include <exception>
+#include <memory>
+
+#include <boost/uuid/uuid.hpp>
+
+#include "../storage/MetadataStorage.hpp"
+#include "../storage/StorageConnection.hpp"
+#include "../storage/StorageFactory.hpp"
+
+namespace spider::core {
+/*
+ * Keep tracks of the number of exceptions and clean up the driver if the
+ * `Driver` holding `unique_ptr` to this class is destructed.
+ *
+ * We cannot use custom destructor directly inside `Driver` in case of moved
+ * `Driver` object being destructed, so we work around by using a `unique_ptr`
+ * so the destructor is not called by moved object.
+ */
+class DriverCleaner {
+public:
+    DriverCleaner(
+            boost::uuids::uuid driver_id,
+            std::shared_ptr<MetadataStorage> metadata_store,
+            std::shared_ptr<StorageFactory> storage_factory,
+            std::shared_ptr<StorageConnection> connection
+    );
+
+    ~DriverCleaner();
+
+    // Default copy constructor and assignment operator
+    DriverCleaner(DriverCleaner const&) = default;
+    auto operator=(DriverCleaner const&) -> DriverCleaner& = default;
+    // Default move constructor and assignment operator
+    DriverCleaner(DriverCleaner&&) = default;
+    auto operator=(DriverCleaner&&) -> DriverCleaner& = default;
+
+private:
+    int m_num_exceptions = std::uncaught_exceptions();
+
+    boost::uuids::uuid m_driver_id;
+    std::shared_ptr<MetadataStorage> m_metadata_store;
+    std::shared_ptr<StorageFactory> m_storage_factory;
+    std::shared_ptr<StorageConnection> m_connection = nullptr;
+};
+}  // namespace spider::core
+
+#endif  // DRIVERCLEANER_HPP

--- a/src/spider/core/JobCleaner.cpp
+++ b/src/spider/core/JobCleaner.cpp
@@ -1,0 +1,47 @@
+#include "JobCleaner.hpp"
+
+#include <exception>
+#include <memory>
+#include <utility>
+#include <variant>
+
+#include <boost/uuid/uuid.hpp>
+
+#include "../core/Error.hpp"
+#include "../storage/MetadataStorage.hpp"
+#include "../storage/StorageConnection.hpp"
+#include "../storage/StorageFactory.hpp"
+
+namespace spider::core {
+JobCleaner::JobCleaner(
+        boost::uuids::uuid job_id,
+        std::shared_ptr<MetadataStorage> metadata_store,
+        std::shared_ptr<StorageFactory> storage_factory,
+        std::shared_ptr<StorageConnection> connection
+)
+        : m_job_id{job_id},
+          m_metadata_store{std::move(metadata_store)},
+          m_storage_factory{std::move(storage_factory)},
+          m_connection{std::move(connection)} {}
+
+JobCleaner::~JobCleaner() {
+    int const num_exceptions = std::uncaught_exceptions();
+    // If destructor is called during stack unwinding, do not remove data reference.
+    if (num_exceptions > m_num_exceptions) {
+        return;
+    }
+    std::shared_ptr<StorageConnection> conn = m_connection;
+    if (nullptr == conn) {
+        std::variant<std::unique_ptr<StorageConnection>, StorageErr> conn_result
+                = m_storage_factory->provide_storage_connection();
+        // If we cannot get the connection, that means we are in a worker.
+        // Just let the reference stays until the job is removed.
+        if (std::holds_alternative<StorageErr>(conn_result)) {
+            return;
+        }
+        conn = std::move(std::get<std::unique_ptr<StorageConnection>>(conn_result));
+    }
+    m_metadata_store->remove_job(*conn, m_job_id);
+}
+}  // namespace spider::core
+

--- a/src/spider/core/JobCleaner.hpp
+++ b/src/spider/core/JobCleaner.hpp
@@ -1,0 +1,50 @@
+#ifndef SPIDER_CORE_JOB_CLEANER_HPP
+#define SPIDER_CORE_JOB_CLEANER_HPP
+
+#include <exception>
+#include <memory>
+
+#include <boost/uuid/uuid.hpp>
+
+#include "../storage/MetadataStorage.hpp"
+#include "../storage/StorageConnection.hpp"
+#include "../storage/StorageFactory.hpp"
+
+namespace spider::core {
+/*
+ * Keep tracks of the number of exceptions and clean up the job if the `Job`
+ * holding `unique_ptr` to this class is destructed.
+ *
+ * We cannot use custom destructor directly inside `Job` in case of moved
+ * `Job` object being destructed, so we work around by using a `unique_ptr`
+ * so the destructor is not called by moved object.
+ */
+class JobCleaner {
+public:
+    JobCleaner(
+            boost::uuids::uuid job_id,
+            std::shared_ptr<MetadataStorage> metadata_store,
+            std::shared_ptr<StorageFactory> storage_factory,
+            std::shared_ptr<StorageConnection> connection
+    );
+
+    ~JobCleaner();
+
+    // Default copy constructor and assignment operator
+    JobCleaner(JobCleaner const&) = default;
+    auto operator=(JobCleaner const&) -> JobCleaner& = default;
+    // Default move constructor and assignment operator
+    JobCleaner(JobCleaner&&) = default;
+    auto operator=(JobCleaner&&) -> JobCleaner& = default;
+
+private:
+    int m_num_exceptions = std::uncaught_exceptions();
+
+    boost::uuids::uuid m_job_id;
+    std::shared_ptr<MetadataStorage> m_metadata_store;
+    std::shared_ptr<StorageFactory> m_storage_factory;
+    std::shared_ptr<StorageConnection> m_connection = nullptr;
+};
+}  // namespace spider::core
+
+#endif

--- a/src/spider/scheduler/scheduler.cpp
+++ b/src/spider/scheduler/scheduler.cpp
@@ -273,5 +273,8 @@ auto main(int argc, char** argv) -> int {
         return cSignalExitBase + SIGTERM;
     }
 
+    // Clean up driver in storage
+    metadata_store->remove_driver(*conn, scheduler_id);
+
     return 0;
 }

--- a/src/spider/storage/MetadataStorage.hpp
+++ b/src/spider/storage/MetadataStorage.hpp
@@ -32,6 +32,13 @@ public:
     virtual auto get_active_scheduler(StorageConnection& conn, std::vector<Scheduler>* schedulers)
             -> StorageErr
             = 0;
+    /*
+     * Remove the driver from the storage.
+     * @param conn The connection to the storage.
+     * @param id The id of the driver to remove.
+     * @return The error code.
+     */
+    virtual auto remove_driver(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr = 0;
 
     virtual auto
     add_job(StorageConnection& conn,

--- a/src/spider/storage/mysql/MySqlStorage.hpp
+++ b/src/spider/storage/mysql/MySqlStorage.hpp
@@ -40,6 +40,7 @@ public:
     auto add_scheduler(StorageConnection& conn, Scheduler const& scheduler) -> StorageErr override;
     auto get_active_scheduler(StorageConnection& conn, std::vector<Scheduler>* schedulers)
             -> StorageErr override;
+    auto remove_driver(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr override;
     auto add_job(
             StorageConnection& conn,
             boost::uuids::uuid job_id,

--- a/src/spider/worker/FunctionManager.hpp
+++ b/src/spider/worker/FunctionManager.hpp
@@ -314,6 +314,7 @@ public:
                     std::get<i.cValue + 1>(args_tuple)
                             = DataImpl::create_data<TemplateParameterT<T>>(
                                     std::move(data),
+                                    Context{Context::Source::Task, task_id},
                                     data_store,
                                     TaskContextImpl::get_storage_factory(context)
                             );

--- a/tests/storage/test-MetadataStorage.cpp
+++ b/tests/storage/test-MetadataStorage.cpp
@@ -69,6 +69,9 @@ TEMPLATE_LIST_TEST_CASE("Driver heartbeat", "[storage]", spider::test::StorageFa
     REQUIRE(std::ranges::none_of(ids, [&driver_id](boost::uuids::uuid id) {
         return id == driver_id;
     }));
+
+    // Clean up
+    REQUIRE(storage->remove_driver(*conn, driver_id).success());
 }
 
 TEMPLATE_LIST_TEST_CASE("Scheduler addr", "[storage]", spider::test::StorageFactoryTypeList) {
@@ -100,6 +103,9 @@ TEMPLATE_LIST_TEST_CASE("Scheduler addr", "[storage]", spider::test::StorageFact
     // Get non-exist scheduler should fail
     REQUIRE(spider::core::StorageErrType::KeyNotFoundErr
             == storage->get_scheduler_addr(*conn, gen(), &addr_res, &port_res).type);
+
+    // Clean up
+    REQUIRE(storage->remove_driver(*conn, scheduler_id).success());
 }
 
 TEMPLATE_LIST_TEST_CASE(
@@ -593,6 +599,7 @@ TEMPLATE_LIST_TEST_CASE(
 
     // Clean up
     REQUIRE(storage->remove_job(*conn, job_id).success());
+    REQUIRE(storage->remove_driver(*conn, scheduler_id).success());
 }
 }  // namespace
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description

`Spider` clients do not remove data, job or even the driver itself from the storage when the associating object is destructed. For a long running client, the data and jobs that are no longer used cannot be cleaned up because the reference from the driver is still valid in the storage.

This pr fixes the problem by introducing special `DataCleaner`, `JobCleaner` and `DriverCleaner` classes the remove the associated `Data`, `Job` and `Driver` in the destructors if the destructors are not called during stack unwinding.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* [x] GitHub workflows pass.
* [x] Unit tests pass.
* [x] Integration tests pass.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
