### PR TITLE
feat: Add job cancellation for early stop of the job execution.

### DIFF
--- a/src/spider/CMakeLists.txt
+++ b/src/spider/CMakeLists.txt
@@ -61,6 +61,8 @@ set(SPIDER_WORKER_SOURCES
     worker/ChildPid.cpp
     worker/DllLoader.hpp
     worker/DllLoader.cpp
+    worker/ExecutorHandle.hpp
+    worker/ExecutorHandle.cpp
     worker/Process.hpp
     worker/Process.cpp
     worker/TaskExecutor.hpp

--- a/src/spider/client/Job.hpp
+++ b/src/spider/client/Job.hpp
@@ -177,7 +177,7 @@ public:
 
             std::pair<std::string, std::string> res;
             core::StorageErr const err
-                    = m_metadata_storage->get_job_message(*conn, m_id, &res.first, &res.second);
+                    = m_metadata_storage->get_error_message(*conn, m_id, &res.first, &res.second);
             if (false == err.success()) {
                 throw ConnectionException{err.description};
             }
@@ -186,7 +186,7 @@ public:
 
         std::pair<std::string, std::string> res;
         core::StorageErr const err
-                = m_metadata_storage->get_job_message(*m_conn, m_id, &res.first, &res.second);
+                = m_metadata_storage->get_error_message(*m_conn, m_id, &res.first, &res.second);
         if (false == err.success()) {
             throw ConnectionException{err.description};
         }

--- a/src/spider/client/Job.hpp
+++ b/src/spider/client/Job.hpp
@@ -90,8 +90,7 @@ public:
         }
         auto conn = std::move(std::get<std::unique_ptr<core::StorageConnection>>(conn_result));
 
-        core::StorageErr const err
-                = m_metadata_storage->cancel_job(*conn, m_id, "Job cancelled by user");
+        core::StorageErr const err = m_metadata_storage->cancel_job(*conn, m_id);
         if (!err.success()) {
             throw ConnectionException(err.description);
         }

--- a/src/spider/client/Job.hpp
+++ b/src/spider/client/Job.hpp
@@ -92,7 +92,8 @@ public:
         }
         auto conn = std::move(std::get<std::unique_ptr<core::StorageConnection>>(conn_result));
 
-        core::StorageErr const err = m_metadata_storage->cancel_job(*conn, m_id);
+        core::StorageErr const err
+                = m_metadata_storage->cancel_job_by_user(*conn, m_id, "Job cancelled by user.");
         if (!err.success()) {
             throw ConnectionException(err.description);
         }
@@ -158,12 +159,14 @@ public:
     }
 
     /**
-     * NOTE: It is undefined behavior to call this method for a job that is not in the `Failed`
+     * NOTE: It is undefined behavior to call this method for a job that is not in the `Cancelled`
      * state.
      *
      * @return A pair:
-     * - the name of the task function that failed.
-     * - the error message sent from the task through `TaskContext::abort` or from Spider.
+     * - the name of the task function that called `TaskContext::abort`, or "user" if job is
+     *   cancelled by calling `Job::cancel`.
+     * - the error message sent from the task through `TaskContext::abort` or "Job cancelled by
+     *   user." if job is cancelled through `Job::cancel`.
      * @throw spider::ConnectionException
      */
     auto get_error() -> std::pair<std::string, std::string> {

--- a/src/spider/client/TaskContext.cpp
+++ b/src/spider/client/TaskContext.cpp
@@ -1,5 +1,6 @@
 #include "TaskContext.hpp"
 
+#include <cstdlib>
 #include <memory>
 #include <optional>
 #include <string>

--- a/src/spider/storage/MetadataStorage.hpp
+++ b/src/spider/storage/MetadataStorage.hpp
@@ -84,6 +84,17 @@ public:
     cancel_job(StorageConnection& conn, boost::uuids::uuid id, std::string const& message)
             -> StorageErr
             = 0;
+    /**
+     * Get the error message of a cancelled job.
+     * @param conn
+     * @param id The job id.
+     * @param message The error message of the cancellation.
+     * @return The error code.
+     */
+    virtual auto
+    get_job_message(StorageConnection& conn, boost::uuids::uuid id, std::string* message)
+            -> StorageErr
+            = 0;
     virtual auto remove_job(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr = 0;
     virtual auto reset_job(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr = 0;
     virtual auto add_child(StorageConnection& conn, boost::uuids::uuid parent_id, Task const& child)

--- a/src/spider/storage/MetadataStorage.hpp
+++ b/src/spider/storage/MetadataStorage.hpp
@@ -73,13 +73,17 @@ public:
     ) -> StorageErr
             = 0;
     /**
-     * Cancel a job. This will set the job state to CANCELED and set all tasks that have not
-     * finished or started to CANCELED.
+     * Cancel a job. This will set the job state to CANCEL and set all tasks that have not
+     * finished or started to CANCEL.
      * @param conn
      * @param id The job id.
+     * @param message The error message of the cancellation.
      * @return The error code.
      */
-    virtual auto cancel_job(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr = 0;
+    virtual auto
+    cancel_job(StorageConnection& conn, boost::uuids::uuid id, std::string const& message)
+            -> StorageErr
+            = 0;
     virtual auto remove_job(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr = 0;
     virtual auto reset_job(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr = 0;
     virtual auto add_child(StorageConnection& conn, boost::uuids::uuid parent_id, Task const& child)

--- a/src/spider/storage/MetadataStorage.hpp
+++ b/src/spider/storage/MetadataStorage.hpp
@@ -100,6 +100,9 @@ public:
     virtual auto set_task_state(StorageConnection& conn, boost::uuids::uuid id, TaskState state)
             -> StorageErr
             = 0;
+    virtual auto get_task_state(StorageConnection& conn, boost::uuids::uuid id, TaskState* state)
+            -> StorageErr
+            = 0;
     virtual auto set_task_running(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr = 0;
     virtual auto add_task_instance(StorageConnection& conn, TaskInstance const& instance)
             -> StorageErr

--- a/src/spider/storage/MetadataStorage.hpp
+++ b/src/spider/storage/MetadataStorage.hpp
@@ -76,16 +76,20 @@ public:
     ) -> StorageErr
             = 0;
     /**
-     * Cancel a job. This will set the job state to CANCEL and set all tasks that have not
-     * finished or started to CANCEL.
+     * Cancel a job by user. Set the job state to CANCEL and set all tasks that have not finished
+     * or started to CANCEL.
      * @param conn
      * @param id The job id.
+     * @param message The error message of the cancellation.
      * @return The error code.
      */
-    virtual auto cancel_job(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr = 0;
+    virtual auto
+    cancel_job_by_user(StorageConnection& conn, boost::uuids::uuid id, std::string const& message)
+            -> StorageErr
+            = 0;
     /**
-     * Cancel a job that owns the task. This will set the job state to CANCEL and set all tasks
-     * that have not finished or started to CANCEL.
+     * Cancel a job that owns the task. Set the job state to CANCEL and set all tasks that have not
+     * finished or started to CANCEL.
      * @param conn
      * @param id The task id.
      * @param message The error message of the cancellation.

--- a/src/spider/storage/MetadataStorage.hpp
+++ b/src/spider/storage/MetadataStorage.hpp
@@ -77,7 +77,7 @@ public:
             = 0;
     /**
      * Cancel a job by user. Set the job state to CANCEL and set all tasks that have not finished
-     * or started to CANCEL.
+     * or started to CANCEL. Set the error message of the job and offender to "user".
      * @param conn
      * @param id The job id.
      * @param message The error message of the cancellation.
@@ -88,8 +88,9 @@ public:
             -> StorageErr
             = 0;
     /**
-     * Cancel a job that owns the task. Set the job state to CANCEL and set all tasks that have not
-     * finished or started to CANCEL.
+     * Cancel the job from the task. Set the job state to CANCEL and set all tasks that have not
+     * finished or started to CANCEL. Se the error message of the job and offender to the function
+     * name of the task.
      * @param conn
      * @param id The task id.
      * @param message The error message of the cancellation.
@@ -103,14 +104,15 @@ public:
      * Get the error message of a cancelled job.
      * @param conn
      * @param id The job id.
-     * @param function_name The function name of the cancelled task.
+     * @param offender The function name of the cancelling task if job cancelled by task, "user" if
+     *                 the job is cancelled by user.
      * @param message The error message of the cancellation.
      * @return The error code.
      */
     virtual auto get_error_message(
             StorageConnection& conn,
             boost::uuids::uuid id,
-            std::string* function_name,
+            std::string* offender,
             std::string* message
     ) -> StorageErr
             = 0;

--- a/src/spider/storage/MetadataStorage.hpp
+++ b/src/spider/storage/MetadataStorage.hpp
@@ -85,6 +85,18 @@ public:
             -> StorageErr
             = 0;
     /**
+     * Cancel a job that owns the task. This will set the job state to CANCEL and set all tasks
+     * that have not finished or started to CANCEL.
+     * @param conn
+     * @param id The task id.
+     * @param message The error message of the cancellation.
+     * @return The error code.
+     */
+    virtual auto
+    cancel_job_by_task(StorageConnection& conn, boost::uuids::uuid id, std::string const& message)
+            -> StorageErr
+            = 0;
+    /**
      * Get the error message of a cancelled job.
      * @param conn
      * @param id The job id.

--- a/src/spider/storage/MetadataStorage.hpp
+++ b/src/spider/storage/MetadataStorage.hpp
@@ -100,12 +100,16 @@ public:
      * Get the error message of a cancelled job.
      * @param conn
      * @param id The job id.
+     * @page function_name The function name of the cancelled task.
      * @param message The error message of the cancellation.
      * @return The error code.
      */
-    virtual auto
-    get_job_message(StorageConnection& conn, boost::uuids::uuid id, std::string* message)
-            -> StorageErr
+    virtual auto get_job_message(
+            StorageConnection& conn,
+            boost::uuids::uuid id,
+            std::string* function_name,
+            std::string* message
+    ) -> StorageErr
             = 0;
     virtual auto remove_job(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr = 0;
     virtual auto reset_job(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr = 0;

--- a/src/spider/storage/MetadataStorage.hpp
+++ b/src/spider/storage/MetadataStorage.hpp
@@ -103,7 +103,7 @@ public:
      * @param message The error message of the cancellation.
      * @return The error code.
      */
-    virtual auto get_job_message(
+    virtual auto get_error_message(
             StorageConnection& conn,
             boost::uuids::uuid id,
             std::string* function_name,

--- a/src/spider/storage/MetadataStorage.hpp
+++ b/src/spider/storage/MetadataStorage.hpp
@@ -77,13 +77,9 @@ public:
      * finished or started to CANCEL.
      * @param conn
      * @param id The job id.
-     * @param message The error message of the cancellation.
      * @return The error code.
      */
-    virtual auto
-    cancel_job(StorageConnection& conn, boost::uuids::uuid id, std::string const& message)
-            -> StorageErr
-            = 0;
+    virtual auto cancel_job(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr = 0;
     /**
      * Cancel a job that owns the task. This will set the job state to CANCEL and set all tasks
      * that have not finished or started to CANCEL.

--- a/src/spider/storage/MetadataStorage.hpp
+++ b/src/spider/storage/MetadataStorage.hpp
@@ -100,7 +100,7 @@ public:
      * Get the error message of a cancelled job.
      * @param conn
      * @param id The job id.
-     * @page function_name The function name of the cancelled task.
+     * @param function_name The function name of the cancelled task.
      * @param message The error message of the cancellation.
      * @return The error code.
      */

--- a/src/spider/storage/MetadataStorage.hpp
+++ b/src/spider/storage/MetadataStorage.hpp
@@ -72,6 +72,14 @@ public:
             std::vector<boost::uuids::uuid>* job_ids
     ) -> StorageErr
             = 0;
+    /**
+     * Cancel a job. This will set the job state to CANCELED and set all tasks that have not
+     * finished or started to CANCELED.
+     * @param conn
+     * @param id The job id.
+     * @return The error code.
+     */
+    virtual auto cancel_job(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr = 0;
     virtual auto remove_job(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr = 0;
     virtual auto reset_job(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr = 0;
     virtual auto add_child(StorageConnection& conn, boost::uuids::uuid parent_id, Task const& child)

--- a/src/spider/storage/mysql/MySqlStorage.cpp
+++ b/src/spider/storage/mysql/MySqlStorage.cpp
@@ -1103,7 +1103,7 @@ auto MySqlMetadataStorage::cancel_job_by_user(
         // Set the cancel message
         std::unique_ptr<sql::PreparedStatement> message_statement(
                 static_cast<MySqlConnection&>(conn)->prepareStatement(
-                        "INSERT INTO `job_errors` (`job_id`, `func_name`, `message`) VALUES (?, ?, "
+                        "INSERT INTO `job_errors` (`job_id`, `offender`, `message`) VALUES (?, ?, "
                         "?) "
                 )
         );
@@ -1162,7 +1162,7 @@ auto MySqlMetadataStorage::cancel_job_by_task(
         // Set the cancel message
         std::unique_ptr<sql::PreparedStatement> message_statement(
                 static_cast<MySqlConnection&>(conn)->prepareStatement(
-                        "INSERT INTO `job_errors` (`job_id`, `func_name`, `message`) VALUES (?, ?, "
+                        "INSERT INTO `job_errors` (`job_id`, `offender`, `message`) VALUES (?, ?, "
                         "?) "
                 )
         );
@@ -1181,13 +1181,13 @@ auto MySqlMetadataStorage::cancel_job_by_task(
 auto MySqlMetadataStorage::get_error_message(
         StorageConnection& conn,
         boost::uuids::uuid const id,
-        std::string* function_name,
+        std::string* offender,
         std::string* message
 ) -> StorageErr {
     try {
         std::unique_ptr<sql::PreparedStatement> statement{
                 static_cast<MySqlConnection&>(conn)->prepareStatement(
-                        "SELECT `func_name`, `message` FROM `job_errors` WHERE `job_id` = ?"
+                        "SELECT `offender`, `message` FROM `job_errors` WHERE `job_id` = ?"
                 )
         };
         sql::bytes id_bytes = uuid_get_bytes(id);
@@ -1198,7 +1198,7 @@ auto MySqlMetadataStorage::get_error_message(
             return StorageErr{StorageErrType::KeyNotFoundErr, "No messages found"};
         }
         res->next();
-        *function_name = get_sql_string(res->getString("func_name"));
+        *offender = get_sql_string(res->getString("func_name"));
         *message = get_sql_string(res->getString("message"));
     } catch (sql::SQLException& e) {
         static_cast<MySqlConnection&>(conn)->rollback();

--- a/src/spider/storage/mysql/MySqlStorage.cpp
+++ b/src/spider/storage/mysql/MySqlStorage.cpp
@@ -1080,11 +1080,11 @@ auto MySqlMetadataStorage::cancel_job(
         // Set the cancel message
         std::unique_ptr<sql::PreparedStatement> message_statement(
                 static_cast<MySqlConnection&>(conn)->prepareStatement(
-                        "UPDATE `jobs` SET `message` = ? WHERE `id` = ?"
+                        "INSERT INTO `job_errors` (`job_id`, `message`) VALUES (?, ?) "
                 )
         );
-        message_statement->setString(1, message);
-        message_statement->setBytes(2, &id_bytes);
+        message_statement->setBytes(1, &id_bytes);
+        message_statement->setString(2, message);
         message_statement->executeUpdate();
     } catch (sql::SQLException& e) {
         static_cast<MySqlConnection&>(conn)->rollback();

--- a/src/spider/storage/mysql/MySqlStorage.cpp
+++ b/src/spider/storage/mysql/MySqlStorage.cpp
@@ -1840,7 +1840,8 @@ auto MySqlMetadataStorage::task_fail(
             // Set the task fail if the last task instance fails
             std::unique_ptr<sql::PreparedStatement> const task_statement(
                     static_cast<MySqlConnection&>(conn)->prepareStatement(
-                            "UPDATE `tasks` SET `state` = 'fail' WHERE `id` = ?"
+                            "UPDATE `tasks` SET `state` = 'fail' WHERE `id` = ? AND `state` = "
+                            "'running'"
                     )
             );
             task_statement->setBytes(1, &task_id_bytes);
@@ -1849,7 +1850,7 @@ auto MySqlMetadataStorage::task_fail(
             std::unique_ptr<sql::PreparedStatement> const job_statement(
                     static_cast<MySqlConnection&>(conn)->prepareStatement(
                             "UPDATE `jobs` SET `state` = 'fail' WHERE `id` = (SELECT `job_id` FROM "
-                            "`tasks` WHERE `id` = ?)"
+                            "`tasks` WHERE `id` = ?) AND `state` = 'running'"
                     )
             );
             job_statement->setBytes(1, &task_id_bytes);

--- a/src/spider/storage/mysql/MySqlStorage.cpp
+++ b/src/spider/storage/mysql/MySqlStorage.cpp
@@ -1198,7 +1198,7 @@ auto MySqlMetadataStorage::get_error_message(
             return StorageErr{StorageErrType::KeyNotFoundErr, "No messages found"};
         }
         res->next();
-        *offender = get_sql_string(res->getString("func_name"));
+        *offender = get_sql_string(res->getString("offender"));
         *message = get_sql_string(res->getString("message"));
     } catch (sql::SQLException& e) {
         static_cast<MySqlConnection&>(conn)->rollback();

--- a/src/spider/storage/mysql/MySqlStorage.cpp
+++ b/src/spider/storage/mysql/MySqlStorage.cpp
@@ -1164,7 +1164,7 @@ auto MySqlMetadataStorage::cancel_job_by_task(
     return StorageErr{};
 }
 
-auto MySqlMetadataStorage::get_job_message(
+auto MySqlMetadataStorage::get_error_message(
         StorageConnection& conn,
         boost::uuids::uuid const id,
         std::string* function_name,

--- a/src/spider/storage/mysql/MySqlStorage.hpp
+++ b/src/spider/storage/mysql/MySqlStorage.hpp
@@ -73,6 +73,9 @@ public:
     ) -> StorageErr override;
     auto cancel_job(StorageConnection& conn, boost::uuids::uuid id, std::string const& message)
             -> StorageErr override;
+    auto
+    cancel_job_by_task(StorageConnection& conn, boost::uuids::uuid id, std::string const& message)
+            -> StorageErr override;
     auto get_job_message(StorageConnection& conn, boost::uuids::uuid id, std::string* message)
             -> StorageErr override;
     auto remove_job(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr override;

--- a/src/spider/storage/mysql/MySqlStorage.hpp
+++ b/src/spider/storage/mysql/MySqlStorage.hpp
@@ -71,7 +71,8 @@ public:
             boost::uuids::uuid client_id,
             std::vector<boost::uuids::uuid>* job_ids
     ) -> StorageErr override;
-    auto cancel_job(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr override;
+    auto cancel_job(StorageConnection& conn, boost::uuids::uuid id, std::string const& message)
+            -> StorageErr override;
     auto remove_job(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr override;
     auto reset_job(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr override;
     auto add_child(StorageConnection& conn, boost::uuids::uuid parent_id, Task const& child)

--- a/src/spider/storage/mysql/MySqlStorage.hpp
+++ b/src/spider/storage/mysql/MySqlStorage.hpp
@@ -71,8 +71,7 @@ public:
             boost::uuids::uuid client_id,
             std::vector<boost::uuids::uuid>* job_ids
     ) -> StorageErr override;
-    auto cancel_job(StorageConnection& conn, boost::uuids::uuid id, std::string const& message)
-            -> StorageErr override;
+    auto cancel_job(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr override;
     auto
     cancel_job_by_task(StorageConnection& conn, boost::uuids::uuid id, std::string const& message)
             -> StorageErr override;

--- a/src/spider/storage/mysql/MySqlStorage.hpp
+++ b/src/spider/storage/mysql/MySqlStorage.hpp
@@ -77,7 +77,7 @@ public:
     auto
     cancel_job_by_task(StorageConnection& conn, boost::uuids::uuid id, std::string const& message)
             -> StorageErr override;
-    auto get_job_message(
+    auto get_error_message(
             StorageConnection& conn,
             boost::uuids::uuid id,
             std::string* function_name,

--- a/src/spider/storage/mysql/MySqlStorage.hpp
+++ b/src/spider/storage/mysql/MySqlStorage.hpp
@@ -73,6 +73,8 @@ public:
     ) -> StorageErr override;
     auto cancel_job(StorageConnection& conn, boost::uuids::uuid id, std::string const& message)
             -> StorageErr override;
+    auto get_job_message(StorageConnection& conn, boost::uuids::uuid id, std::string* message)
+            -> StorageErr override;
     auto remove_job(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr override;
     auto reset_job(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr override;
     auto add_child(StorageConnection& conn, boost::uuids::uuid parent_id, Task const& child)

--- a/src/spider/storage/mysql/MySqlStorage.hpp
+++ b/src/spider/storage/mysql/MySqlStorage.hpp
@@ -82,7 +82,7 @@ public:
     auto get_error_message(
             StorageConnection& conn,
             boost::uuids::uuid id,
-            std::string* function_name,
+            std::string* offender,
             std::string* message
     ) -> StorageErr override;
     auto remove_job(StorageConnection& conn, boost::uuids::uuid id) noexcept -> StorageErr override;

--- a/src/spider/storage/mysql/MySqlStorage.hpp
+++ b/src/spider/storage/mysql/MySqlStorage.hpp
@@ -76,8 +76,12 @@ public:
     auto
     cancel_job_by_task(StorageConnection& conn, boost::uuids::uuid id, std::string const& message)
             -> StorageErr override;
-    auto get_job_message(StorageConnection& conn, boost::uuids::uuid id, std::string* message)
-            -> StorageErr override;
+    auto get_job_message(
+            StorageConnection& conn,
+            boost::uuids::uuid id,
+            std::string* function_name,
+            std::string* message
+    ) -> StorageErr override;
     auto remove_job(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr override;
     auto reset_job(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr override;
     auto add_child(StorageConnection& conn, boost::uuids::uuid parent_id, Task const& child)

--- a/src/spider/storage/mysql/MySqlStorage.hpp
+++ b/src/spider/storage/mysql/MySqlStorage.hpp
@@ -73,7 +73,9 @@ public:
             boost::uuids::uuid client_id,
             std::vector<boost::uuids::uuid>* job_ids
     ) -> StorageErr override;
-    auto cancel_job(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr override;
+    auto
+    cancel_job_by_user(StorageConnection& conn, boost::uuids::uuid id, std::string const& message)
+            -> StorageErr override;
     auto
     cancel_job_by_task(StorageConnection& conn, boost::uuids::uuid id, std::string const& message)
             -> StorageErr override;

--- a/src/spider/storage/mysql/MySqlStorage.hpp
+++ b/src/spider/storage/mysql/MySqlStorage.hpp
@@ -87,6 +87,8 @@ public:
     ) -> StorageErr override;
     auto set_task_state(StorageConnection& conn, boost::uuids::uuid id, TaskState state)
             -> StorageErr override;
+    auto get_task_state(StorageConnection& conn, boost::uuids::uuid id, TaskState* state)
+            -> StorageErr override;
     auto set_task_running(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr override;
     auto add_task_instance(StorageConnection& conn, TaskInstance const& instance)
             -> StorageErr override;

--- a/src/spider/storage/mysql/MySqlStorage.hpp
+++ b/src/spider/storage/mysql/MySqlStorage.hpp
@@ -71,6 +71,7 @@ public:
             boost::uuids::uuid client_id,
             std::vector<boost::uuids::uuid>* job_ids
     ) -> StorageErr override;
+    auto cancel_job(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr override;
     auto remove_job(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr override;
     auto reset_job(StorageConnection& conn, boost::uuids::uuid id) -> StorageErr override;
     auto add_child(StorageConnection& conn, boost::uuids::uuid parent_id, Task const& child)

--- a/src/spider/storage/mysql/mysql_stmt.hpp
+++ b/src/spider/storage/mysql/mysql_stmt.hpp
@@ -32,6 +32,13 @@ std::string const cCreateJobTable = R"(CREATE TABLE IF NOT EXISTS jobs (
     PRIMARY KEY (`id`)
 ))";
 
+std::string const cCreateJobErrorTable = R"(CREATE TABLE IF NOT EXISTS `job_errors` (
+    `job_id` BINARY(16) NOT NULL,
+    `message` VARCHAR(999) NOT NULL,
+    CONSTRAINT `job_error_job_id` FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+    PRIMARY KEY (`job_id`)
+))";
+
 std::string const cCreateTaskTable = R"(CREATE TABLE IF NOT EXISTS tasks (
     `id` BINARY(16) NOT NULL,
     `job_id` BINARY(16) NOT NULL,
@@ -167,10 +174,11 @@ std::string const cCreateTaskKVDataTable = R"(CREATE TABLE IF NOT EXISTS `task_k
     CONSTRAINT `kv_data_task_id` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
 ))";
 
-std::array<std::string const, 17> const cCreateStorage = {
+std::array<std::string const, 18> const cCreateStorage = {
         cCreateDriverTable,  // drivers table must be created before data_ref_driver
         cCreateSchedulerTable,
-        cCreateJobTable,  // jobs table must be created before task
+        cCreateJobTable,  // jobs table must be created before task and job_error
+        cCreateJobErrorTable,
         cCreateTaskTable,  // tasks table must be created before data_ref_task
         cCreateDataTable,  // data table must be created before task_outputs
         cCreateDataLocalityTable,

--- a/src/spider/storage/mysql/mysql_stmt.hpp
+++ b/src/spider/storage/mysql/mysql_stmt.hpp
@@ -34,6 +34,7 @@ std::string const cCreateJobTable = R"(CREATE TABLE IF NOT EXISTS jobs (
 
 std::string const cCreateJobErrorTable = R"(CREATE TABLE IF NOT EXISTS `job_errors` (
     `job_id` BINARY(16) NOT NULL,
+    `func_name` VARCHAR(64) NOT NULL,
     `message` VARCHAR(999) NOT NULL,
     CONSTRAINT `job_error_job_id` FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
     PRIMARY KEY (`job_id`)

--- a/src/spider/storage/mysql/mysql_stmt.hpp
+++ b/src/spider/storage/mysql/mysql_stmt.hpp
@@ -34,7 +34,7 @@ std::string const cCreateJobTable = R"(CREATE TABLE IF NOT EXISTS jobs (
 
 std::string const cCreateJobErrorTable = R"(CREATE TABLE IF NOT EXISTS `job_errors` (
     `job_id` BINARY(16) NOT NULL,
-    `func_name` VARCHAR(64) NOT NULL,
+    `offender` VARCHAR(64) NOT NULL,
     `message` VARCHAR(999) NOT NULL,
     CONSTRAINT `job_error_job_id` FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
     PRIMARY KEY (`job_id`)

--- a/src/spider/worker/ExecutorHandle.cpp
+++ b/src/spider/worker/ExecutorHandle.cpp
@@ -3,7 +3,7 @@
 #include <mutex>
 
 namespace spider::worker {
-auto ExecutorHandle::get_task_id() const -> std::optional<boost::uuids::uuid> {
+auto ExecutorHandle::get_task_id() -> std::optional<boost::uuids::uuid> {
     std::lock_guard const lock_guard{m_mutex};
     if (nullptr != m_executor) {
         return m_task_id;
@@ -11,7 +11,7 @@ auto ExecutorHandle::get_task_id() const -> std::optional<boost::uuids::uuid> {
     return std::nullopt;
 }
 
-auto ExecutorHandle::get_executor() const -> TaskExecutor* {
+auto ExecutorHandle::get_executor() -> TaskExecutor* {
     std::lock_guard const lock_guard{m_mutex};
     return m_executor;
 }

--- a/src/spider/worker/ExecutorHandle.cpp
+++ b/src/spider/worker/ExecutorHandle.cpp
@@ -11,7 +11,7 @@ namespace spider::worker {
 auto ExecutorHandle::get_task_id() -> std::optional<boost::uuids::uuid> {
     std::lock_guard const lock_guard{m_mutex};
     if (nullptr != m_executor) {
-        return m_task_id;
+        return m_executor->get_task_id();
     }
     return std::nullopt;
 }
@@ -23,15 +23,13 @@ auto ExecutorHandle::cancel_executor() -> void {
     }
 }
 
-auto ExecutorHandle::set(boost::uuids::uuid const task_id, TaskExecutor* executor) -> void {
+auto ExecutorHandle::set(TaskExecutor* executor) -> void {
     std::lock_guard const lock_guard{m_mutex};
-    m_task_id = task_id;
     m_executor = executor;
 }
 
 auto ExecutorHandle::clear() -> void {
     std::lock_guard const lock_guard{m_mutex};
-    m_task_id = boost::uuids::uuid{};
     m_executor = nullptr;
 }
 }  // namespace spider::worker

--- a/src/spider/worker/ExecutorHandle.cpp
+++ b/src/spider/worker/ExecutorHandle.cpp
@@ -1,6 +1,11 @@
 #include "ExecutorHandle.hpp"
 
 #include <mutex>
+#include <optional>
+
+#include <boost/uuid/uuid.hpp>
+
+#include "TaskExecutor.hpp"
 
 namespace spider::worker {
 auto ExecutorHandle::get_task_id() -> std::optional<boost::uuids::uuid> {

--- a/src/spider/worker/ExecutorHandle.cpp
+++ b/src/spider/worker/ExecutorHandle.cpp
@@ -16,7 +16,7 @@ auto ExecutorHandle::get_task_id() -> std::optional<boost::uuids::uuid> {
     return std::nullopt;
 }
 
-auto ExecutorHandle::executor_cancel() -> void {
+auto ExecutorHandle::cancel_executor() -> void {
     std::lock_guard const lock_guard{m_mutex};
     if (nullptr != m_executor) {
         m_executor->cancel();

--- a/src/spider/worker/ExecutorHandle.cpp
+++ b/src/spider/worker/ExecutorHandle.cpp
@@ -32,4 +32,7 @@ auto ExecutorHandle::clear() -> void {
     std::lock_guard const lock_guard{m_mutex};
     m_executor = nullptr;
 }
+
+TaskExecutor* ExecutorHandle::m_executor = nullptr;
+std::mutex ExecutorHandle::m_mutex;
 }  // namespace spider::worker

--- a/src/spider/worker/ExecutorHandle.cpp
+++ b/src/spider/worker/ExecutorHandle.cpp
@@ -1,0 +1,30 @@
+#include "ExecutorHandle.hpp"
+
+#include <mutex>
+
+namespace spider::worker {
+auto ExecutorHandle::get_task_id() const -> std::optional<boost::uuids::uuid> {
+    std::lock_guard const lock_guard{m_mutex};
+    if (nullptr != m_executor) {
+        return m_task_id;
+    }
+    return std::nullopt;
+}
+
+auto ExecutorHandle::get_executor() const -> TaskExecutor* {
+    std::lock_guard const lock_guard{m_mutex};
+    return m_executor;
+}
+
+auto ExecutorHandle::set(boost::uuids::uuid const task_id, TaskExecutor* executor) -> void {
+    std::lock_guard const lock_guard{m_mutex};
+    m_task_id = task_id;
+    m_executor = executor;
+}
+
+auto ExecutorHandle::clear() -> void {
+    std::lock_guard const lock_guard{m_mutex};
+    m_task_id = boost::uuids::uuid{};
+    m_executor = nullptr;
+}
+}  // namespace spider::worker

--- a/src/spider/worker/ExecutorHandle.cpp
+++ b/src/spider/worker/ExecutorHandle.cpp
@@ -16,11 +16,6 @@ auto ExecutorHandle::get_task_id() -> std::optional<boost::uuids::uuid> {
     return std::nullopt;
 }
 
-auto ExecutorHandle::get_executor() -> TaskExecutor* {
-    std::lock_guard const lock_guard{m_mutex};
-    return m_executor;
-}
-
 auto ExecutorHandle::executor_cancel() -> void {
     std::lock_guard const lock_guard{m_mutex};
     if (nullptr != m_executor) {

--- a/src/spider/worker/ExecutorHandle.cpp
+++ b/src/spider/worker/ExecutorHandle.cpp
@@ -21,6 +21,13 @@ auto ExecutorHandle::get_executor() -> TaskExecutor* {
     return m_executor;
 }
 
+auto ExecutorHandle::executor_cancel() -> void {
+    std::lock_guard const lock_guard{m_mutex};
+    if (nullptr != m_executor) {
+        m_executor->cancel();
+    }
+}
+
 auto ExecutorHandle::set(boost::uuids::uuid const task_id, TaskExecutor* executor) -> void {
     std::lock_guard const lock_guard{m_mutex};
     m_task_id = task_id;

--- a/src/spider/worker/ExecutorHandle.hpp
+++ b/src/spider/worker/ExecutorHandle.hpp
@@ -10,22 +10,33 @@
 
 namespace spider::worker {
 /**
- * This class acts as a handle for thread-safe access to the task executor and task id.
+ * This singleton class acts as a handle for thread-safe access to the task executor and task id.
  * It maintains a weak reference to the task executor to prevent multiple destructor calls and
  * ensures that access remains valid only while the executor itself is valid.
  */
 class ExecutorHandle {
 public:
-    [[nodiscard]] auto get_task_id() -> std::optional<boost::uuids::uuid>;
-    auto cancel_executor() -> void;
-    auto set(TaskExecutor* executor) -> void;
-    auto clear() -> void;
+    [[nodiscard]] static auto get_task_id() -> std::optional<boost::uuids::uuid>;
+    static auto cancel_executor() -> void;
+    static auto set(TaskExecutor* executor) -> void;
+    static auto clear() -> void;
+
+    // Delete default constructor
+    ExecutorHandle() = delete;
+    // Delete copy constructor and assignment operator
+    ExecutorHandle(ExecutorHandle const&) = delete;
+    auto operator=(ExecutorHandle const&) -> ExecutorHandle& = delete;
+    // Delete move constructor and assignment operator
+    ExecutorHandle(ExecutorHandle&&) = delete;
+    auto operator=(ExecutorHandle&&) -> ExecutorHandle& = delete;
+    // Default destructor
+    ~ExecutorHandle() = default;
 
 private:
     // Do not use std::shared_ptr to avoid calling destructor twice.
-    TaskExecutor* m_executor = nullptr;
+    static TaskExecutor* m_executor;
 
-    std::mutex m_mutex;
+    static std::mutex m_mutex;
 };
 }  // namespace spider::worker
 

--- a/src/spider/worker/ExecutorHandle.hpp
+++ b/src/spider/worker/ExecutorHandle.hpp
@@ -24,8 +24,10 @@ public:
 
 private:
     boost::uuids::uuid m_task_id;
-    TaskExecutor* m_executor
-            = nullptr;  // Do not use std::shared_ptr to avoid calling destructor twice.
+
+    // Do not use std::shared_ptr to avoid calling destructor twice.
+    TaskExecutor* m_executor = nullptr;
+
     std::mutex m_mutex;
 };
 }  // namespace spider::worker

--- a/src/spider/worker/ExecutorHandle.hpp
+++ b/src/spider/worker/ExecutorHandle.hpp
@@ -17,7 +17,6 @@ namespace spider::worker {
 class ExecutorHandle {
 public:
     [[nodiscard]] auto get_task_id() -> std::optional<boost::uuids::uuid>;
-    [[nodiscard]] auto get_executor() -> TaskExecutor*;
     auto executor_cancel() -> void;
     auto set(boost::uuids::uuid task_id, TaskExecutor* executor) -> void;
     auto clear() -> void;

--- a/src/spider/worker/ExecutorHandle.hpp
+++ b/src/spider/worker/ExecutorHandle.hpp
@@ -17,6 +17,7 @@ class ExecutorHandle {
 public:
     [[nodiscard]] auto get_task_id() -> std::optional<boost::uuids::uuid>;
     [[nodiscard]] auto get_executor() -> TaskExecutor*;
+    auto executor_cancel() -> void;
     auto set(boost::uuids::uuid task_id, TaskExecutor* executor) -> void;
     auto clear() -> void;
 

--- a/src/spider/worker/ExecutorHandle.hpp
+++ b/src/spider/worker/ExecutorHandle.hpp
@@ -18,12 +18,10 @@ class ExecutorHandle {
 public:
     [[nodiscard]] auto get_task_id() -> std::optional<boost::uuids::uuid>;
     auto cancel_executor() -> void;
-    auto set(boost::uuids::uuid task_id, TaskExecutor* executor) -> void;
+    auto set(TaskExecutor* executor) -> void;
     auto clear() -> void;
 
 private:
-    boost::uuids::uuid m_task_id;
-
     // Do not use std::shared_ptr to avoid calling destructor twice.
     TaskExecutor* m_executor = nullptr;
 

--- a/src/spider/worker/ExecutorHandle.hpp
+++ b/src/spider/worker/ExecutorHandle.hpp
@@ -10,8 +10,9 @@
 
 namespace spider::worker {
 /**
- * Provides a thread-safe access to the task executor and other task related variables across
- * threads.
+ * This class acts as a handle for thread-safe access to the task executor and task id.
+ * It maintains a weak reference to the task executor to prevent multiple destructor calls and
+ * ensures that access remains valid only while the executor itself is valid.
  */
 class ExecutorHandle {
 public:
@@ -22,7 +23,7 @@ public:
     auto clear() -> void;
 
 private:
-    boost::uuids::uuid m_task_id;  // The task id is only valid if there is an executor.
+    boost::uuids::uuid m_task_id;
     TaskExecutor* m_executor
             = nullptr;  // Do not use std::shared_ptr to avoid calling destructor twice.
     std::mutex m_mutex;

--- a/src/spider/worker/ExecutorHandle.hpp
+++ b/src/spider/worker/ExecutorHandle.hpp
@@ -2,6 +2,7 @@
 #define SPIDER_WORKER_EXECUTORHANDLE_HPP
 
 #include <mutex>
+#include <optional>
 
 #include <boost/uuid/uuid.hpp>
 

--- a/src/spider/worker/ExecutorHandle.hpp
+++ b/src/spider/worker/ExecutorHandle.hpp
@@ -17,7 +17,7 @@ namespace spider::worker {
 class ExecutorHandle {
 public:
     [[nodiscard]] auto get_task_id() -> std::optional<boost::uuids::uuid>;
-    auto executor_cancel() -> void;
+    auto cancel_executor() -> void;
     auto set(boost::uuids::uuid task_id, TaskExecutor* executor) -> void;
     auto clear() -> void;
 

--- a/src/spider/worker/ExecutorHandle.hpp
+++ b/src/spider/worker/ExecutorHandle.hpp
@@ -1,0 +1,30 @@
+#ifndef SPIDER_WORKER_EXECUTORHANDLE_HPP
+#define SPIDER_WORKER_EXECUTORHANDLE_HPP
+
+#include <mutex>
+
+#include <boost/uuid/uuid.hpp>
+
+#include "TaskExecutor.hpp"
+
+namespace spider::worker {
+/**
+ * Provides a thread-safe access to the task executor and other task related variables across
+ * threads.
+ */
+class ExecutorHandle {
+public:
+    [[nodiscard]] auto get_task_id() const -> std::optional<boost::uuids::uuid>;
+    [[nodiscard]] auto get_executor() const -> TaskExecutor*;
+    auto set(boost::uuids::uuid task_id, TaskExecutor* executor) -> void;
+    auto clear() -> void;
+
+private:
+    boost::uuids::uuid m_task_id;  // The task id is only valid if there is an executor.
+    TaskExecutor* m_executor
+            = nullptr;  // Do not use std::shared_ptr to avoid calling destructor twice.
+    std::mutex m_mutex;
+};
+}  // namespace spider::worker
+
+#endif

--- a/src/spider/worker/ExecutorHandle.hpp
+++ b/src/spider/worker/ExecutorHandle.hpp
@@ -14,8 +14,8 @@ namespace spider::worker {
  */
 class ExecutorHandle {
 public:
-    [[nodiscard]] auto get_task_id() const -> std::optional<boost::uuids::uuid>;
-    [[nodiscard]] auto get_executor() const -> TaskExecutor*;
+    [[nodiscard]] auto get_task_id() -> std::optional<boost::uuids::uuid>;
+    [[nodiscard]] auto get_executor() -> TaskExecutor*;
     auto set(boost::uuids::uuid task_id, TaskExecutor* executor) -> void;
     auto clear() -> void;
 

--- a/src/spider/worker/TaskExecutor.cpp
+++ b/src/spider/worker/TaskExecutor.cpp
@@ -21,25 +21,30 @@ auto TaskExecutor::get_pid() const -> pid_t {
     return m_process->get_pid();
 }
 
-auto TaskExecutor::completed() -> bool {
+auto TaskExecutor::is_completed() -> bool {
     std::lock_guard const lock(m_state_mutex);
     return TaskExecutorState::Succeed == m_state || TaskExecutorState::Error == m_state
            || TaskExecutorState::Cancelled == m_state;
 }
 
-auto TaskExecutor::waiting() -> bool {
+auto TaskExecutor::is_waiting() -> bool {
     std::lock_guard const lock(m_state_mutex);
     return TaskExecutorState::Waiting == m_state;
 }
 
-auto TaskExecutor::succeed() -> bool {
+auto TaskExecutor::is_succeeded() -> bool {
     std::lock_guard const lock(m_state_mutex);
     return TaskExecutorState::Succeed == m_state;
 }
 
-auto TaskExecutor::error() -> bool {
+auto TaskExecutor::is_error() -> bool {
     std::lock_guard const lock(m_state_mutex);
     return TaskExecutorState::Error == m_state;
+}
+
+auto TaskExecutor::is_cancelled() -> bool {
+    std::lock_guard const lock(m_state_mutex);
+    return TaskExecutorState::Cancelled == m_state;
 }
 
 void TaskExecutor::wait() {

--- a/src/spider/worker/TaskExecutor.cpp
+++ b/src/spider/worker/TaskExecutor.cpp
@@ -8,6 +8,7 @@
 #include <tuple>
 #include <vector>
 
+#include <boost/uuid/uuid.hpp>
 #include <fmt/format.h>
 
 #include <spider/io/BoostAsio.hpp>  // IWYU pragma: keep
@@ -17,6 +18,10 @@
 #include <spider/worker/TaskExecutorMessage.hpp>
 
 namespace spider::worker {
+auto TaskExecutor::get_task_id() const -> boost::uuids::uuid {
+    return m_task_id;
+}
+
 auto TaskExecutor::get_pid() const -> pid_t {
     return m_process->get_pid();
 }

--- a/src/spider/worker/TaskExecutor.cpp
+++ b/src/spider/worker/TaskExecutor.cpp
@@ -21,28 +21,28 @@ auto TaskExecutor::get_pid() const -> pid_t {
     return m_process->get_pid();
 }
 
-auto TaskExecutor::is_completed() -> bool {
+auto TaskExecutor::completed() -> bool {
     std::lock_guard const lock(m_state_mutex);
     return TaskExecutorState::Succeed == m_state || TaskExecutorState::Error == m_state
            || TaskExecutorState::Cancelled == m_state;
 }
 
-auto TaskExecutor::is_waiting() -> bool {
+auto TaskExecutor::waiting() -> bool {
     std::lock_guard const lock(m_state_mutex);
     return TaskExecutorState::Waiting == m_state;
 }
 
-auto TaskExecutor::is_succeeded() -> bool {
+auto TaskExecutor::succeeded() -> bool {
     std::lock_guard const lock(m_state_mutex);
     return TaskExecutorState::Succeed == m_state;
 }
 
-auto TaskExecutor::is_error() -> bool {
+auto TaskExecutor::errored() -> bool {
     std::lock_guard const lock(m_state_mutex);
     return TaskExecutorState::Error == m_state;
 }
 
-auto TaskExecutor::is_cancelled() -> bool {
+auto TaskExecutor::cancelled() -> bool {
     std::lock_guard const lock(m_state_mutex);
     return TaskExecutorState::Cancelled == m_state;
 }

--- a/src/spider/worker/TaskExecutor.hpp
+++ b/src/spider/worker/TaskExecutor.hpp
@@ -155,10 +155,11 @@ public:
      */
     [[nodiscard]] auto get_pid() const -> pid_t;
 
-    auto completed() -> bool;
-    auto waiting() -> bool;
-    auto succeed() -> bool;
-    auto error() -> bool;
+    auto is_completed() -> bool;
+    auto is_waiting() -> bool;
+    auto is_succeeded() -> bool;
+    auto is_error() -> bool;
+    auto is_cancelled() -> bool;
 
     void wait();
 

--- a/src/spider/worker/TaskExecutor.hpp
+++ b/src/spider/worker/TaskExecutor.hpp
@@ -50,7 +50,8 @@ public:
                     boost::process::v2::environment::value> const& environment,
             Args&&... args
     )
-            : m_read_pipe(context),
+            : m_task_id(task_id),
+              m_read_pipe(context),
               m_write_pipe(context) {
         std::vector<std::string> process_args{
                 "--func",
@@ -103,7 +104,8 @@ public:
                     boost::process::v2::environment::value> const& environment,
             std::vector<msgpack::sbuffer> const& args_buffers
     )
-            : m_read_pipe(context),
+            : m_task_id(task_id),
+              m_read_pipe(context),
               m_write_pipe(context) {
         std::vector<std::string> process_args{
                 "--func",
@@ -165,6 +167,8 @@ public:
 
     void cancel();
 
+    auto get_task_id() const -> boost::uuids::uuid;
+
     template <class T>
     auto get_result() const -> std::optional<T> {
         return core::response_get_result<T>(m_result_buffer);
@@ -176,6 +180,8 @@ public:
 
 private:
     auto process_output_handler() -> boost::asio::awaitable<void>;
+
+    boost::uuids::uuid m_task_id;
 
     std::mutex m_state_mutex;
     std::condition_variable m_complete_cv;

--- a/src/spider/worker/TaskExecutor.hpp
+++ b/src/spider/worker/TaskExecutor.hpp
@@ -155,11 +155,11 @@ public:
      */
     [[nodiscard]] auto get_pid() const -> pid_t;
 
-    auto is_completed() -> bool;
-    auto is_waiting() -> bool;
-    auto is_succeeded() -> bool;
-    auto is_error() -> bool;
-    auto is_cancelled() -> bool;
+    auto completed() -> bool;
+    auto waiting() -> bool;
+    auto succeeded() -> bool;
+    auto errored() -> bool;
+    auto cancelled() -> bool;
 
     void wait();
 

--- a/src/spider/worker/TaskExecutor.hpp
+++ b/src/spider/worker/TaskExecutor.hpp
@@ -167,7 +167,7 @@ public:
 
     void cancel();
 
-    auto get_task_id() const -> boost::uuids::uuid;
+    [[nodiscard]] auto get_task_id() const -> boost::uuids::uuid;
 
     template <class T>
     auto get_result() const -> std::optional<T> {

--- a/src/spider/worker/worker.cpp
+++ b/src/spider/worker/worker.cpp
@@ -564,12 +564,15 @@ auto main(int argc, char** argv) -> int {
             boost::process::v2::environment::value> const environment_variables
             = get_environment_variable();
 
+    spider::worker::ExecutorHandle executor_handle;
+
     // Start a thread that periodically updates the scheduler's heartbeat
     std::thread heartbeat_thread{
             heartbeat_loop,
             std::cref(storage_factory),
             std::cref(metadata_store),
             std::ref(driver),
+            std::cref(executor_handle),
     };
 
     // Start a thread that processes tasks
@@ -577,6 +580,7 @@ auto main(int argc, char** argv) -> int {
             task_loop,
             std::cref(storage_factory),
             std::cref(metadata_store),
+            std::ref(executor_handle),
             std::ref(client),
             std::cref(storage_url),
             std::cref(libs),

--- a/src/spider/worker/worker.cpp
+++ b/src/spider/worker/worker.cpp
@@ -323,7 +323,7 @@ auto handle_executor_result(
     }
     auto conn = std::move(std::get<std::unique_ptr<spider::core::StorageConnection>>(conn_result));
 
-    if (!executor.is_succeeded()) {
+    if (!executor.succeeded()) {
         spdlog::warn("Task {} failed", task.get_function_name());
         metadata_store->task_fail(
                 *conn,
@@ -443,7 +443,7 @@ auto task_loop(
         executor_handle.clear();
         spider::core::ChildPid::set_pid(0);
 
-        if (executor.is_cancelled()) {
+        if (executor.cancelled()) {
             // If task is cancelled by user or other tasks, the states have been updated in the
             // storage, no need to do anything.
             // If task is cancelled by calling `TaskContext::abort`, the storage has also been

--- a/src/spider/worker/worker.cpp
+++ b/src/spider/worker/worker.cpp
@@ -184,7 +184,6 @@ auto heartbeat_loop(
         check_task_cancel(conn, metadata_store, executor_handle);
 
         spdlog::debug("Updating heartbeat");
-
         spider::core::StorageErr const err
                 = metadata_store->update_heartbeat(*conn, driver.get_id());
         if (!err.success()) {

--- a/src/spider/worker/worker.cpp
+++ b/src/spider/worker/worker.cpp
@@ -424,7 +424,7 @@ auto task_loop(
                 arg_buffers
         };
 
-        executor_handle.set(task_id, &executor);
+        executor_handle.set(&executor);
 
         pid_t const pid = executor.get_pid();
         spider::core::ChildPid::set_pid(pid);

--- a/src/spider/worker/worker.cpp
+++ b/src/spider/worker/worker.cpp
@@ -141,7 +141,6 @@ auto check_task_cancel(
     }
     boost::uuids::uuid const task_id = optional_task_id.value();
 
-    // Check if the task is cancelled
     spider::core::TaskState task_state = spider::core::TaskState::Running;
     spider::core::StorageErr err = metadata_store->get_task_state(*conn, task_id, &task_state);
     if (false == err.success()) {

--- a/src/spider/worker/worker.cpp
+++ b/src/spider/worker/worker.cpp
@@ -133,7 +133,7 @@ auto get_environment_variable() -> absl::flat_hash_map<
 auto check_task_cancel(
         std::shared_ptr<spider::core::StorageFactory> storage_factory,
         std::shared_ptr<spider::core::MetadataStorage> metadata_store,
-        spider::worker::ExecutorHandle const& executor_handle
+        spider::worker::ExecutorHandle& executor_handle
 ) -> void {
     std::optional<boost::uuids::uuid> const optional_task_id = executor_handle.get_task_id();
     if (!optional_task_id.has_value()) {
@@ -172,7 +172,7 @@ auto heartbeat_loop(
         std::shared_ptr<spider::core::StorageFactory> const& storage_factory,
         std::shared_ptr<spider::core::MetadataStorage> const& metadata_store,
         spider::core::Driver const& driver,
-        spider::worker::ExecutorHandle const& executor_handle
+        spider::worker::ExecutorHandle& executor_handle
 ) -> void {
     int fail_count = 0;
     while (!spider::core::StopFlag::is_stop_requested()) {
@@ -572,7 +572,7 @@ auto main(int argc, char** argv) -> int {
             std::cref(storage_factory),
             std::cref(metadata_store),
             std::ref(driver),
-            std::cref(executor_handle),
+            std::ref(executor_handle),
     };
 
     // Start a thread that processes tasks

--- a/src/spider/worker/worker.cpp
+++ b/src/spider/worker/worker.cpp
@@ -131,8 +131,8 @@ auto get_environment_variable() -> absl::flat_hash_map<
  * @param executor_handle Handle to the task id and executor.
  */
 auto check_task_cancel(
-        std::shared_ptr<spider::core::StorageFactory> storage_factory,
-        std::shared_ptr<spider::core::MetadataStorage> metadata_store,
+        std::shared_ptr<spider::core::StorageFactory> const& storage_factory,
+        std::shared_ptr<spider::core::MetadataStorage> const& metadata_store,
         spider::worker::ExecutorHandle& executor_handle
 ) -> void {
     std::optional<boost::uuids::uuid> const optional_task_id = executor_handle.get_task_id();

--- a/src/spider/worker/worker.cpp
+++ b/src/spider/worker/worker.cpp
@@ -154,8 +154,7 @@ auto check_task_cancel(
     }
 
     // Cancel the task.
-    spider::worker::TaskExecutor* executor = executor_handle.get_executor();
-    executor->cancel();
+    executor_handle.executor_cancel();
 }
 
 auto heartbeat_loop(

--- a/src/spider/worker/worker.cpp
+++ b/src/spider/worker/worker.cpp
@@ -153,7 +153,7 @@ auto check_task_cancel(
         return;
     }
 
-    // Cancel thet task.
+    // Cancel the task.
     spider::worker::TaskExecutor* executor = executor_handle.get_executor();
     executor->cancel();
 }

--- a/src/spider/worker/worker.cpp
+++ b/src/spider/worker/worker.cpp
@@ -152,8 +152,7 @@ auto check_task_cancel(
         return;
     }
 
-    // Cancel the task.
-    executor_handle.executor_cancel();
+    executor_handle.cancel_executor();
 }
 
 auto heartbeat_loop(

--- a/src/spider/worker/worker.cpp
+++ b/src/spider/worker/worker.cpp
@@ -444,10 +444,10 @@ auto task_loop(
         spider::core::ChildPid::set_pid(0);
 
         if (executor.cancelled()) {
-            // If task is cancelled by user or other tasks, the states have been updated in the
-            // storage, no need to do anything.
-            // If task is cancelled by calling `TaskContext::abort`, the storage has also been
-            // updated, so we also don't need to do anything.
+            // If the task is cancelled by the user or other tasks, the states have already been
+            // updated in the storage, so there's no need to do anything.
+            // If the task is cancelled by calling `TaskContext::abort`, the storage has also been
+            // updated, so again, no further action is needed.
             spdlog::debug("Task {} was cancelled", task.get_function_name());
             continue;
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -108,4 +108,5 @@ add_dependencies(
     worker_test
     client_test
     signal_test
+    cancel_test
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -92,7 +92,7 @@ target_link_libraries(
         spider_client
         worker_test
         Boost::program_options
-        spider_client
+        spdlog::spdlog
 )
 
 add_custom_target(integrationTest ALL)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -83,6 +83,18 @@ target_link_libraries(
         spider_client
 )
 
+add_executable(cancel_test)
+target_sources(cancel_test PRIVATE client/cancel-test.cpp)
+target_link_libraries(
+    cancel_test
+    PRIVATE
+        spider_core
+        spider_client
+        worker_test
+        Boost::program_options
+        spider_client
+)
+
 add_custom_target(integrationTest ALL)
 add_custom_command(
     TARGET integrationTest

--- a/tests/client/cancel-test.cpp
+++ b/tests/client/cancel-test.cpp
@@ -13,9 +13,9 @@
 #include <spdlog/sinks/stdout_color_sinks.h>  // IWYU pragma: keep
 #include <spdlog/spdlog.h>
 
-#include "../../src/spider/client/Driver.hpp"
-#include "../../src/spider/client/Job.hpp"
-#include "../worker/worker-test.hpp"
+#include <spider/client/Driver.hpp>
+#include <spider/client/Job.hpp>
+#include <tests/worker/worker-test.hpp>
 
 namespace {
 auto parse_args(int const argc, char** argv) -> boost::program_options::variables_map {

--- a/tests/client/cancel-test.cpp
+++ b/tests/client/cancel-test.cpp
@@ -64,12 +64,11 @@ auto main(int argc, char** argv) -> int {
         spider::Driver driver{storage_url};
         spdlog::debug("Driver created");
 
-        // Cancel task from user
         spider::Job<int> sleep_job = driver.start(&sleep_test, 3);
-        // Wait for the task to run
+
         std::this_thread::sleep_for(std::chrono::seconds(1));
         sleep_job.cancel();
-        // Check for job status
+
         sleep_job.wait_complete();
         if (spider::JobStatus::Cancelled != sleep_job.get_status()) {
             spdlog::error("Sleep job status is not cancelled");

--- a/tests/client/cancel-test.cpp
+++ b/tests/client/cancel-test.cpp
@@ -4,13 +4,8 @@
 #include <thread>
 #include <utility>
 
-#include <boost/any/bad_any_cast.hpp>
-#include <boost/program_options/errors.hpp>
-#include <boost/program_options/options_description.hpp>
-#include <boost/program_options/parsers.hpp>
-#include <boost/program_options/value_semantic.hpp>
-#include <boost/program_options/variables_map.hpp>
-#include <spdlog/sinks/stdout_color_sinks.h>  // IWYU pragma: keep
+#include <boost/any.hpp>
+#include <boost/program_options.hpp>
 #include <spdlog/spdlog.h>
 
 #include <spider/client/Driver.hpp>
@@ -29,7 +24,6 @@ auto parse_args(int const argc, char** argv) -> boost::program_options::variable
 
     boost::program_options::variables_map variables;
     boost::program_options::store(
-            // NOLINTNEXTLINE(misc-include-cleaner)
             boost::program_options::parse_command_line(argc, argv, desc),
             variables
     );

--- a/tests/client/cancel-test.cpp
+++ b/tests/client/cancel-test.cpp
@@ -71,19 +71,21 @@ auto main(int argc, char** argv) -> int {
 
     // Cancel task from user
     spider::Job<int> sleep_job = driver.start(&sleep_test, 3);
+    // Wait for the task to run
+    std::this_thread::sleep_for(std::chrono::seconds(1));
     sleep_job.cancel();
     // Check for job status
     sleep_job.wait_complete();
     if (spider::JobStatus::Cancelled != sleep_job.get_status()) {
-        spdlog::error("Job status is not cancelled.");
+        spdlog::error("Sleep job status is not cancelled");
         return cJobNotCancelled;
     }
 
     // Cancel task from task
-    spider::Job<int> abort_job = driver.start(&abort_test);
+    spider::Job<int> abort_job = driver.start(&abort_test, 0);
     abort_job.wait_complete();
     if (spider::JobStatus::Cancelled != abort_job.get_status()) {
-        spdlog::error("Job status is not cancelled.");
+        spdlog::error("Abort job status is not cancelled");
         return cJobNotCancelled;
     }
     std::pair<std::string, std::string> const job_errors = abort_job.get_error();

--- a/tests/client/cancel-test.cpp
+++ b/tests/client/cancel-test.cpp
@@ -4,8 +4,13 @@
 #include <thread>
 #include <utility>
 
-#include <boost/any.hpp>
-#include <boost/program_options.hpp>
+#include <boost/any/bad_any_cast.hpp>
+#include <boost/program_options/errors.hpp>
+#include <boost/program_options/options_description.hpp>
+#include <boost/program_options/parsers.hpp>
+#include <boost/program_options/value_semantic.hpp>
+#include <boost/program_options/variables_map.hpp>
+#include <spdlog/sinks/stdout_color_sinks.h>  // IWYU pragma: keep
 #include <spdlog/spdlog.h>
 
 #include <spider/client/Driver.hpp>

--- a/tests/client/cancel-test.cpp
+++ b/tests/client/cancel-test.cpp
@@ -1,0 +1,100 @@
+#include <cstddef>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include <boost/any/bad_any_cast.hpp>
+#include <boost/program_options/errors.hpp>
+#include <boost/program_options/options_description.hpp>
+#include <boost/program_options/parsers.hpp>
+#include <boost/program_options/value_semantic.hpp>
+#include <boost/program_options/variables_map.hpp>
+#include <spdlog/sinks/stdout_color_sinks.h>  // IWYU pragma: keep
+#include <spdlog/spdlog.h>
+
+#include "../../src/spider/client/Data.hpp"
+#include "../../src/spider/client/Driver.hpp"
+#include "../../src/spider/client/Job.hpp"
+#include "../../src/spider/client/TaskGraph.hpp"
+#include "../worker/worker-test.hpp"
+
+namespace {
+auto parse_args(int const argc, char** argv) -> boost::program_options::variables_map {
+    boost::program_options::options_description desc;
+    desc.add_options()("help", "spider client test");
+    desc.add_options()(
+            "storage_url",
+            boost::program_options::value<std::string>(),
+            "storage server url"
+    );
+
+    boost::program_options::variables_map variables;
+    boost::program_options::store(
+            // NOLINTNEXTLINE(misc-include-cleaner)
+            boost::program_options::parse_command_line(argc, argv, desc),
+            variables
+    );
+    boost::program_options::notify(variables);
+    return variables;
+}
+
+constexpr int cCmdArgParseErr = 1;
+constexpr int cJobNotCancelled = 2;
+constexpr int cWrongErrorMessage = 3;
+}  // namespace
+
+auto main(int argc, char** argv) -> int {
+    // NOLINTNEXTLINE(misc-include-cleaner)
+    spdlog::set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%^%l%$] [spider.client] %v");
+#ifndef NDEBUG
+    spdlog::set_level(spdlog::level::trace);
+#endif
+
+    boost::program_options::variables_map const args = parse_args(argc, argv);
+
+    std::string storage_url;
+    try {
+        if (!args.contains("storage_url")) {
+            spdlog::error("storage_url is required");
+            return cCmdArgParseErr;
+        }
+        storage_url = args["storage_url"].as<std::string>();
+    } catch (boost::bad_any_cast& e) {
+        return cCmdArgParseErr;
+    } catch (boost::program_options::error& e) {
+        return cCmdArgParseErr;
+    }
+
+    // Create driver
+    spider::Driver driver{storage_url};
+    spdlog::debug("Driver created");
+
+    // Cancel task from user
+    spider::Job<int> sleep_job = driver.start(&sleep_test, 3);
+    sleep_job.cancel();
+    // Check for job status
+    sleep_job.wait_complete();
+    if (spider::JobStatus::Cancelled != sleep_job.get_status()) {
+        spdlog::error("Job status is not cancelled.");
+        return cJobNotCancelled;
+    }
+
+    // Cancel task from task
+    spider::Job<int> abort_job = driver.start(&abort_test);
+    abort_job.wait_complete();
+    if (spider::JobStatus::Cancelled != abort_job.get_status()) {
+        spdlog::error("Job status is not cancelled.");
+        return cJobNotCancelled;
+    }
+    std::pair<std::string, std::string> const job_errors = abort_job.get_error();
+    if ("abort_test" != job_errors.first) {
+        spdlog::error("Cancelled task wrong function name");
+        return cWrongErrorMessage;
+    }
+    if ("Abort test" != job_errors.second) {
+        spdlog::error("Cancelled task wrong error message");
+        return cWrongErrorMessage;
+    }
+
+    return 0;
+}

--- a/tests/client/cancel-test.cpp
+++ b/tests/client/cancel-test.cpp
@@ -38,7 +38,6 @@ constexpr int cException = 4;
 }  // namespace
 
 auto main(int argc, char** argv) -> int {
-    // NOLINTNEXTLINE(misc-include-cleaner)
     spdlog::set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%^%l%$] [spider.client] %v");
 #ifndef NDEBUG
     spdlog::set_level(spdlog::level::trace);

--- a/tests/client/cancel-test.cpp
+++ b/tests/client/cancel-test.cpp
@@ -29,6 +29,7 @@ auto parse_args(int const argc, char** argv) -> boost::program_options::variable
 
     boost::program_options::variables_map variables;
     boost::program_options::store(
+            // NOLINTNEXTLINE(misc-include-cleaner)
             boost::program_options::parse_command_line(argc, argv, desc),
             variables
     );

--- a/tests/integration/client.py
+++ b/tests/integration/client.py
@@ -72,7 +72,7 @@ def is_head_task(task_id: uuid.UUID, dependencies: List[Tuple[uuid.UUID, uuid.UU
     return not any(dependency[1] == task_id for dependency in dependencies)
 
 
-g_storage_url = "jdbc:mariadb://localhost:3306/spider-storage?user=spider&password=password"
+g_storage_url = "jdbc:mariadb://localhost:3306/spider_test?user=root&password=password"
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/client.py
+++ b/tests/integration/client.py
@@ -72,7 +72,7 @@ def is_head_task(task_id: uuid.UUID, dependencies: List[Tuple[uuid.UUID, uuid.UU
     return not any(dependency[1] == task_id for dependency in dependencies)
 
 
-g_storage_url = "jdbc:mariadb://localhost:3306/spider_test?user=root&password=password"
+g_storage_url = "jdbc:mariadb://localhost:3306/spider-storage?user=spider&password=password"
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/test_cancel.py
+++ b/tests/integration/test_cancel.py
@@ -71,7 +71,8 @@ def scheduler_worker(storage):
 class TestCancel:
 
     # Test that the task can be cancelled by user and from the task.
-    # Execute the cancel_test client.
+    # Execute the cancel_test client, which includes cancelling a running task
+    # and executing a task that cancels itself.
     def test_task_cancel(self, scheduler_worker):
         dir_path = Path(__file__).resolve().parent
         dir_path = dir_path / ".."

--- a/tests/integration/test_cancel.py
+++ b/tests/integration/test_cancel.py
@@ -1,0 +1,84 @@
+import subprocess
+import time
+import uuid
+from pathlib import Path
+from typing import Tuple
+
+import msgpack
+import pytest
+
+from .client import (
+    add_driver,
+    add_driver_data,
+    Data,
+    Driver,
+    g_storage_url,
+    get_task_outputs,
+    get_task_state,
+    remove_data,
+    remove_job,
+    storage,
+    submit_job,
+    Task,
+    TaskGraph,
+    TaskInput,
+    TaskOutput,
+)
+from .utils import g_scheduler_port
+
+
+def start_scheduler_worker(
+    storage_url: str, scheduler_port: int
+) -> Tuple[subprocess.Popen, subprocess.Popen]:
+    # Start the scheduler
+    dir_path = Path(__file__).resolve().parent
+    dir_path = dir_path / ".." / ".." / "src" / "spider"
+    scheduler_cmds = [
+        str(dir_path / "spider_scheduler"),
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(scheduler_port),
+        "--storage_url",
+        storage_url,
+    ]
+    scheduler_process = subprocess.Popen(scheduler_cmds)
+    worker_cmds = [
+        str(dir_path / "spider_worker"),
+        "--host",
+        "127.0.0.1",
+        "--storage_url",
+        storage_url,
+        "--libs",
+        "tests/libworker_test.so",
+    ]
+    worker_process = subprocess.Popen(worker_cmds)
+    return scheduler_process, worker_process
+
+
+@pytest.fixture(scope="class")
+def scheduler_worker(storage):
+    scheduler_process, worker_process = start_scheduler_worker(
+        storage_url=g_storage_url, scheduler_port=g_scheduler_port
+    )
+    # Wait for 5 second to make sure the scheduler and worker are started
+    time.sleep(5)
+    yield
+    scheduler_process.kill()
+    worker_process.kill()
+
+
+class TestCancel:
+
+    # Test that the task can be cancelled by user and from the task.
+    # Execute the cancel_test client.
+    def test_task_cancel(self, scheduler_worker):
+        dir_path = Path(__file__).resolve().parent
+        dir_path = dir_path / ".."
+        client_cmds = [
+            str(dir_path / "cancel_test"),
+            "--storage_url",
+            g_storage_url,
+        ]
+        p = subprocess.run(client_cmds, timeout=20)
+        assert p.returncode == 0

--- a/tests/storage/StorageTestHelper.hpp
+++ b/tests/storage/StorageTestHelper.hpp
@@ -12,7 +12,7 @@
 
 namespace spider::test {
 std::string const cMySqlStorageUrl
-        = "jdbc:mariadb://localhost:3306/spider_test?user=root&password=password";
+        = "jdbc:mariadb://localhost:3306/spider-storage?user=spider&password=password";
 
 using StorageFactoryTypeList = std::tuple<core::MySqlStorageFactory>;
 

--- a/tests/storage/StorageTestHelper.hpp
+++ b/tests/storage/StorageTestHelper.hpp
@@ -12,7 +12,7 @@
 
 namespace spider::test {
 std::string const cMySqlStorageUrl
-        = "jdbc:mariadb://localhost:3306/spider-storage?user=spider&password=password";
+        = "jdbc:mariadb://localhost:3306/spider_test?user=root&password=password";
 
 using StorageFactoryTypeList = std::tuple<core::MySqlStorageFactory>;
 

--- a/tests/storage/test-MetadataStorage.cpp
+++ b/tests/storage/test-MetadataStorage.cpp
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <memory>
 #include <thread>
+#include <tuple>
 #include <utility>
 #include <variant>
 #include <vector>

--- a/tests/storage/test-MetadataStorage.cpp
+++ b/tests/storage/test-MetadataStorage.cpp
@@ -497,7 +497,8 @@ TEMPLATE_LIST_TEST_CASE("Job cancel", "[storage]", spider::test::StorageFactoryT
                     .success());
 
     // Cancel job should succeed
-    REQUIRE(storage->cancel_job(*conn, job_id).success());
+    std::string const error_message = "test error message";
+    REQUIRE(storage->cancel_job(*conn, job_id, error_message).success());
     // Job status should be cancelled
     spider::core::JobStatus job_status = spider::core::JobStatus::Running;
     REQUIRE(storage->get_job_status(*conn, job_id, &job_status).success());

--- a/tests/storage/test-MetadataStorage.cpp
+++ b/tests/storage/test-MetadataStorage.cpp
@@ -450,12 +450,21 @@ TEMPLATE_LIST_TEST_CASE("Task finish", "[storage]", spider::test::StorageFactory
 }
 
 /**
- * Create a common job cancel test setup. Create a job with a task graph that consists of two
- * parent tasks and one child task. Set the state of parent 1 to succeed. Parent 2 state remains
- * ready and child state remains pending.
+ * Creates a test job with a task dependency graph for cancellation tests.
+ *
+ * Task graph structure:
+ *   parent_1 (p1) ──┐
+ *                   ├──> child_task
+ *   parent_2 (p2) ──┘
+ *
+ * Task states after setup:
+ *   - parent_1: Succeeded (with output "1.1")
+ *   - parent_2: Ready
+ *   - child_task: Pending (waiting for parent_2 to complete)
+ *
  * @param storage
  * @param conn
- * @return A tuple containing the job_id, parent_1_id, parent_2_id, and child_task_id.
+ * @return A tuple containing (job_id, parent_1_id, parent_2_id, and child_task_id).
  */
 auto job_cancel_setup(
         std::unique_ptr<spider::core::MetadataStorage>& storage,

--- a/tests/storage/test-MetadataStorage.cpp
+++ b/tests/storage/test-MetadataStorage.cpp
@@ -503,6 +503,10 @@ TEMPLATE_LIST_TEST_CASE("Job cancel", "[storage]", spider::test::StorageFactoryT
     spider::core::JobStatus job_status = spider::core::JobStatus::Running;
     REQUIRE(storage->get_job_status(*conn, job_id, &job_status).success());
     REQUIRE(spider::core::JobStatus::Cancelled == job_status);
+    // Job error message should be set
+    std::string error_message_res;
+    REQUIRE(storage->get_job_message(*conn, job_id, &error_message_res).success());
+    REQUIRE(error_message == error_message_res);
 
     // Parent 1 state should be success
     spider::core::TaskState task_state = spider::core::TaskState::Running;

--- a/tests/storage/test-MetadataStorage.cpp
+++ b/tests/storage/test-MetadataStorage.cpp
@@ -450,8 +450,9 @@ TEMPLATE_LIST_TEST_CASE("Task finish", "[storage]", spider::test::StorageFactory
 }
 
 /**
- * Create a common job cancel test setup. Create a job with a task graph and set parent_1 to
- * succeed.
+ * Create a common job cancel test setup. Create a job with a task graph that consists of two
+ * parent tasks and one child task. Set the state of parent 1 to succeed. Parent 2 state remains
+ * ready and child state remains pending.
  * @param storage
  * @param conn
  * @return A tuple containing the job_id, parent_1_id, parent_2_id, and child_task_id.

--- a/tests/storage/test-MetadataStorage.cpp
+++ b/tests/storage/test-MetadataStorage.cpp
@@ -587,7 +587,9 @@ TEMPLATE_LIST_TEST_CASE("Job cancel by task", "[storage]", spider::test::Storage
     // Job error message should be set
     std::string error_task_res;
     std::string error_message_res;
-    REQUIRE(storage->get_job_message(*conn, job_id, &error_task_res, &error_message_res).success());
+    REQUIRE(
+            storage->get_error_message(*conn, job_id, &error_task_res, &error_message_res).success()
+    );
     REQUIRE("p2" == error_task_res);
     REQUIRE(error_message == error_message_res);
 

--- a/tests/storage/test-MetadataStorage.cpp
+++ b/tests/storage/test-MetadataStorage.cpp
@@ -448,17 +448,17 @@ TEMPLATE_LIST_TEST_CASE("Task finish", "[storage]", spider::test::StorageFactory
     REQUIRE(storage->remove_job(*conn, job_id).success());
 }
 
-TEMPLATE_LIST_TEST_CASE("Job cancel", "[storage]", spider::test::StorageFactoryTypeList) {
-    std::unique_ptr<spider::core::StorageFactory> storage_factory
-            = spider::test::create_storage_factory<TestType>();
-    std::unique_ptr<spider::core::MetadataStorage> storage
-            = storage_factory->provide_metadata_storage();
-
-    std::variant<std::unique_ptr<spider::core::StorageConnection>, spider::core::StorageErr>
-            conn_result = storage_factory->provide_storage_connection();
-    REQUIRE(std::holds_alternative<std::unique_ptr<spider::core::StorageConnection>>(conn_result));
-    auto conn = std::move(std::get<std::unique_ptr<spider::core::StorageConnection>>(conn_result));
-
+/**
+ * Create a common job cancel test setup. Create a job with a task graph and set parent_1 to
+ * succeed.
+ * @param storage
+ * @param conn
+ * @return A tuple containing the job_id, parent_1_id, parent_2_id, and child_task_id.
+ */
+auto job_cancel_setup(
+        std::unique_ptr<spider::core::MetadataStorage>& storage,
+        std::unique_ptr<spider::core::StorageConnection>& conn
+) -> std::tuple<boost::uuids::uuid, boost::uuids::uuid, boost::uuids::uuid, boost::uuids::uuid> {
     boost::uuids::random_generator gen;
     boost::uuids::uuid const job_id = gen();
 
@@ -498,17 +498,33 @@ TEMPLATE_LIST_TEST_CASE("Job cancel", "[storage]", spider::test::StorageFactoryT
     )
                     .success());
 
+    return std::make_tuple(job_id, parent_1.get_id(), parent_2.get_id(), child_task.get_id());
+}
+
+TEMPLATE_LIST_TEST_CASE("Job cancel", "[storage]", spider::test::StorageFactoryTypeList) {
+    std::unique_ptr<spider::core::StorageFactory> storage_factory
+            = spider::test::create_storage_factory<TestType>();
+    std::unique_ptr<spider::core::MetadataStorage> storage
+            = storage_factory->provide_metadata_storage();
+
+    std::variant<std::unique_ptr<spider::core::StorageConnection>, spider::core::StorageErr>
+            conn_result = storage_factory->provide_storage_connection();
+    REQUIRE(std::holds_alternative<std::unique_ptr<spider::core::StorageConnection>>(conn_result));
+    auto conn = std::move(std::get<std::unique_ptr<spider::core::StorageConnection>>(conn_result));
+
+    auto [job_id, parent_1_id, parent_2_id, child_id] = job_cancel_setup(storage, conn);
+
     REQUIRE(storage->cancel_job(*conn, job_id).success());
     spider::core::JobStatus job_status = spider::core::JobStatus::Running;
     REQUIRE(storage->get_job_status(*conn, job_id, &job_status).success());
     REQUIRE(spider::core::JobStatus::Cancelled == job_status);
 
     spider::core::TaskState task_state = spider::core::TaskState::Running;
-    REQUIRE(storage->get_task_state(*conn, parent_1.get_id(), &task_state).success());
+    REQUIRE(storage->get_task_state(*conn, parent_1_id, &task_state).success());
     REQUIRE(spider::core::TaskState::Succeed == task_state);
-    REQUIRE(storage->get_task_state(*conn, parent_2.get_id(), &task_state).success());
+    REQUIRE(storage->get_task_state(*conn, parent_2_id, &task_state).success());
     REQUIRE(spider::core::TaskState::Canceled == task_state);
-    REQUIRE(storage->get_task_state(*conn, child_task.get_id(), &task_state).success());
+    REQUIRE(storage->get_task_state(*conn, child_id, &task_state).success());
     REQUIRE(spider::core::TaskState::Canceled == task_state);
 
     REQUIRE(storage->remove_job(*conn, job_id).success());
@@ -525,47 +541,10 @@ TEMPLATE_LIST_TEST_CASE("Job cancel by task", "[storage]", spider::test::Storage
     REQUIRE(std::holds_alternative<std::unique_ptr<spider::core::StorageConnection>>(conn_result));
     auto conn = std::move(std::get<std::unique_ptr<spider::core::StorageConnection>>(conn_result));
 
-    boost::uuids::random_generator gen;
-    boost::uuids::uuid const job_id = gen();
-
-    spider::core::Task child_task{"child"};
-    spider::core::Task parent_1{"p1"};
-    spider::core::Task parent_2{"p2"};
-    parent_1.add_input(spider::core::TaskInput{"1", "float"});
-    parent_1.add_input(spider::core::TaskInput{"2", "float"});
-    parent_2.add_input(spider::core::TaskInput{"3", "int"});
-    parent_2.add_input(spider::core::TaskInput{"4", "int"});
-    parent_1.add_output(spider::core::TaskOutput{"float"});
-    parent_2.add_output(spider::core::TaskOutput{"int"});
-    child_task.add_input(spider::core::TaskInput{parent_1.get_id(), 0, "float"});
-    child_task.add_input(spider::core::TaskInput{parent_2.get_id(), 0, "int"});
-    child_task.add_output(spider::core::TaskOutput{"float"});
-    parent_1.set_max_retries(1);
-    parent_2.set_max_retries(1);
-    child_task.set_max_retries(1);
-    spider::core::TaskGraph graph;
-    graph.add_task(child_task);
-    graph.add_task(parent_1);
-    graph.add_task(parent_2);
-    graph.add_dependency(parent_2.get_id(), child_task.get_id());
-    graph.add_dependency(parent_1.get_id(), child_task.get_id());
-    graph.add_input_task(parent_1.get_id());
-    graph.add_input_task(parent_2.get_id());
-    graph.add_output_task(child_task.get_id());
-    REQUIRE(storage->add_job(*conn, job_id, gen(), graph).success());
-
-    spider::core::TaskInstance const parent_1_instance{gen(), parent_1.get_id()};
-    REQUIRE(storage->set_task_state(*conn, parent_1.get_id(), spider::core::TaskState::Running)
-                    .success());
-    REQUIRE(storage->task_finish(
-                           *conn,
-                           parent_1_instance,
-                           {spider::core::TaskOutput{"1.1", "float"}}
-    )
-                    .success());
+    auto [job_id, parent_1_id, parent_2_id, child_id] = job_cancel_setup(storage, conn);
 
     std::string const error_message = "test error message";
-    REQUIRE(storage->cancel_job_by_task(*conn, parent_2.get_id(), error_message).success());
+    REQUIRE(storage->cancel_job_by_task(*conn, parent_2_id, error_message).success());
     spider::core::JobStatus job_status = spider::core::JobStatus::Running;
     REQUIRE(storage->get_job_status(*conn, job_id, &job_status).success());
     REQUIRE(spider::core::JobStatus::Cancelled == job_status);
@@ -578,11 +557,11 @@ TEMPLATE_LIST_TEST_CASE("Job cancel by task", "[storage]", spider::test::Storage
     REQUIRE(error_message == error_message_res);
 
     spider::core::TaskState task_state = spider::core::TaskState::Running;
-    REQUIRE(storage->get_task_state(*conn, parent_1.get_id(), &task_state).success());
+    REQUIRE(storage->get_task_state(*conn, parent_1_id, &task_state).success());
     REQUIRE(spider::core::TaskState::Succeed == task_state);
-    REQUIRE(storage->get_task_state(*conn, parent_2.get_id(), &task_state).success());
+    REQUIRE(storage->get_task_state(*conn, parent_2_id, &task_state).success());
     REQUIRE(spider::core::TaskState::Canceled == task_state);
-    REQUIRE(storage->get_task_state(*conn, child_task.get_id(), &task_state).success());
+    REQUIRE(storage->get_task_state(*conn, child_id, &task_state).success());
     REQUIRE(spider::core::TaskState::Canceled == task_state);
 
     REQUIRE(storage->remove_job(*conn, job_id).success());

--- a/tests/storage/test-MetadataStorage.cpp
+++ b/tests/storage/test-MetadataStorage.cpp
@@ -497,18 +497,11 @@ TEMPLATE_LIST_TEST_CASE("Job cancel", "[storage]", spider::test::StorageFactoryT
                     .success());
 
     // Cancel job should succeed
-    std::string const error_message = "test error message";
-    REQUIRE(storage->cancel_job(*conn, job_id, error_message).success());
+    REQUIRE(storage->cancel_job(*conn, job_id).success());
     // Job status should be cancelled
     spider::core::JobStatus job_status = spider::core::JobStatus::Running;
     REQUIRE(storage->get_job_status(*conn, job_id, &job_status).success());
     REQUIRE(spider::core::JobStatus::Cancelled == job_status);
-    // Job error message should be set
-    std::string error_task_res{"random"};
-    std::string error_message_res;
-    REQUIRE(storage->get_job_message(*conn, job_id, &error_task_res, &error_message_res).success());
-    REQUIRE(error_task_res.empty());
-    REQUIRE(error_message == error_message_res);
 
     // Parent 1 state should be success
     spider::core::TaskState task_state = spider::core::TaskState::Running;

--- a/tests/storage/test-MetadataStorage.cpp
+++ b/tests/storage/test-MetadataStorage.cpp
@@ -522,6 +522,86 @@ TEMPLATE_LIST_TEST_CASE("Job cancel", "[storage]", spider::test::StorageFactoryT
     REQUIRE(storage->remove_job(*conn, job_id).success());
 }
 
+TEMPLATE_LIST_TEST_CASE("Job cancel by task", "[storage]", spider::test::StorageFactoryTypeList) {
+    std::unique_ptr<spider::core::StorageFactory> storage_factory
+            = spider::test::create_storage_factory<TestType>();
+    std::unique_ptr<spider::core::MetadataStorage> storage
+            = storage_factory->provide_metadata_storage();
+
+    std::variant<std::unique_ptr<spider::core::StorageConnection>, spider::core::StorageErr>
+            conn_result = storage_factory->provide_storage_connection();
+    REQUIRE(std::holds_alternative<std::unique_ptr<spider::core::StorageConnection>>(conn_result));
+    auto conn = std::move(std::get<std::unique_ptr<spider::core::StorageConnection>>(conn_result));
+
+    boost::uuids::random_generator gen;
+    boost::uuids::uuid const job_id = gen();
+
+    // Create a complicated task graph
+    spider::core::Task child_task{"child"};
+    spider::core::Task parent_1{"p1"};
+    spider::core::Task parent_2{"p2"};
+    parent_1.add_input(spider::core::TaskInput{"1", "float"});
+    parent_1.add_input(spider::core::TaskInput{"2", "float"});
+    parent_2.add_input(spider::core::TaskInput{"3", "int"});
+    parent_2.add_input(spider::core::TaskInput{"4", "int"});
+    parent_1.add_output(spider::core::TaskOutput{"float"});
+    parent_2.add_output(spider::core::TaskOutput{"int"});
+    child_task.add_input(spider::core::TaskInput{parent_1.get_id(), 0, "float"});
+    child_task.add_input(spider::core::TaskInput{parent_2.get_id(), 0, "int"});
+    child_task.add_output(spider::core::TaskOutput{"float"});
+    parent_1.set_max_retries(1);
+    parent_2.set_max_retries(1);
+    child_task.set_max_retries(1);
+    spider::core::TaskGraph graph;
+    // Add task and dependencies to task graph in wrong order
+    graph.add_task(child_task);
+    graph.add_task(parent_1);
+    graph.add_task(parent_2);
+    graph.add_dependency(parent_2.get_id(), child_task.get_id());
+    graph.add_dependency(parent_1.get_id(), child_task.get_id());
+    graph.add_input_task(parent_1.get_id());
+    graph.add_input_task(parent_2.get_id());
+    graph.add_output_task(child_task.get_id());
+    // Submit job should success
+    REQUIRE(storage->add_job(*conn, job_id, gen(), graph).success());
+
+    // Task finish for parent 1 should succeed
+    spider::core::TaskInstance const parent_1_instance{gen(), parent_1.get_id()};
+    REQUIRE(storage->set_task_state(*conn, parent_1.get_id(), spider::core::TaskState::Running)
+                    .success());
+    REQUIRE(storage->task_finish(
+                           *conn,
+                           parent_1_instance,
+                           {spider::core::TaskOutput{"1.1", "float"}}
+    )
+                    .success());
+
+    // Cancel job by task should succeed
+    std::string const error_message = "test error message";
+    REQUIRE(storage->cancel_job_by_task(*conn, parent_2.get_id(), error_message).success());
+    // Job status should be cancelled
+    spider::core::JobStatus job_status = spider::core::JobStatus::Running;
+    REQUIRE(storage->get_job_status(*conn, job_id, &job_status).success());
+    REQUIRE(spider::core::JobStatus::Cancelled == job_status);
+    // Job error message should be set
+    std::string error_message_res;
+    REQUIRE(storage->get_job_message(*conn, job_id, &error_message_res).success());
+    REQUIRE(error_message == error_message_res);
+
+    // Parent 1 state should be success
+    spider::core::TaskState task_state = spider::core::TaskState::Running;
+    REQUIRE(storage->get_task_state(*conn, parent_1.get_id(), &task_state).success());
+    REQUIRE(spider::core::TaskState::Succeed == task_state);
+    // Parent 2 and child states should be cancelled
+    REQUIRE(storage->get_task_state(*conn, parent_2.get_id(), &task_state).success());
+    REQUIRE(spider::core::TaskState::Canceled == task_state);
+    REQUIRE(storage->get_task_state(*conn, child_task.get_id(), &task_state).success());
+    REQUIRE(spider::core::TaskState::Canceled == task_state);
+
+    // Clean up
+    REQUIRE(storage->remove_job(*conn, job_id).success());
+}
+
 TEMPLATE_LIST_TEST_CASE("Job reset", "[storage]", spider::test::StorageFactoryTypeList) {
     std::unique_ptr<spider::core::StorageFactory> storage_factory
             = spider::test::create_storage_factory<TestType>();

--- a/tests/storage/test-MetadataStorage.cpp
+++ b/tests/storage/test-MetadataStorage.cpp
@@ -504,8 +504,10 @@ TEMPLATE_LIST_TEST_CASE("Job cancel", "[storage]", spider::test::StorageFactoryT
     REQUIRE(storage->get_job_status(*conn, job_id, &job_status).success());
     REQUIRE(spider::core::JobStatus::Cancelled == job_status);
     // Job error message should be set
+    std::string error_task_res{"random"};
     std::string error_message_res;
-    REQUIRE(storage->get_job_message(*conn, job_id, &error_message_res).success());
+    REQUIRE(storage->get_job_message(*conn, job_id, &error_task_res, &error_message_res).success());
+    REQUIRE(error_task_res.empty());
     REQUIRE(error_message == error_message_res);
 
     // Parent 1 state should be success
@@ -584,8 +586,10 @@ TEMPLATE_LIST_TEST_CASE("Job cancel by task", "[storage]", spider::test::Storage
     REQUIRE(storage->get_job_status(*conn, job_id, &job_status).success());
     REQUIRE(spider::core::JobStatus::Cancelled == job_status);
     // Job error message should be set
+    std::string error_task_res;
     std::string error_message_res;
-    REQUIRE(storage->get_job_message(*conn, job_id, &error_message_res).success());
+    REQUIRE(storage->get_job_message(*conn, job_id, &error_task_res, &error_message_res).success());
+    REQUIRE("p2" == error_task_res);
     REQUIRE(error_message == error_message_res);
 
     // Parent 1 state should be success

--- a/tests/storage/test-MetadataStorage.cpp
+++ b/tests/storage/test-MetadataStorage.cpp
@@ -504,14 +504,14 @@ TEMPLATE_LIST_TEST_CASE("Job cancel", "[storage]", spider::test::StorageFactoryT
     REQUIRE(spider::core::JobStatus::Cancelled == job_status);
 
     // Parent 1 state should be success
-    spider::core::Task task_res{""};
-    REQUIRE(storage->get_task(*conn, parent_1.get_id(), &task_res).success());
-    REQUIRE(spider::core::TaskState::Succeed == task_res.get_state());
+    spider::core::TaskState task_state = spider::core::TaskState::Running;
+    REQUIRE(storage->get_task_state(*conn, parent_1.get_id(), &task_state).success());
+    REQUIRE(spider::core::TaskState::Succeed == task_state);
     // Parent 2 and child states should be cancelled
-    REQUIRE(storage->get_task(*conn, parent_2.get_id(), &task_res).success());
-    REQUIRE(spider::core::TaskState::Canceled == task_res.get_state());
-    REQUIRE(storage->get_task(*conn, child_task.get_id(), &task_res).success());
-    REQUIRE(spider::core::TaskState::Canceled == task_res.get_state());
+    REQUIRE(storage->get_task_state(*conn, parent_2.get_id(), &task_state).success());
+    REQUIRE(spider::core::TaskState::Canceled == task_state);
+    REQUIRE(storage->get_task_state(*conn, child_task.get_id(), &task_state).success());
+    REQUIRE(spider::core::TaskState::Canceled == task_state);
 
     // Clean up
     REQUIRE(storage->remove_job(*conn, job_id).success());

--- a/tests/worker/test-TaskExecutor.cpp
+++ b/tests/worker/test-TaskExecutor.cpp
@@ -86,7 +86,7 @@ TEMPLATE_LIST_TEST_CASE(
     };
     context.run();
     executor.wait();
-    REQUIRE(executor.succeed());
+    REQUIRE(executor.is_succeeded());
     std::optional<int> const result_option = executor.get_result<int>();
     REQUIRE(result_option.has_value());
     REQUIRE(5 == result_option.value_or(0));
@@ -117,7 +117,7 @@ TEMPLATE_LIST_TEST_CASE(
     };
     context.run();
     executor.wait();
-    REQUIRE(executor.error());
+    REQUIRE(executor.is_error());
     std::tuple<spider::core::FunctionInvokeError, std::string> error = executor.get_error();
     REQUIRE(spider::core::FunctionInvokeError::WrongNumberOfArguments == std::get<0>(error));
 }
@@ -147,7 +147,7 @@ TEMPLATE_LIST_TEST_CASE(
     };
     context.run();
     executor.wait();
-    REQUIRE(executor.error());
+    REQUIRE(executor.is_error());
     std::tuple<spider::core::FunctionInvokeError, std::string> error = executor.get_error();
     REQUIRE(spider::core::FunctionInvokeError::FunctionExecutionError == std::get<0>(error));
 }
@@ -197,7 +197,7 @@ TEMPLATE_LIST_TEST_CASE(
     };
     context.run();
     executor.wait();
-    REQUIRE(executor.succeed());
+    REQUIRE(executor.is_succeeded());
     std::optional<int> const optional_result = executor.get_result<int>();
     REQUIRE(optional_result.has_value());
     if (optional_result.has_value()) {
@@ -239,7 +239,7 @@ TEMPLATE_LIST_TEST_CASE(
     };
     context.run();
     executor.wait();
-    REQUIRE(executor.succeed());
+    REQUIRE(executor.is_succeeded());
     std::optional<std::string> const result_option = executor.get_result<std::string>();
     REQUIRE(result_option.has_value());
     REQUIRE(input_1 + input_2 == result_option.value_or(""));

--- a/tests/worker/test-TaskExecutor.cpp
+++ b/tests/worker/test-TaskExecutor.cpp
@@ -88,7 +88,7 @@ TEMPLATE_LIST_TEST_CASE(
     };
     context.run();
     executor.wait();
-    REQUIRE(executor.is_succeeded());
+    REQUIRE(executor.succeeded());
     std::optional<int> const result_option = executor.get_result<int>();
     REQUIRE(result_option.has_value());
     REQUIRE(5 == result_option.value_or(0));
@@ -119,7 +119,7 @@ TEMPLATE_LIST_TEST_CASE(
     };
     context.run();
     executor.wait();
-    REQUIRE(executor.is_error());
+    REQUIRE(executor.errored());
     std::tuple<spider::core::FunctionInvokeError, std::string> error = executor.get_error();
     REQUIRE(spider::core::FunctionInvokeError::WrongNumberOfArguments == std::get<0>(error));
 }
@@ -149,7 +149,7 @@ TEMPLATE_LIST_TEST_CASE(
     };
     context.run();
     executor.wait();
-    REQUIRE(executor.is_error());
+    REQUIRE(executor.errored());
     std::tuple<spider::core::FunctionInvokeError, std::string> error = executor.get_error();
     REQUIRE(spider::core::FunctionInvokeError::FunctionExecutionError == std::get<0>(error));
 }
@@ -211,7 +211,7 @@ TEMPLATE_LIST_TEST_CASE(
     };
     context.run();
     executor.wait();
-    REQUIRE(executor.is_succeeded());
+    REQUIRE(executor.succeeded());
     std::optional<int> const optional_result = executor.get_result<int>();
     REQUIRE(optional_result.has_value());
     if (optional_result.has_value()) {
@@ -255,7 +255,7 @@ TEMPLATE_LIST_TEST_CASE(
     };
     context.run();
     executor.wait();
-    REQUIRE(executor.is_succeeded());
+    REQUIRE(executor.succeeded());
     std::optional<std::string> const result_option = executor.get_result<std::string>();
     REQUIRE(result_option.has_value());
     REQUIRE(input_1 + input_2 == result_option.value_or(""));

--- a/tests/worker/worker-test.cpp
+++ b/tests/worker/worker-test.cpp
@@ -77,7 +77,7 @@ auto sleep_test(spider::TaskContext& /*context*/, int milliseconds) -> int {
     return milliseconds;
 }
 
-auto abort_test(spider::TaskContext& context) -> int {
+auto abort_test(spider::TaskContext& context, int /*x*/) -> int {
     context.abort("Abort test");
     return 0;
 }

--- a/tests/worker/worker-test.cpp
+++ b/tests/worker/worker-test.cpp
@@ -72,12 +72,12 @@ auto join_string_test(
     return input_1 + input_2;
 }
 
-auto sleep_test(spider::TaskContext& /*context*/, int milliseconds) -> int {
+auto sleep_test([[maybe_unused]] spider::TaskContext& context, int milliseconds) -> int {
     std::this_thread::sleep_for(std::chrono::milliseconds{milliseconds});
     return milliseconds;
 }
 
-auto abort_test(spider::TaskContext& context, int /*x*/) -> int {
+auto abort_test(spider::TaskContext& context, [[maybe_unused]] int x) -> int {
     context.abort("Abort test");
     return 0;
 }

--- a/tests/worker/worker-test.cpp
+++ b/tests/worker/worker-test.cpp
@@ -1,9 +1,11 @@
 #include "worker-test.hpp"
 
+#include <chrono>
 #include <iostream>
 #include <random>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <tuple>
 
 #include <spider/client/Data.hpp>
@@ -70,6 +72,16 @@ auto join_string_test(
     return input_1 + input_2;
 }
 
+auto sleep_test(spider::TaskContext& /*context*/, int milliseconds) -> int {
+    std::this_thread::sleep_for(std::chrono::milliseconds{milliseconds});
+    return milliseconds;
+}
+
+auto abort_test(spider::TaskContext& context) -> int {
+    context.abort("Abort test");
+    return 0;
+}
+
 // NOLINTBEGIN(cert-err58-cpp)
 SPIDER_REGISTER_TASK(sum_test);
 SPIDER_REGISTER_TASK(swap_test);
@@ -79,4 +91,6 @@ SPIDER_REGISTER_TASK(random_fail_test);
 SPIDER_REGISTER_TASK(create_data_test);
 SPIDER_REGISTER_TASK(create_task_test);
 SPIDER_REGISTER_TASK(join_string_test);
+SPIDER_REGISTER_TASK(sleep_test);
+SPIDER_REGISTER_TASK(abort_test);
 // NOLINTEND(cert-err58-cpp)

--- a/tests/worker/worker-test.hpp
+++ b/tests/worker/worker-test.hpp
@@ -29,6 +29,6 @@ auto join_string_test(
 
 auto sleep_test(spider::TaskContext& context, int milliseconds) -> int;
 
-auto abort_test(spider::TaskContext& context, int /*x*/) -> int;
+auto abort_test(spider::TaskContext& context, int x) -> int;
 
 #endif

--- a/tests/worker/worker-test.hpp
+++ b/tests/worker/worker-test.hpp
@@ -27,4 +27,8 @@ auto join_string_test(
         std::string const& input_2
 ) -> std::string;
 
+auto sleep_test(spider::TaskContext& context, int milliseconds) -> int;
+
+auto abort_test(spider::TaskContext& context) -> int;
+
 #endif

--- a/tests/worker/worker-test.hpp
+++ b/tests/worker/worker-test.hpp
@@ -29,6 +29,6 @@ auto join_string_test(
 
 auto sleep_test(spider::TaskContext& context, int milliseconds) -> int;
 
-auto abort_test(spider::TaskContext& context) -> int;
+auto abort_test(spider::TaskContext& context, int /*x*/) -> int;
 
 #endif

--- a/tools/scripts/storage/init_db.sql
+++ b/tools/scripts/storage/init_db.sql
@@ -25,6 +25,7 @@ CREATE TABLE IF NOT EXISTS jobs
 );
 CREATE TABLE IF NOT EXISTS `job_errors` (
     `job_id` BINARY(16) NOT NULL,
+    `func_name` VARCHAR(64) NOT NULL,
     `message` VARCHAR(999) NOT NULL,
     CONSTRAINT `job_error_job_id` FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
     PRIMARY KEY (`job_id`)

--- a/tools/scripts/storage/init_db.sql
+++ b/tools/scripts/storage/init_db.sql
@@ -25,7 +25,7 @@ CREATE TABLE IF NOT EXISTS jobs
 );
 CREATE TABLE IF NOT EXISTS `job_errors` (
     `job_id` BINARY(16) NOT NULL,
-    `func_name` VARCHAR(64) NOT NULL,
+    `offender` VARCHAR(64) NOT NULL,
     `message` VARCHAR(999) NOT NULL,
     CONSTRAINT `job_error_job_id` FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
     PRIMARY KEY (`job_id`)

--- a/tools/scripts/storage/init_db.sql
+++ b/tools/scripts/storage/init_db.sql
@@ -23,6 +23,12 @@ CREATE TABLE IF NOT EXISTS jobs
     INDEX idx_jobs_state (`state`),
     PRIMARY KEY (`id`)
 );
+CREATE TABLE IF NOT EXISTS `job_errors` (
+    `job_id` BINARY(16) NOT NULL,
+    `message` VARCHAR(999) NOT NULL,
+    CONSTRAINT `job_error_job_id` FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+    PRIMARY KEY (`job_id`)
+);
 CREATE TABLE IF NOT EXISTS tasks
 (
     `id`          BINARY(16)                                                        NOT NULL,


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description
User might want to stop a job from executing if the task fails and has no hope of recovery or because of other reason, so `Spider` need to support job cancellation both from inside inside the task through `TaskContext::abort` and from user through `Job::cancel`. The cancelled job will be in `JobStatus::Cancelled` state.

User also need to get the reason why a job is cancelled. This PR adds `job_errors` table to store the cancellation messages. The messages are set inside `TaskContext::abort` as a user argument and set to `Job cancelled by user.` inside `Job::cancel`. The table also stores the function name of the task calling `TaskContext::abort`, or `user` if the job is cancelled using `Job::cancel`. User could retrieve both information using `Job::get_error`.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* [x] GitHub workflows pass.
* [x] Unit tests pass in dev container.
* [x] Integration tests pass in dev container.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added job and task cancellation methods with detailed error message retrieval.
  - Introduced thread-safe management of task execution and cancellation control.
  - Extended database schema with a `job_errors` table to store cancellation details.
  - Added new task cancellation and abort test tasks.
- **Bug Fixes**
  - Enhanced task state handling to properly reflect cancellations and error conditions.
- **Tests**
  - Added comprehensive unit and integration tests for cancellation workflows.
  - Included a new cancellation test executable with command-line interface.
- **Refactor**
  - Renamed task state check methods for improved clarity and consistency.
- **Chores**
  - Updated build and test configurations to support new features and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210104031287392