### PR TITLE
refactor: Update include statements to match our latest style guidelines (resolves #140). 

### DIFF
--- a/examples/quick-start/.clang-format
+++ b/examples/quick-start/.clang-format
@@ -2,15 +2,18 @@ BasedOnStyle: "InheritParentConfig"
 
 IncludeCategories:
   # NOTE: A header is grouped by first matching regex
-  # Project headers
-  - Regex: "^\""
+  # Project relative headers
+  - Regex: "^\"spider"
+    Priority: 5
+  # Project library headers
+  - Regex: "^<spider"
     Priority: 4
   # Library headers. Update when adding new libraries.
   # NOTE: clang-format retains leading white-space on a line in violation of the YAML spec.
   # Ex:
   # - Regex: "<(fmt|spdlog)"
   #   Priority: 3
-  - Regex: "^<(absl|boost|catch2|fmt|mariadb|msgpack|spdlog|spider)"
+  - Regex: "^<(absl|boost|catch2|fmt|mariadb|msgpack|spdlog|ystdlib)"
     Priority: 3
   # C system headers
   - Regex: "^<.+\\.h>"

--- a/examples/quick-start/.clang-format
+++ b/examples/quick-start/.clang-format
@@ -2,9 +2,6 @@ BasedOnStyle: "InheritParentConfig"
 
 IncludeCategories:
   # NOTE: A header is grouped by first matching regex
-  # Project relative headers
-  - Regex: "^\"spider"
-    Priority: 5
   # Project library headers
   - Regex: "^<spider"
     Priority: 4
@@ -21,3 +18,6 @@ IncludeCategories:
   # C++ standard libraries
   - Regex: "^<.+>"
     Priority: 2
+  # Project relative headers
+  - Regex: "^\".+\""
+    Priority: 5

--- a/examples/quick-start/.clang-format
+++ b/examples/quick-start/.clang-format
@@ -1,15 +1,12 @@
 BasedOnStyle: "InheritParentConfig"
 
 IncludeCategories:
-  # NOTE: A header is grouped by first matching regex
+  # NOTE: A header is grouped by first matching regex library headers.
+  # NOTE: clang-format retains leading white-space on a line in violation of the YAML spec.
   # Project library headers
   - Regex: "^<spider"
     Priority: 4
-  # Library headers. Update when adding new libraries.
-  # NOTE: clang-format retains leading white-space on a line in violation of the YAML spec.
-  # Ex:
-  # - Regex: "<(fmt|spdlog)"
-  #   Priority: 3
+  # External library headers. Update when adding new libraries.
   - Regex: "^<(absl|boost|catch2|fmt|mariadb|msgpack|spdlog|ystdlib)"
     Priority: 3
   # C system headers

--- a/src/spider/.clang-format
+++ b/src/spider/.clang-format
@@ -2,7 +2,6 @@ BasedOnStyle: "InheritParentConfig"
 
 IncludeCategories:
   # NOTE: A header is grouped by first matching regex
-
   # Project library headers
   - Regex: "^<spider"
     Priority: 4

--- a/src/spider/.clang-format
+++ b/src/spider/.clang-format
@@ -2,6 +2,12 @@ BasedOnStyle: "InheritParentConfig"
 
 IncludeCategories:
   # NOTE: A header is grouped by first matching regex
+  # Project relative headers
+  - Regex: "^\"spider"
+    Priority: 5
+  # Project library headers
+  - Regex: "^<spider"
+    Priority: 4
   # Library headers. Update when adding new libraries.
   # NOTE: clang-format retains leading white-space on a line in violation of the YAML spec.
   # Ex:
@@ -15,9 +21,3 @@ IncludeCategories:
   # C++ standard libraries
   - Regex: "^<.+>"
     Priority: 2
-  # Project library headers
-  - Regex: "^<spider"
-    Priority: 4
-  # Project relative headers
-  - Regex: "^\"spider"
-    Priority: 5

--- a/src/spider/.clang-format
+++ b/src/spider/.clang-format
@@ -2,9 +2,6 @@ BasedOnStyle: "InheritParentConfig"
 
 IncludeCategories:
   # NOTE: A header is grouped by first matching regex
-  # Project headers
-  - Regex: "^<spider"
-    Priority: 4
   # Library headers. Update when adding new libraries.
   # NOTE: clang-format retains leading white-space on a line in violation of the YAML spec.
   # Ex:
@@ -18,3 +15,9 @@ IncludeCategories:
   # C++ standard libraries
   - Regex: "^<.+>"
     Priority: 2
+  # Project library headers
+  - Regex: "^<spider"
+    Priority: 4
+  # Project relative headers
+  - Regex: "^\"spider"
+    Priority: 5

--- a/src/spider/.clang-format
+++ b/src/spider/.clang-format
@@ -2,9 +2,7 @@ BasedOnStyle: "InheritParentConfig"
 
 IncludeCategories:
   # NOTE: A header is grouped by first matching regex
-  # Project relative headers
-  - Regex: "^\"spider"
-    Priority: 5
+
   # Project library headers
   - Regex: "^<spider"
     Priority: 4
@@ -21,3 +19,6 @@ IncludeCategories:
   # C++ standard libraries
   - Regex: "^<.+>"
     Priority: 2
+  # Project relative headers
+  - Regex: "^\".+\""
+    Priority: 5

--- a/src/spider/.clang-format
+++ b/src/spider/.clang-format
@@ -1,15 +1,12 @@
 BasedOnStyle: "InheritParentConfig"
 
 IncludeCategories:
-  # NOTE: A header is grouped by first matching regex
+  # NOTE: A header is grouped by first matching regex library headers.
+  # NOTE: clang-format retains leading white-space on a line in violation of the YAML spec.
   # Project library headers
   - Regex: "^<spider"
     Priority: 4
-  # Library headers. Update when adding new libraries.
-  # NOTE: clang-format retains leading white-space on a line in violation of the YAML spec.
-  # Ex:
-  # - Regex: "<(fmt|spdlog)"
-  #   Priority: 3
+  # External library headers. Update when adding new libraries.
   - Regex: "^<(absl|boost|catch2|fmt|mariadb|msgpack|spdlog|ystdlib)"
     Priority: 3
   # C system headers

--- a/src/spider/CMakeLists.txt
+++ b/src/spider/CMakeLists.txt
@@ -43,7 +43,7 @@ set(SPIDER_CORE_HEADERS
 
 add_library(spider_core)
 target_sources(spider_core PRIVATE ${SPIDER_CORE_SOURCES})
-target_sources(spider_core PUBLIC ${SPIDER_CORE_HEADERS})
+target_include_directories(spider_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
 target_link_libraries(
     spider_core
     PUBLIC
@@ -88,6 +88,7 @@ set(SPIDER_TASK_EXECUTOR_SOURCES
 
 add_executable(spider_task_executor)
 target_sources(spider_task_executor PRIVATE ${SPIDER_TASK_EXECUTOR_SOURCES})
+target_include_directories(spider_task_executor PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
 target_link_libraries(
     spider_task_executor
     PRIVATE
@@ -108,6 +109,7 @@ target_link_libraries(
 add_executable(spider_worker)
 target_sources(spider_worker PRIVATE ${SPIDER_WORKER_SOURCES})
 target_sources(spider_worker PRIVATE worker/worker.cpp)
+target_include_directories(spider_worker PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
 target_link_libraries(spider_worker PRIVATE spider_core)
 target_link_libraries(
     spider_worker
@@ -138,6 +140,7 @@ set(SPIDER_SCHEDULER_SOURCES
 add_executable(spider_scheduler)
 target_sources(spider_scheduler PRIVATE ${SPIDER_SCHEDULER_SOURCES})
 target_sources(spider_scheduler PRIVATE scheduler/scheduler.cpp)
+target_include_directories(spider_scheduler PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
 target_link_libraries(spider_scheduler PRIVATE spider_core)
 target_link_libraries(
     spider_scheduler

--- a/src/spider/CMakeLists.txt
+++ b/src/spider/CMakeLists.txt
@@ -88,7 +88,6 @@ set(SPIDER_TASK_EXECUTOR_SOURCES
 
 add_executable(spider_task_executor)
 target_sources(spider_task_executor PRIVATE ${SPIDER_TASK_EXECUTOR_SOURCES})
-target_include_directories(spider_task_executor PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
 target_link_libraries(
     spider_task_executor
     PRIVATE
@@ -109,7 +108,6 @@ target_link_libraries(
 add_executable(spider_worker)
 target_sources(spider_worker PRIVATE ${SPIDER_WORKER_SOURCES})
 target_sources(spider_worker PRIVATE worker/worker.cpp)
-target_include_directories(spider_worker PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
 target_link_libraries(spider_worker PRIVATE spider_core)
 target_link_libraries(
     spider_worker
@@ -140,7 +138,6 @@ set(SPIDER_SCHEDULER_SOURCES
 add_executable(spider_scheduler)
 target_sources(spider_scheduler PRIVATE ${SPIDER_SCHEDULER_SOURCES})
 target_sources(spider_scheduler PRIVATE scheduler/scheduler.cpp)
-target_include_directories(spider_scheduler PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
 target_link_libraries(spider_scheduler PRIVATE spider_core)
 target_link_libraries(
     spider_scheduler

--- a/src/spider/client/Data.hpp
+++ b/src/spider/client/Data.hpp
@@ -11,13 +11,13 @@
 
 #include <boost/uuid/uuid.hpp>
 
-#include "spider/client/Exception.hpp"
-#include "spider/core/Error.hpp"
-#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
-#include "spider/io/Serializer.hpp"
-#include "spider/storage/DataStorage.hpp"
-#include "spider/storage/StorageConnection.hpp"
-#include "spider/storage/StorageFactory.hpp"
+#include <spider/client/Exception.hpp>
+#include <spider/core/Error.hpp>
+#include <spider/io/MsgPack.hpp>  // IWYU pragma: keep
+#include <spider/io/Serializer.hpp>
+#include <spider/storage/DataStorage.hpp>
+#include <spider/storage/StorageConnection.hpp>
+#include <spider/storage/StorageFactory.hpp>
 
 namespace spider {
 namespace core {

--- a/src/spider/client/Data.hpp
+++ b/src/spider/client/Data.hpp
@@ -11,13 +11,13 @@
 
 #include <boost/uuid/uuid.hpp>
 
-#include "../core/Error.hpp"
-#include "../io/MsgPack.hpp"  // IWYU pragma: keep
-#include "../io/Serializer.hpp"
-#include "../storage/DataStorage.hpp"
-#include "../storage/StorageConnection.hpp"
-#include "../storage/StorageFactory.hpp"
-#include "Exception.hpp"
+#include "spider/core/Error.hpp"
+#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
+#include "spider/io/Serializer.hpp"
+#include "spider/storage/DataStorage.hpp"
+#include "spider/storage/StorageConnection.hpp"
+#include "spider/storage/StorageFactory.hpp"
+#include "spider/client/Exception.hpp"
 
 namespace spider {
 namespace core {

--- a/src/spider/client/Data.hpp
+++ b/src/spider/client/Data.hpp
@@ -11,13 +11,13 @@
 
 #include <boost/uuid/uuid.hpp>
 
+#include "spider/client/Exception.hpp"
 #include "spider/core/Error.hpp"
 #include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
 #include "spider/io/Serializer.hpp"
 #include "spider/storage/DataStorage.hpp"
 #include "spider/storage/StorageConnection.hpp"
 #include "spider/storage/StorageFactory.hpp"
-#include "spider/client/Exception.hpp"
 
 namespace spider {
 namespace core {

--- a/src/spider/client/Driver.cpp
+++ b/src/spider/client/Driver.cpp
@@ -12,13 +12,13 @@
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid.hpp>
 
-#include "spider/client/Exception.hpp"
-#include "spider/core/Driver.hpp"
-#include "spider/core/Error.hpp"
-#include "spider/core/KeyValueData.hpp"
-#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "spider/storage/mysql/MySqlStorageFactory.hpp"
-#include "spider/storage/StorageConnection.hpp"
+#include <spider/client/Exception.hpp>
+#include <spider/core/Driver.hpp>
+#include <spider/core/Error.hpp>
+#include <spider/core/KeyValueData.hpp>
+#include <spider/io/BoostAsio.hpp>  // IWYU pragma: keep
+#include <spider/storage/mysql/MySqlStorageFactory.hpp>
+#include <spider/storage/StorageConnection.hpp>
 
 namespace spider {
 Driver::Driver(std::string const& storage_url)

--- a/src/spider/client/Driver.cpp
+++ b/src/spider/client/Driver.cpp
@@ -12,13 +12,13 @@
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid.hpp>
 
+#include "spider/client/Exception.hpp"
 #include "spider/core/Driver.hpp"
 #include "spider/core/Error.hpp"
 #include "spider/core/KeyValueData.hpp"
 #include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
 #include "spider/storage/mysql/MySqlStorageFactory.hpp"
 #include "spider/storage/StorageConnection.hpp"
-#include "spider/client/Exception.hpp"
 
 namespace spider {
 Driver::Driver(std::string const& storage_url)

--- a/src/spider/client/Driver.cpp
+++ b/src/spider/client/Driver.cpp
@@ -12,13 +12,13 @@
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid.hpp>
 
-#include "../core/Driver.hpp"
-#include "../core/Error.hpp"
-#include "../core/KeyValueData.hpp"
-#include "../io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "../storage/mysql/MySqlStorageFactory.hpp"
-#include "../storage/StorageConnection.hpp"
-#include "Exception.hpp"
+#include "spider/core/Driver.hpp"
+#include "spider/core/Error.hpp"
+#include "spider/core/KeyValueData.hpp"
+#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
+#include "spider/storage/mysql/MySqlStorageFactory.hpp"
+#include "spider/storage/StorageConnection.hpp"
+#include "spider/client/Exception.hpp"
 
 namespace spider {
 Driver::Driver(std::string const& storage_url)

--- a/src/spider/client/Driver.hpp
+++ b/src/spider/client/Driver.hpp
@@ -15,6 +15,11 @@
 #include <boost/uuid/uuid.hpp>
 #include <fmt/format.h>
 
+#include "spider/client/Data.hpp"
+#include "spider/client/Exception.hpp"
+#include "spider/client/Job.hpp"
+#include "spider/client/task.hpp"
+#include "spider/client/TaskGraph.hpp"
 #include "spider/core/Error.hpp"
 #include "spider/core/TaskGraphImpl.hpp"
 #include "spider/io/Serializer.hpp"
@@ -23,11 +28,6 @@
 #include "spider/storage/StorageFactory.hpp"
 #include "spider/worker/FunctionManager.hpp"
 #include "spider/worker/FunctionNameManager.hpp"
-#include "spider/client/Data.hpp"
-#include "spider/client/Exception.hpp"
-#include "spider/client/Job.hpp"
-#include "spider/client/task.hpp"
-#include "spider/client/TaskGraph.hpp"
 
 /**
  * Registers a Task function with Spider

--- a/src/spider/client/Driver.hpp
+++ b/src/spider/client/Driver.hpp
@@ -8,26 +8,26 @@
 #include <thread>
 #include <tuple>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <fmt/format.h>
 
-#include "../core/Error.hpp"
-#include "../core/TaskGraphImpl.hpp"
-#include "../io/Serializer.hpp"
-#include "../storage/JobSubmissionBatch.hpp"
-#include "../storage/StorageConnection.hpp"
-#include "../storage/StorageFactory.hpp"
-#include "../worker/FunctionManager.hpp"
-#include "../worker/FunctionNameManager.hpp"
-#include "Data.hpp"
-#include "Exception.hpp"
-#include "Job.hpp"
-#include "task.hpp"
-#include "TaskGraph.hpp"
-#include "utility"
+#include "spider/core/Error.hpp"
+#include "spider/core/TaskGraphImpl.hpp"
+#include "spider/io/Serializer.hpp"
+#include "spider/storage/JobSubmissionBatch.hpp"
+#include "spider/storage/StorageConnection.hpp"
+#include "spider/storage/StorageFactory.hpp"
+#include "spider/worker/FunctionManager.hpp"
+#include "spider/worker/FunctionNameManager.hpp"
+#include "spider/client/Data.hpp"
+#include "spider/client/Exception.hpp"
+#include "spider/client/Job.hpp"
+#include "spider/client/task.hpp"
+#include "spider/client/TaskGraph.hpp"
 
 /**
  * Registers a Task function with Spider

--- a/src/spider/client/Driver.hpp
+++ b/src/spider/client/Driver.hpp
@@ -15,19 +15,19 @@
 #include <boost/uuid/uuid.hpp>
 #include <fmt/format.h>
 
-#include "spider/client/Data.hpp"
-#include "spider/client/Exception.hpp"
-#include "spider/client/Job.hpp"
-#include "spider/client/task.hpp"
-#include "spider/client/TaskGraph.hpp"
-#include "spider/core/Error.hpp"
-#include "spider/core/TaskGraphImpl.hpp"
-#include "spider/io/Serializer.hpp"
-#include "spider/storage/JobSubmissionBatch.hpp"
-#include "spider/storage/StorageConnection.hpp"
-#include "spider/storage/StorageFactory.hpp"
-#include "spider/worker/FunctionManager.hpp"
-#include "spider/worker/FunctionNameManager.hpp"
+#include <spider/client/Data.hpp>
+#include <spider/client/Exception.hpp>
+#include <spider/client/Job.hpp>
+#include <spider/client/task.hpp>
+#include <spider/client/TaskGraph.hpp>
+#include <spider/core/Error.hpp>
+#include <spider/core/TaskGraphImpl.hpp>
+#include <spider/io/Serializer.hpp>
+#include <spider/storage/JobSubmissionBatch.hpp>
+#include <spider/storage/StorageConnection.hpp>
+#include <spider/storage/StorageFactory.hpp>
+#include <spider/worker/FunctionManager.hpp>
+#include <spider/worker/FunctionNameManager.hpp>
 
 /**
  * Registers a Task function with Spider

--- a/src/spider/client/Job.hpp
+++ b/src/spider/client/Job.hpp
@@ -16,6 +16,10 @@
 #include <boost/uuid/uuid.hpp>
 #include <fmt/format.h>
 
+#include "spider/client/Data.hpp"
+#include "spider/client/Exception.hpp"
+#include "spider/client/task.hpp"
+#include "spider/client/type_utils.hpp"
 #include "spider/core/DataImpl.hpp"
 #include "spider/core/Error.hpp"
 #include "spider/core/JobMetadata.hpp"
@@ -23,10 +27,6 @@
 #include "spider/storage/MetadataStorage.hpp"
 #include "spider/storage/StorageConnection.hpp"
 #include "spider/storage/StorageFactory.hpp"
-#include "spider/client/Data.hpp"
-#include "spider/client/Exception.hpp"
-#include "spider/client/task.hpp"
-#include "spider/client/type_utils.hpp"
 
 namespace spider {
 namespace core {

--- a/src/spider/client/Job.hpp
+++ b/src/spider/client/Job.hpp
@@ -16,17 +16,17 @@
 #include <boost/uuid/uuid.hpp>
 #include <fmt/format.h>
 
-#include "spider/client/Data.hpp"
-#include "spider/client/Exception.hpp"
-#include "spider/client/task.hpp"
-#include "spider/client/type_utils.hpp"
-#include "spider/core/DataImpl.hpp"
-#include "spider/core/Error.hpp"
-#include "spider/core/JobMetadata.hpp"
-#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
-#include "spider/storage/MetadataStorage.hpp"
-#include "spider/storage/StorageConnection.hpp"
-#include "spider/storage/StorageFactory.hpp"
+#include <spider/client/Data.hpp>
+#include <spider/client/Exception.hpp>
+#include <spider/client/task.hpp>
+#include <spider/client/type_utils.hpp>
+#include <spider/core/DataImpl.hpp>
+#include <spider/core/Error.hpp>
+#include <spider/core/JobMetadata.hpp>
+#include <spider/io/MsgPack.hpp>  // IWYU pragma: keep
+#include <spider/storage/MetadataStorage.hpp>
+#include <spider/storage/StorageConnection.hpp>
+#include <spider/storage/StorageFactory.hpp>
 
 namespace spider {
 namespace core {

--- a/src/spider/client/Job.hpp
+++ b/src/spider/client/Job.hpp
@@ -16,17 +16,17 @@
 #include <boost/uuid/uuid.hpp>
 #include <fmt/format.h>
 
-#include "../core/DataImpl.hpp"
-#include "../core/Error.hpp"
-#include "../core/JobMetadata.hpp"
-#include "../io/MsgPack.hpp"  // IWYU pragma: keep
-#include "../storage/MetadataStorage.hpp"
-#include "../storage/StorageConnection.hpp"
-#include "../storage/StorageFactory.hpp"
-#include "Data.hpp"
-#include "Exception.hpp"
-#include "task.hpp"
-#include "type_utils.hpp"
+#include "spider/core/DataImpl.hpp"
+#include "spider/core/Error.hpp"
+#include "spider/core/JobMetadata.hpp"
+#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
+#include "spider/storage/MetadataStorage.hpp"
+#include "spider/storage/StorageConnection.hpp"
+#include "spider/storage/StorageFactory.hpp"
+#include "spider/client/Data.hpp"
+#include "spider/client/Exception.hpp"
+#include "spider/client/task.hpp"
+#include "spider/client/type_utils.hpp"
 
 namespace spider {
 namespace core {

--- a/src/spider/client/TaskContext.cpp
+++ b/src/spider/client/TaskContext.cpp
@@ -9,10 +9,10 @@
 
 #include <boost/uuid/uuid.hpp>
 
-#include "spider/client/Exception.hpp"
-#include "spider/core/Error.hpp"
-#include "spider/core/KeyValueData.hpp"
-#include "spider/storage/StorageConnection.hpp"
+#include <spider/client/Exception.hpp>
+#include <spider/core/Error.hpp>
+#include <spider/core/KeyValueData.hpp>
+#include <spider/storage/StorageConnection.hpp>
 
 namespace spider {
 auto TaskContext::get_id() const -> boost::uuids::uuid {

--- a/src/spider/client/TaskContext.cpp
+++ b/src/spider/client/TaskContext.cpp
@@ -9,10 +9,10 @@
 
 #include <boost/uuid/uuid.hpp>
 
-#include "../core/Error.hpp"
-#include "../core/KeyValueData.hpp"
-#include "../storage/StorageConnection.hpp"
-#include "Exception.hpp"
+#include "spider/core/Error.hpp"
+#include "spider/core/KeyValueData.hpp"
+#include "spider/storage/StorageConnection.hpp"
+#include "spider/client/Exception.hpp"
 
 namespace spider {
 auto TaskContext::get_id() const -> boost::uuids::uuid {

--- a/src/spider/client/TaskContext.cpp
+++ b/src/spider/client/TaskContext.cpp
@@ -9,10 +9,10 @@
 
 #include <boost/uuid/uuid.hpp>
 
+#include "spider/client/Exception.hpp"
 #include "spider/core/Error.hpp"
 #include "spider/core/KeyValueData.hpp"
 #include "spider/storage/StorageConnection.hpp"
-#include "spider/client/Exception.hpp"
 
 namespace spider {
 auto TaskContext::get_id() const -> boost::uuids::uuid {

--- a/src/spider/client/TaskContext.hpp
+++ b/src/spider/client/TaskContext.hpp
@@ -15,17 +15,17 @@
 #include <boost/uuid/uuid.hpp>
 #include <fmt/format.h>
 
-#include "spider/client/Data.hpp"
-#include "spider/client/Exception.hpp"
-#include "spider/client/Job.hpp"
-#include "spider/client/task.hpp"
-#include "spider/client/TaskGraph.hpp"
-#include "spider/core/Error.hpp"
-#include "spider/core/TaskGraph.hpp"
-#include "spider/core/TaskGraphImpl.hpp"
-#include "spider/io/Serializer.hpp"
-#include "spider/storage/StorageConnection.hpp"
-#include "spider/storage/StorageFactory.hpp"
+#include <spider/client/Data.hpp>
+#include <spider/client/Exception.hpp>
+#include <spider/client/Job.hpp>
+#include <spider/client/task.hpp>
+#include <spider/client/TaskGraph.hpp>
+#include <spider/core/Error.hpp>
+#include <spider/core/TaskGraph.hpp>
+#include <spider/core/TaskGraphImpl.hpp>
+#include <spider/io/Serializer.hpp>
+#include <spider/storage/StorageConnection.hpp>
+#include <spider/storage/StorageFactory.hpp>
 
 namespace spider {
 namespace core {

--- a/src/spider/client/TaskContext.hpp
+++ b/src/spider/client/TaskContext.hpp
@@ -15,17 +15,17 @@
 #include <boost/uuid/uuid.hpp>
 #include <fmt/format.h>
 
-#include "../core/Error.hpp"
-#include "../core/TaskGraph.hpp"
-#include "../core/TaskGraphImpl.hpp"
-#include "../io/Serializer.hpp"
-#include "../storage/StorageConnection.hpp"
-#include "../storage/StorageFactory.hpp"
-#include "Data.hpp"
-#include "Exception.hpp"
-#include "Job.hpp"
-#include "task.hpp"
-#include "TaskGraph.hpp"
+#include "spider/core/Error.hpp"
+#include "spider/core/TaskGraph.hpp"
+#include "spider/core/TaskGraphImpl.hpp"
+#include "spider/io/Serializer.hpp"
+#include "spider/storage/StorageConnection.hpp"
+#include "spider/storage/StorageFactory.hpp"
+#include "spider/client/Data.hpp"
+#include "spider/client/Exception.hpp"
+#include "spider/client/Job.hpp"
+#include "spider/client/task.hpp"
+#include "spider/client/TaskGraph.hpp"
 
 namespace spider {
 namespace core {

--- a/src/spider/client/TaskContext.hpp
+++ b/src/spider/client/TaskContext.hpp
@@ -15,17 +15,17 @@
 #include <boost/uuid/uuid.hpp>
 #include <fmt/format.h>
 
+#include "spider/client/Data.hpp"
+#include "spider/client/Exception.hpp"
+#include "spider/client/Job.hpp"
+#include "spider/client/task.hpp"
+#include "spider/client/TaskGraph.hpp"
 #include "spider/core/Error.hpp"
 #include "spider/core/TaskGraph.hpp"
 #include "spider/core/TaskGraphImpl.hpp"
 #include "spider/io/Serializer.hpp"
 #include "spider/storage/StorageConnection.hpp"
 #include "spider/storage/StorageFactory.hpp"
-#include "spider/client/Data.hpp"
-#include "spider/client/Exception.hpp"
-#include "spider/client/Job.hpp"
-#include "spider/client/task.hpp"
-#include "spider/client/TaskGraph.hpp"
 
 namespace spider {
 namespace core {

--- a/src/spider/client/TaskGraph.hpp
+++ b/src/spider/client/TaskGraph.hpp
@@ -4,7 +4,7 @@
 #include <memory>
 #include <utility>
 
-#include "spider/client/task.hpp"
+#include <spider/client/task.hpp>
 
 namespace spider {
 namespace core {

--- a/src/spider/client/TaskGraph.hpp
+++ b/src/spider/client/TaskGraph.hpp
@@ -4,7 +4,7 @@
 #include <memory>
 #include <utility>
 
-#include "task.hpp"
+#include "spider/client/task.hpp"
 
 namespace spider {
 namespace core {

--- a/src/spider/client/spider.hpp
+++ b/src/spider/client/spider.hpp
@@ -2,11 +2,11 @@
 #define SPIDER_CLIENT_SPIDER_HPP
 
 // IWYU pragma: begin_exports
-#include "spider/client/Data.hpp"
-#include "spider/client/Driver.hpp"
-#include "spider/client/Job.hpp"
-#include "spider/client/TaskContext.hpp"
-#include "spider/client/TaskGraph.hpp"
+#include <spider/client/Data.hpp>
+#include <spider/client/Driver.hpp>
+#include <spider/client/Job.hpp>
+#include <spider/client/TaskContext.hpp>
+#include <spider/client/TaskGraph.hpp>
 
 // IWYU pragma: end_exports
 

--- a/src/spider/client/spider.hpp
+++ b/src/spider/client/spider.hpp
@@ -2,11 +2,11 @@
 #define SPIDER_CLIENT_SPIDER_HPP
 
 // IWYU pragma: begin_exports
-#include "Data.hpp"
-#include "Driver.hpp"
-#include "Job.hpp"
-#include "TaskContext.hpp"
-#include "TaskGraph.hpp"
+#include "spider/client/Data.hpp"
+#include "spider/client/Driver.hpp"
+#include "spider/client/Job.hpp"
+#include "spider/client/TaskContext.hpp"
+#include "spider/client/TaskGraph.hpp"
 
 // IWYU pragma: end_exports
 

--- a/src/spider/client/task.hpp
+++ b/src/spider/client/task.hpp
@@ -3,9 +3,9 @@
 
 #include <type_traits>
 
-#include "spider/io/Serializer.hpp"
 #include "spider/client/Data.hpp"
 #include "spider/client/type_utils.hpp"
+#include "spider/io/Serializer.hpp"
 
 namespace spider {
 /**

--- a/src/spider/client/task.hpp
+++ b/src/spider/client/task.hpp
@@ -3,9 +3,9 @@
 
 #include <type_traits>
 
-#include "spider/client/Data.hpp"
-#include "spider/client/type_utils.hpp"
-#include "spider/io/Serializer.hpp"
+#include <spider/client/Data.hpp>
+#include <spider/client/type_utils.hpp>
+#include <spider/io/Serializer.hpp>
 
 namespace spider {
 /**

--- a/src/spider/client/task.hpp
+++ b/src/spider/client/task.hpp
@@ -3,9 +3,9 @@
 
 #include <type_traits>
 
-#include "../io/Serializer.hpp"
-#include "Data.hpp"
-#include "type_utils.hpp"
+#include "spider/io/Serializer.hpp"
+#include "spider/client/Data.hpp"
+#include "spider/client/type_utils.hpp"
 
 namespace spider {
 /**

--- a/src/spider/core/DataImpl.hpp
+++ b/src/spider/core/DataImpl.hpp
@@ -4,9 +4,9 @@
 #include <memory>
 #include <utility>
 
-#include "../client/Data.hpp"
-#include "../storage/StorageFactory.hpp"
-#include "Data.hpp"
+#include "spider/client/Data.hpp"
+#include "spider/storage/StorageFactory.hpp"
+#include "spider/core/Data.hpp"
 
 namespace spider::core {
 class DataImpl {

--- a/src/spider/core/DataImpl.hpp
+++ b/src/spider/core/DataImpl.hpp
@@ -5,8 +5,8 @@
 #include <utility>
 
 #include "spider/client/Data.hpp"
-#include "spider/storage/StorageFactory.hpp"
 #include "spider/core/Data.hpp"
+#include "spider/storage/StorageFactory.hpp"
 
 namespace spider::core {
 class DataImpl {

--- a/src/spider/core/DataImpl.hpp
+++ b/src/spider/core/DataImpl.hpp
@@ -4,9 +4,9 @@
 #include <memory>
 #include <utility>
 
-#include "spider/client/Data.hpp"
-#include "spider/core/Data.hpp"
-#include "spider/storage/StorageFactory.hpp"
+#include <spider/client/Data.hpp>
+#include <spider/core/Data.hpp>
+#include <spider/storage/StorageFactory.hpp>
 
 namespace spider::core {
 class DataImpl {

--- a/src/spider/core/Task.cpp
+++ b/src/spider/core/Task.cpp
@@ -9,8 +9,8 @@
 #include <boost/uuid/uuid_io.hpp>
 #include <spdlog/spdlog.h>
 
-#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
-#include "spider/io/Serializer.hpp"  // IWYU pragma: keep
+#include <spider/io/MsgPack.hpp>  // IWYU pragma: keep
+#include <spider/io/Serializer.hpp>  // IWYU pragma: keep
 
 namespace spider::core {
 auto Task::get_arg_buffers() const -> std::optional<std::vector<msgpack::sbuffer>> {

--- a/src/spider/core/Task.cpp
+++ b/src/spider/core/Task.cpp
@@ -9,8 +9,8 @@
 #include <boost/uuid/uuid_io.hpp>
 #include <spdlog/spdlog.h>
 
-#include "../io/MsgPack.hpp"  // IWYU pragma: keep
-#include "../io/Serializer.hpp"  // IWYU pragma: keep
+#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
+#include "spider/io/Serializer.hpp"  // IWYU pragma: keep
 
 namespace spider::core {
 auto Task::get_arg_buffers() const -> std::optional<std::vector<msgpack::sbuffer>> {

--- a/src/spider/core/Task.hpp
+++ b/src/spider/core/Task.hpp
@@ -13,8 +13,8 @@
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid.hpp>
 
-#include "spider/io/MsgPack.hpp"
 #include "spider/core/Data.hpp"
+#include "spider/io/MsgPack.hpp"
 
 namespace spider::core {
 class TaskInput {

--- a/src/spider/core/Task.hpp
+++ b/src/spider/core/Task.hpp
@@ -13,8 +13,8 @@
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid.hpp>
 
-#include "spider/core/Data.hpp"
-#include "spider/io/MsgPack.hpp"
+#include <spider/core/Data.hpp>
+#include <spider/io/MsgPack.hpp>
 
 namespace spider::core {
 class TaskInput {

--- a/src/spider/core/Task.hpp
+++ b/src/spider/core/Task.hpp
@@ -13,8 +13,8 @@
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid.hpp>
 
-#include "../io/MsgPack.hpp"
-#include "Data.hpp"
+#include "spider/io/MsgPack.hpp"
+#include "spider/core/Data.hpp"
 
 namespace spider::core {
 class TaskInput {

--- a/src/spider/core/TaskContextImpl.hpp
+++ b/src/spider/core/TaskContextImpl.hpp
@@ -5,10 +5,10 @@
 
 #include <boost/uuid/uuid.hpp>
 
-#include "spider/client/TaskContext.hpp"
-#include "spider/storage/DataStorage.hpp"
-#include "spider/storage/MetadataStorage.hpp"
-#include "spider/storage/StorageFactory.hpp"
+#include <spider/client/TaskContext.hpp>
+#include <spider/storage/DataStorage.hpp>
+#include <spider/storage/MetadataStorage.hpp>
+#include <spider/storage/StorageFactory.hpp>
 
 namespace spider::core {
 class TaskContextImpl {

--- a/src/spider/core/TaskContextImpl.hpp
+++ b/src/spider/core/TaskContextImpl.hpp
@@ -5,10 +5,10 @@
 
 #include <boost/uuid/uuid.hpp>
 
-#include "../client/TaskContext.hpp"
-#include "../storage/DataStorage.hpp"
-#include "../storage/MetadataStorage.hpp"
-#include "../storage/StorageFactory.hpp"
+#include "spider/client/TaskContext.hpp"
+#include "spider/storage/DataStorage.hpp"
+#include "spider/storage/MetadataStorage.hpp"
+#include "spider/storage/StorageFactory.hpp"
 
 namespace spider::core {
 class TaskContextImpl {

--- a/src/spider/core/TaskGraph.hpp
+++ b/src/spider/core/TaskGraph.hpp
@@ -12,7 +12,7 @@
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid.hpp>
 
-#include "spider/core/Task.hpp"
+#include <spider/core/Task.hpp>
 
 namespace spider::core {
 class TaskGraph {

--- a/src/spider/core/TaskGraph.hpp
+++ b/src/spider/core/TaskGraph.hpp
@@ -12,7 +12,7 @@
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid.hpp>
 
-#include "Task.hpp"
+#include "spider/core/Task.hpp"
 
 namespace spider::core {
 class TaskGraph {

--- a/src/spider/core/TaskGraphImpl.hpp
+++ b/src/spider/core/TaskGraphImpl.hpp
@@ -11,14 +11,14 @@
 
 #include <boost/uuid/uuid.hpp>
 
-#include "spider/client/Data.hpp"
-#include "spider/client/task.hpp"
-#include "spider/client/type_utils.hpp"
-#include "spider/core/Task.hpp"
-#include "spider/core/TaskGraph.hpp"
-#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
-#include "spider/io/Serializer.hpp"  // IWYU pragma: keep
-#include "spider/worker/FunctionNameManager.hpp"
+#include <spider/client/Data.hpp>
+#include <spider/client/task.hpp>
+#include <spider/client/type_utils.hpp>
+#include <spider/core/Task.hpp>
+#include <spider/core/TaskGraph.hpp>
+#include <spider/io/MsgPack.hpp>  // IWYU pragma: keep
+#include <spider/io/Serializer.hpp>  // IWYU pragma: keep
+#include <spider/worker/FunctionNameManager.hpp>
 
 namespace spider::core {
 class Data;

--- a/src/spider/core/TaskGraphImpl.hpp
+++ b/src/spider/core/TaskGraphImpl.hpp
@@ -11,14 +11,14 @@
 
 #include <boost/uuid/uuid.hpp>
 
-#include "../client/Data.hpp"
-#include "../client/task.hpp"
-#include "../client/type_utils.hpp"
-#include "../core/Task.hpp"
-#include "../core/TaskGraph.hpp"
-#include "../io/MsgPack.hpp"  // IWYU pragma: keep
-#include "../io/Serializer.hpp"  // IWYU pragma: keep
-#include "../worker/FunctionNameManager.hpp"
+#include "spider/client/Data.hpp"
+#include "spider/client/task.hpp"
+#include "spider/client/type_utils.hpp"
+#include "spider/core/Task.hpp"
+#include "spider/core/TaskGraph.hpp"
+#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
+#include "spider/io/Serializer.hpp"  // IWYU pragma: keep
+#include "spider/worker/FunctionNameManager.hpp"
 
 namespace spider::core {
 class Data;

--- a/src/spider/io/Serializer.hpp
+++ b/src/spider/io/Serializer.hpp
@@ -6,7 +6,7 @@
 
 #include <boost/uuid/uuid.hpp>
 
-#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
+#include <spider/io/MsgPack.hpp>  // IWYU pragma: keep
 
 template <>
 struct msgpack::adaptor::convert<boost::uuids::uuid> {

--- a/src/spider/io/Serializer.hpp
+++ b/src/spider/io/Serializer.hpp
@@ -6,7 +6,7 @@
 
 #include <boost/uuid/uuid.hpp>
 
-#include "MsgPack.hpp"  // IWYU pragma: keep
+#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
 
 template <>
 struct msgpack::adaptor::convert<boost::uuids::uuid> {

--- a/src/spider/io/msgpack_message.cpp
+++ b/src/spider/io/msgpack_message.cpp
@@ -14,8 +14,8 @@
 
 #include <spdlog/spdlog.h>
 
-#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
+#include <spider/io/BoostAsio.hpp>  // IWYU pragma: keep
+#include <spider/io/MsgPack.hpp>  // IWYU pragma: keep
 
 namespace {
 /**

--- a/src/spider/io/msgpack_message.cpp
+++ b/src/spider/io/msgpack_message.cpp
@@ -14,8 +14,8 @@
 
 #include <spdlog/spdlog.h>
 
-#include "BoostAsio.hpp"  // IWYU pragma: keep
-#include "MsgPack.hpp"  // IWYU pragma: keep
+#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
+#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
 
 namespace {
 /**

--- a/src/spider/io/msgpack_message.hpp
+++ b/src/spider/io/msgpack_message.hpp
@@ -4,8 +4,8 @@
 #include <functional>
 #include <optional>
 
-#include "BoostAsio.hpp"  // IWYU pragma: keep
-#include "MsgPack.hpp"  // IWYU pragma :keep
+#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
+#include "spider/io/MsgPack.hpp"  // IWYU pragma :keep
 
 namespace spider::core {
 auto send_message(boost::asio::ip::tcp::socket& socket, msgpack::sbuffer const& buffer) -> bool;

--- a/src/spider/io/msgpack_message.hpp
+++ b/src/spider/io/msgpack_message.hpp
@@ -5,7 +5,7 @@
 #include <optional>
 
 #include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "spider/io/MsgPack.hpp"  // IWYU pragma :keep
+#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
 
 namespace spider::core {
 auto send_message(boost::asio::ip::tcp::socket& socket, msgpack::sbuffer const& buffer) -> bool;

--- a/src/spider/io/msgpack_message.hpp
+++ b/src/spider/io/msgpack_message.hpp
@@ -4,8 +4,8 @@
 #include <functional>
 #include <optional>
 
-#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
+#include <spider/io/BoostAsio.hpp>  // IWYU pragma: keep
+#include <spider/io/MsgPack.hpp>  // IWYU pragma: keep
 
 namespace spider::core {
 auto send_message(boost::asio::ip::tcp::socket& socket, msgpack::sbuffer const& buffer) -> bool;

--- a/src/spider/scheduler/FifoPolicy.cpp
+++ b/src/spider/scheduler/FifoPolicy.cpp
@@ -10,10 +10,10 @@
 
 #include <boost/uuid/uuid.hpp>
 
-#include "../core/Task.hpp"
-#include "../storage/DataStorage.hpp"
-#include "../storage/MetadataStorage.hpp"
-#include "../storage/StorageConnection.hpp"
+#include "spider/core/Task.hpp"
+#include "spider/storage/DataStorage.hpp"
+#include "spider/storage/MetadataStorage.hpp"
+#include "spider/storage/StorageConnection.hpp"
 
 namespace spider::scheduler {
 FifoPolicy::FifoPolicy(

--- a/src/spider/scheduler/FifoPolicy.cpp
+++ b/src/spider/scheduler/FifoPolicy.cpp
@@ -10,10 +10,10 @@
 
 #include <boost/uuid/uuid.hpp>
 
-#include "spider/core/Task.hpp"
-#include "spider/storage/DataStorage.hpp"
-#include "spider/storage/MetadataStorage.hpp"
-#include "spider/storage/StorageConnection.hpp"
+#include <spider/core/Task.hpp>
+#include <spider/storage/DataStorage.hpp>
+#include <spider/storage/MetadataStorage.hpp>
+#include <spider/storage/StorageConnection.hpp>
 
 namespace spider::scheduler {
 FifoPolicy::FifoPolicy(

--- a/src/spider/scheduler/FifoPolicy.hpp
+++ b/src/spider/scheduler/FifoPolicy.hpp
@@ -9,10 +9,10 @@
 #include <boost/uuid/uuid.hpp>
 
 #include "spider/core/Task.hpp"
+#include "spider/scheduler/SchedulerPolicy.hpp"
 #include "spider/storage/DataStorage.hpp"
 #include "spider/storage/MetadataStorage.hpp"
 #include "spider/storage/StorageConnection.hpp"
-#include "spider/scheduler/SchedulerPolicy.hpp"
 
 namespace spider::scheduler {
 class FifoPolicy final : public SchedulerPolicy {

--- a/src/spider/scheduler/FifoPolicy.hpp
+++ b/src/spider/scheduler/FifoPolicy.hpp
@@ -8,11 +8,11 @@
 
 #include <boost/uuid/uuid.hpp>
 
-#include "../core/Task.hpp"
-#include "../storage/DataStorage.hpp"
-#include "../storage/MetadataStorage.hpp"
-#include "../storage/StorageConnection.hpp"
-#include "SchedulerPolicy.hpp"
+#include "spider/core/Task.hpp"
+#include "spider/storage/DataStorage.hpp"
+#include "spider/storage/MetadataStorage.hpp"
+#include "spider/storage/StorageConnection.hpp"
+#include "spider/scheduler/SchedulerPolicy.hpp"
 
 namespace spider::scheduler {
 class FifoPolicy final : public SchedulerPolicy {

--- a/src/spider/scheduler/FifoPolicy.hpp
+++ b/src/spider/scheduler/FifoPolicy.hpp
@@ -8,11 +8,11 @@
 
 #include <boost/uuid/uuid.hpp>
 
-#include "spider/core/Task.hpp"
-#include "spider/scheduler/SchedulerPolicy.hpp"
-#include "spider/storage/DataStorage.hpp"
-#include "spider/storage/MetadataStorage.hpp"
-#include "spider/storage/StorageConnection.hpp"
+#include <spider/core/Task.hpp>
+#include <spider/scheduler/SchedulerPolicy.hpp>
+#include <spider/storage/DataStorage.hpp>
+#include <spider/storage/MetadataStorage.hpp>
+#include <spider/storage/StorageConnection.hpp>
 
 namespace spider::scheduler {
 class FifoPolicy final : public SchedulerPolicy {

--- a/src/spider/scheduler/SchedulerMessage.hpp
+++ b/src/spider/scheduler/SchedulerMessage.hpp
@@ -7,8 +7,8 @@
 
 #include <boost/uuid/uuid.hpp>
 
-#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
-#include "spider/io/Serializer.hpp"  // IWYU pragma: keep
+#include <spider/io/MsgPack.hpp>  // IWYU pragma: keep
+#include <spider/io/Serializer.hpp>  // IWYU pragma: keep
 
 namespace spider::scheduler {
 class ScheduleTaskRequest {

--- a/src/spider/scheduler/SchedulerMessage.hpp
+++ b/src/spider/scheduler/SchedulerMessage.hpp
@@ -7,8 +7,8 @@
 
 #include <boost/uuid/uuid.hpp>
 
-#include "../io/MsgPack.hpp"  // IWYU pragma: keep
-#include "../io/Serializer.hpp"  // IWYU pragma: keep
+#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
+#include "spider/io/Serializer.hpp"  // IWYU pragma: keep
 
 namespace spider::scheduler {
 class ScheduleTaskRequest {

--- a/src/spider/scheduler/SchedulerServer.cpp
+++ b/src/spider/scheduler/SchedulerServer.cpp
@@ -11,17 +11,17 @@
 #include <boost/uuid/uuid_io.hpp>
 #include <spdlog/spdlog.h>
 
-#include "../core/Error.hpp"
-#include "../io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "../io/MsgPack.hpp"  // IWYU pragma: keep
-#include "../io/msgpack_message.hpp"
-#include "../io/Serializer.hpp"  // IWYU pragma: keep
-#include "../storage/DataStorage.hpp"
-#include "../storage/MetadataStorage.hpp"
-#include "../storage/StorageConnection.hpp"
-#include "../utils/StopFlag.hpp"
-#include "SchedulerMessage.hpp"
-#include "SchedulerPolicy.hpp"
+#include "spider/core/Error.hpp"
+#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
+#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
+#include "spider/io/msgpack_message.hpp"
+#include "spider/io/Serializer.hpp"  // IWYU pragma: keep
+#include "spider/storage/DataStorage.hpp"
+#include "spider/storage/MetadataStorage.hpp"
+#include "spider/storage/StorageConnection.hpp"
+#include "spider/utils/StopFlag.hpp"
+#include "spider/scheduler/SchedulerMessage.hpp"
+#include "spider/scheduler/SchedulerPolicy.hpp"
 
 namespace spider::scheduler {
 SchedulerServer::SchedulerServer(

--- a/src/spider/scheduler/SchedulerServer.cpp
+++ b/src/spider/scheduler/SchedulerServer.cpp
@@ -16,12 +16,12 @@
 #include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
 #include "spider/io/msgpack_message.hpp"
 #include "spider/io/Serializer.hpp"  // IWYU pragma: keep
+#include "spider/scheduler/SchedulerMessage.hpp"
+#include "spider/scheduler/SchedulerPolicy.hpp"
 #include "spider/storage/DataStorage.hpp"
 #include "spider/storage/MetadataStorage.hpp"
 #include "spider/storage/StorageConnection.hpp"
 #include "spider/utils/StopFlag.hpp"
-#include "spider/scheduler/SchedulerMessage.hpp"
-#include "spider/scheduler/SchedulerPolicy.hpp"
 
 namespace spider::scheduler {
 SchedulerServer::SchedulerServer(

--- a/src/spider/scheduler/SchedulerServer.cpp
+++ b/src/spider/scheduler/SchedulerServer.cpp
@@ -11,17 +11,17 @@
 #include <boost/uuid/uuid_io.hpp>
 #include <spdlog/spdlog.h>
 
-#include "spider/core/Error.hpp"
-#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
-#include "spider/io/msgpack_message.hpp"
-#include "spider/io/Serializer.hpp"  // IWYU pragma: keep
-#include "spider/scheduler/SchedulerMessage.hpp"
-#include "spider/scheduler/SchedulerPolicy.hpp"
-#include "spider/storage/DataStorage.hpp"
-#include "spider/storage/MetadataStorage.hpp"
-#include "spider/storage/StorageConnection.hpp"
-#include "spider/utils/StopFlag.hpp"
+#include <spider/core/Error.hpp>
+#include <spider/io/BoostAsio.hpp>  // IWYU pragma: keep
+#include <spider/io/MsgPack.hpp>  // IWYU pragma: keep
+#include <spider/io/msgpack_message.hpp>
+#include <spider/io/Serializer.hpp>  // IWYU pragma: keep
+#include <spider/scheduler/SchedulerMessage.hpp>
+#include <spider/scheduler/SchedulerPolicy.hpp>
+#include <spider/storage/DataStorage.hpp>
+#include <spider/storage/MetadataStorage.hpp>
+#include <spider/storage/StorageConnection.hpp>
+#include <spider/utils/StopFlag.hpp>
 
 namespace spider::scheduler {
 SchedulerServer::SchedulerServer(

--- a/src/spider/scheduler/SchedulerServer.hpp
+++ b/src/spider/scheduler/SchedulerServer.hpp
@@ -5,11 +5,11 @@
 #include <mutex>
 #include <thread>
 
-#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "spider/scheduler/SchedulerPolicy.hpp"
-#include "spider/storage/DataStorage.hpp"
-#include "spider/storage/MetadataStorage.hpp"
-#include "spider/storage/StorageConnection.hpp"
+#include <spider/io/BoostAsio.hpp>  // IWYU pragma: keep
+#include <spider/scheduler/SchedulerPolicy.hpp>
+#include <spider/storage/DataStorage.hpp>
+#include <spider/storage/MetadataStorage.hpp>
+#include <spider/storage/StorageConnection.hpp>
 
 namespace spider::scheduler {
 class SchedulerServer {

--- a/src/spider/scheduler/SchedulerServer.hpp
+++ b/src/spider/scheduler/SchedulerServer.hpp
@@ -6,10 +6,10 @@
 #include <thread>
 
 #include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
+#include "spider/scheduler/SchedulerPolicy.hpp"
 #include "spider/storage/DataStorage.hpp"
 #include "spider/storage/MetadataStorage.hpp"
 #include "spider/storage/StorageConnection.hpp"
-#include "spider/scheduler/SchedulerPolicy.hpp"
 
 namespace spider::scheduler {
 class SchedulerServer {

--- a/src/spider/scheduler/SchedulerServer.hpp
+++ b/src/spider/scheduler/SchedulerServer.hpp
@@ -5,11 +5,11 @@
 #include <mutex>
 #include <thread>
 
-#include "../io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "../storage/DataStorage.hpp"
-#include "../storage/MetadataStorage.hpp"
-#include "../storage/StorageConnection.hpp"
-#include "SchedulerPolicy.hpp"
+#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
+#include "spider/storage/DataStorage.hpp"
+#include "spider/storage/MetadataStorage.hpp"
+#include "spider/storage/StorageConnection.hpp"
+#include "spider/scheduler/SchedulerPolicy.hpp"
 
 namespace spider::scheduler {
 class SchedulerServer {

--- a/src/spider/scheduler/scheduler.cpp
+++ b/src/spider/scheduler/scheduler.cpp
@@ -23,15 +23,15 @@
 #include "spider/core/Driver.hpp"
 #include "spider/core/Error.hpp"
 #include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
+#include "spider/scheduler/FifoPolicy.hpp"
+#include "spider/scheduler/SchedulerPolicy.hpp"
+#include "spider/scheduler/SchedulerServer.hpp"
 #include "spider/storage/DataStorage.hpp"
 #include "spider/storage/MetadataStorage.hpp"
 #include "spider/storage/mysql/MySqlStorageFactory.hpp"
 #include "spider/storage/StorageConnection.hpp"
 #include "spider/storage/StorageFactory.hpp"
 #include "spider/utils/StopFlag.hpp"
-#include "spider/scheduler/FifoPolicy.hpp"
-#include "spider/scheduler/SchedulerPolicy.hpp"
-#include "spider/scheduler/SchedulerServer.hpp"
 
 constexpr int cCmdArgParseErr = 1;
 constexpr int cSignalHandleErr = 2;

--- a/src/spider/scheduler/scheduler.cpp
+++ b/src/spider/scheduler/scheduler.cpp
@@ -20,18 +20,18 @@
 #include <spdlog/sinks/stdout_color_sinks.h>  // IWYU pragma: keep
 #include <spdlog/spdlog.h>
 
-#include "../core/Driver.hpp"
-#include "../core/Error.hpp"
-#include "../io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "../storage/DataStorage.hpp"
-#include "../storage/MetadataStorage.hpp"
-#include "../storage/mysql/MySqlStorageFactory.hpp"
-#include "../storage/StorageConnection.hpp"
-#include "../storage/StorageFactory.hpp"
-#include "../utils/StopFlag.hpp"
-#include "FifoPolicy.hpp"
-#include "SchedulerPolicy.hpp"
-#include "SchedulerServer.hpp"
+#include "spider/core/Driver.hpp"
+#include "spider/core/Error.hpp"
+#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
+#include "spider/storage/DataStorage.hpp"
+#include "spider/storage/MetadataStorage.hpp"
+#include "spider/storage/mysql/MySqlStorageFactory.hpp"
+#include "spider/storage/StorageConnection.hpp"
+#include "spider/storage/StorageFactory.hpp"
+#include "spider/utils/StopFlag.hpp"
+#include "spider/scheduler/FifoPolicy.hpp"
+#include "spider/scheduler/SchedulerPolicy.hpp"
+#include "spider/scheduler/SchedulerServer.hpp"
 
 constexpr int cCmdArgParseErr = 1;
 constexpr int cSignalHandleErr = 2;

--- a/src/spider/scheduler/scheduler.cpp
+++ b/src/spider/scheduler/scheduler.cpp
@@ -20,18 +20,18 @@
 #include <spdlog/sinks/stdout_color_sinks.h>  // IWYU pragma: keep
 #include <spdlog/spdlog.h>
 
-#include "spider/core/Driver.hpp"
-#include "spider/core/Error.hpp"
-#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "spider/scheduler/FifoPolicy.hpp"
-#include "spider/scheduler/SchedulerPolicy.hpp"
-#include "spider/scheduler/SchedulerServer.hpp"
-#include "spider/storage/DataStorage.hpp"
-#include "spider/storage/MetadataStorage.hpp"
-#include "spider/storage/mysql/MySqlStorageFactory.hpp"
-#include "spider/storage/StorageConnection.hpp"
-#include "spider/storage/StorageFactory.hpp"
-#include "spider/utils/StopFlag.hpp"
+#include <spider/core/Driver.hpp>
+#include <spider/core/Error.hpp>
+#include <spider/io/BoostAsio.hpp>  // IWYU pragma: keep
+#include <spider/scheduler/FifoPolicy.hpp>
+#include <spider/scheduler/SchedulerPolicy.hpp>
+#include <spider/scheduler/SchedulerServer.hpp>
+#include <spider/storage/DataStorage.hpp>
+#include <spider/storage/MetadataStorage.hpp>
+#include <spider/storage/mysql/MySqlStorageFactory.hpp>
+#include <spider/storage/StorageConnection.hpp>
+#include <spider/storage/StorageFactory.hpp>
+#include <spider/utils/StopFlag.hpp>
 
 constexpr int cCmdArgParseErr = 1;
 constexpr int cSignalHandleErr = 2;

--- a/src/spider/storage/DataStorage.hpp
+++ b/src/spider/storage/DataStorage.hpp
@@ -5,10 +5,10 @@
 
 #include <boost/uuid/uuid.hpp>
 
-#include "spider/core/Data.hpp"
-#include "spider/core/Error.hpp"
-#include "spider/core/KeyValueData.hpp"
-#include "spider/storage/StorageConnection.hpp"
+#include <spider/core/Data.hpp>
+#include <spider/core/Error.hpp>
+#include <spider/core/KeyValueData.hpp>
+#include <spider/storage/StorageConnection.hpp>
 
 namespace spider::core {
 class DataStorage {

--- a/src/spider/storage/DataStorage.hpp
+++ b/src/spider/storage/DataStorage.hpp
@@ -5,10 +5,10 @@
 
 #include <boost/uuid/uuid.hpp>
 
-#include "../core/Data.hpp"
-#include "../core/Error.hpp"
-#include "../core/KeyValueData.hpp"
-#include "StorageConnection.hpp"
+#include "spider/core/Data.hpp"
+#include "spider/core/Error.hpp"
+#include "spider/core/KeyValueData.hpp"
+#include "spider/storage/StorageConnection.hpp"
 
 namespace spider::core {
 class DataStorage {

--- a/src/spider/storage/JobSubmissionBatch.hpp
+++ b/src/spider/storage/JobSubmissionBatch.hpp
@@ -1,8 +1,8 @@
 #ifndef SPIDER_STORAGE_JOBSUBMISSIONBATCH_HPP
 #define SPIDER_STORAGE_JOBSUBMISSIONBATCH_HPP
 
-#include "../core/Error.hpp"
-#include "StorageConnection.hpp"
+#include "spider/core/Error.hpp"
+#include "spider/storage/StorageConnection.hpp"
 
 namespace spider::core {
 class JobSubmissionBatch {

--- a/src/spider/storage/JobSubmissionBatch.hpp
+++ b/src/spider/storage/JobSubmissionBatch.hpp
@@ -1,8 +1,8 @@
 #ifndef SPIDER_STORAGE_JOBSUBMISSIONBATCH_HPP
 #define SPIDER_STORAGE_JOBSUBMISSIONBATCH_HPP
 
-#include "spider/core/Error.hpp"
-#include "spider/storage/StorageConnection.hpp"
+#include <spider/core/Error.hpp>
+#include <spider/storage/StorageConnection.hpp>
 
 namespace spider::core {
 class JobSubmissionBatch {

--- a/src/spider/storage/MetadataStorage.hpp
+++ b/src/spider/storage/MetadataStorage.hpp
@@ -6,13 +6,13 @@
 
 #include <boost/uuid/uuid.hpp>
 
-#include "../core/Driver.hpp"
-#include "../core/Error.hpp"
-#include "../core/JobMetadata.hpp"
-#include "../core/Task.hpp"
-#include "../core/TaskGraph.hpp"
-#include "JobSubmissionBatch.hpp"
-#include "StorageConnection.hpp"
+#include "spider/core/Driver.hpp"
+#include "spider/core/Error.hpp"
+#include "spider/core/JobMetadata.hpp"
+#include "spider/core/Task.hpp"
+#include "spider/core/TaskGraph.hpp"
+#include "spider/storage/JobSubmissionBatch.hpp"
+#include "spider/storage/StorageConnection.hpp"
 
 namespace spider::core {
 class MetadataStorage {

--- a/src/spider/storage/MetadataStorage.hpp
+++ b/src/spider/storage/MetadataStorage.hpp
@@ -6,13 +6,13 @@
 
 #include <boost/uuid/uuid.hpp>
 
-#include "spider/core/Driver.hpp"
-#include "spider/core/Error.hpp"
-#include "spider/core/JobMetadata.hpp"
-#include "spider/core/Task.hpp"
-#include "spider/core/TaskGraph.hpp"
-#include "spider/storage/JobSubmissionBatch.hpp"
-#include "spider/storage/StorageConnection.hpp"
+#include <spider/core/Driver.hpp>
+#include <spider/core/Error.hpp>
+#include <spider/core/JobMetadata.hpp>
+#include <spider/core/Task.hpp>
+#include <spider/core/TaskGraph.hpp>
+#include <spider/storage/JobSubmissionBatch.hpp>
+#include <spider/storage/StorageConnection.hpp>
 
 namespace spider::core {
 class MetadataStorage {

--- a/src/spider/storage/StorageFactory.hpp
+++ b/src/spider/storage/StorageFactory.hpp
@@ -4,11 +4,11 @@
 #include <memory>
 #include <variant>
 
-#include "spider/core/Error.hpp"
-#include "spider/storage/DataStorage.hpp"
-#include "spider/storage/JobSubmissionBatch.hpp"
-#include "spider/storage/MetadataStorage.hpp"
-#include "spider/storage/StorageConnection.hpp"
+#include <spider/core/Error.hpp>
+#include <spider/storage/DataStorage.hpp>
+#include <spider/storage/JobSubmissionBatch.hpp>
+#include <spider/storage/MetadataStorage.hpp>
+#include <spider/storage/StorageConnection.hpp>
 
 namespace spider::core {
 class StorageFactory {

--- a/src/spider/storage/StorageFactory.hpp
+++ b/src/spider/storage/StorageFactory.hpp
@@ -4,11 +4,11 @@
 #include <memory>
 #include <variant>
 
-#include "../core/Error.hpp"
-#include "DataStorage.hpp"
-#include "JobSubmissionBatch.hpp"
-#include "MetadataStorage.hpp"
-#include "StorageConnection.hpp"
+#include "spider/core/Error.hpp"
+#include "spider/storage/DataStorage.hpp"
+#include "spider/storage/JobSubmissionBatch.hpp"
+#include "spider/storage/MetadataStorage.hpp"
+#include "spider/storage/StorageConnection.hpp"
 
 namespace spider::core {
 class StorageFactory {

--- a/src/spider/storage/mysql/MySqlConnection.cpp
+++ b/src/spider/storage/mysql/MySqlConnection.cpp
@@ -12,8 +12,8 @@
 #include <mariadb/conncpp/Properties.hpp>
 #include <spdlog/spdlog.h>
 
-#include "spider/core/Error.hpp"
-#include "spider/storage/StorageConnection.hpp"
+#include <spider/core/Error.hpp>
+#include <spider/storage/StorageConnection.hpp>
 
 namespace spider::core {
 auto MySqlConnection::create(std::string const& url)

--- a/src/spider/storage/mysql/MySqlConnection.cpp
+++ b/src/spider/storage/mysql/MySqlConnection.cpp
@@ -12,8 +12,8 @@
 #include <mariadb/conncpp/Properties.hpp>
 #include <spdlog/spdlog.h>
 
-#include "../../core/Error.hpp"
-#include "../StorageConnection.hpp"
+#include "spider/core/Error.hpp"
+#include "spider/storage/StorageConnection.hpp"
 
 namespace spider::core {
 auto MySqlConnection::create(std::string const& url)

--- a/src/spider/storage/mysql/MySqlConnection.hpp
+++ b/src/spider/storage/mysql/MySqlConnection.hpp
@@ -8,8 +8,8 @@
 
 #include <mariadb/conncpp/Connection.hpp>
 
-#include "spider/core/Error.hpp"
-#include "spider/storage/StorageConnection.hpp"
+#include <spider/core/Error.hpp>
+#include <spider/storage/StorageConnection.hpp>
 
 namespace spider::core {
 // Forward declaration for friend class

--- a/src/spider/storage/mysql/MySqlConnection.hpp
+++ b/src/spider/storage/mysql/MySqlConnection.hpp
@@ -8,8 +8,8 @@
 
 #include <mariadb/conncpp/Connection.hpp>
 
-#include "../../core/Error.hpp"
-#include "../StorageConnection.hpp"
+#include "spider/core/Error.hpp"
+#include "spider/storage/StorageConnection.hpp"
 
 namespace spider::core {
 // Forward declaration for friend class

--- a/src/spider/storage/mysql/MySqlJobSubmissionBatch.cpp
+++ b/src/spider/storage/mysql/MySqlJobSubmissionBatch.cpp
@@ -5,9 +5,9 @@
 #include <mariadb/conncpp/PreparedStatement.hpp>
 
 #include "spider/core/Error.hpp"
-#include "spider/storage/StorageConnection.hpp"
 #include "spider/storage/mysql/mysql_stmt.hpp"
 #include "spider/storage/mysql/MySqlConnection.hpp"
+#include "spider/storage/StorageConnection.hpp"
 
 namespace spider::core {
 // NOLINTBEGIN(cppcoreguidelines-pro-type-static-cast-downcast)

--- a/src/spider/storage/mysql/MySqlJobSubmissionBatch.cpp
+++ b/src/spider/storage/mysql/MySqlJobSubmissionBatch.cpp
@@ -4,10 +4,10 @@
 #include <mariadb/conncpp/Exception.hpp>
 #include <mariadb/conncpp/PreparedStatement.hpp>
 
-#include "../../core/Error.hpp"
-#include "../StorageConnection.hpp"
-#include "mysql_stmt.hpp"
-#include "MySqlConnection.hpp"
+#include "spider/core/Error.hpp"
+#include "spider/storage/StorageConnection.hpp"
+#include "spider/storage/mysql/mysql_stmt.hpp"
+#include "spider/storage/mysql/MySqlConnection.hpp"
 
 namespace spider::core {
 // NOLINTBEGIN(cppcoreguidelines-pro-type-static-cast-downcast)

--- a/src/spider/storage/mysql/MySqlJobSubmissionBatch.cpp
+++ b/src/spider/storage/mysql/MySqlJobSubmissionBatch.cpp
@@ -4,10 +4,10 @@
 #include <mariadb/conncpp/Exception.hpp>
 #include <mariadb/conncpp/PreparedStatement.hpp>
 
-#include "spider/core/Error.hpp"
-#include "spider/storage/mysql/mysql_stmt.hpp"
-#include "spider/storage/mysql/MySqlConnection.hpp"
-#include "spider/storage/StorageConnection.hpp"
+#include <spider/core/Error.hpp>
+#include <spider/storage/mysql/mysql_stmt.hpp>
+#include <spider/storage/mysql/MySqlConnection.hpp>
+#include <spider/storage/StorageConnection.hpp>
 
 namespace spider::core {
 // NOLINTBEGIN(cppcoreguidelines-pro-type-static-cast-downcast)

--- a/src/spider/storage/mysql/MySqlJobSubmissionBatch.hpp
+++ b/src/spider/storage/mysql/MySqlJobSubmissionBatch.hpp
@@ -5,9 +5,9 @@
 
 #include <mariadb/conncpp/PreparedStatement.hpp>
 
-#include "spider/core/Error.hpp"
-#include "spider/storage/JobSubmissionBatch.hpp"
-#include "spider/storage/StorageConnection.hpp"
+#include <spider/core/Error.hpp>
+#include <spider/storage/JobSubmissionBatch.hpp>
+#include <spider/storage/StorageConnection.hpp>
 
 namespace spider::core {
 // Forward declaration for friend class

--- a/src/spider/storage/mysql/MySqlJobSubmissionBatch.hpp
+++ b/src/spider/storage/mysql/MySqlJobSubmissionBatch.hpp
@@ -5,9 +5,9 @@
 
 #include <mariadb/conncpp/PreparedStatement.hpp>
 
-#include "../../core/Error.hpp"
-#include "../JobSubmissionBatch.hpp"
-#include "../StorageConnection.hpp"
+#include "spider/core/Error.hpp"
+#include "spider/storage/JobSubmissionBatch.hpp"
+#include "spider/storage/StorageConnection.hpp"
 
 namespace spider::core {
 // Forward declaration for friend class

--- a/src/spider/storage/mysql/MySqlStorage.cpp
+++ b/src/spider/storage/mysql/MySqlStorage.cpp
@@ -28,18 +28,18 @@
 #include <mariadb/conncpp/Types.hpp>
 #include <spdlog/spdlog.h>
 
-#include "../../core/Data.hpp"
-#include "../../core/Driver.hpp"
-#include "../../core/Error.hpp"
-#include "../../core/JobMetadata.hpp"
-#include "../../core/KeyValueData.hpp"
-#include "../../core/Task.hpp"
-#include "../../core/TaskGraph.hpp"
-#include "../JobSubmissionBatch.hpp"
-#include "../StorageConnection.hpp"
-#include "mysql_stmt.hpp"
-#include "MySqlConnection.hpp"
-#include "MySqlJobSubmissionBatch.hpp"
+#include "spider/core/Data.hpp"
+#include "spider/core/Driver.hpp"
+#include "spider/core/Error.hpp"
+#include "spider/core/JobMetadata.hpp"
+#include "spider/core/KeyValueData.hpp"
+#include "spider/core/Task.hpp"
+#include "spider/core/TaskGraph.hpp"
+#include "spider/storage/JobSubmissionBatch.hpp"
+#include "spider/storage/StorageConnection.hpp"
+#include "spider/storage/mysql/mysql_stmt.hpp"
+#include "spider/storage/mysql/MySqlConnection.hpp"
+#include "spider/storage/mysql/MySqlJobSubmissionBatch.hpp"
 
 // mariadb-connector-cpp does not define SQL errcode. Just include some useful ones.
 enum MariadbErr : uint16_t {

--- a/src/spider/storage/mysql/MySqlStorage.cpp
+++ b/src/spider/storage/mysql/MySqlStorage.cpp
@@ -28,18 +28,18 @@
 #include <mariadb/conncpp/Types.hpp>
 #include <spdlog/spdlog.h>
 
-#include "spider/core/Data.hpp"
-#include "spider/core/Driver.hpp"
-#include "spider/core/Error.hpp"
-#include "spider/core/JobMetadata.hpp"
-#include "spider/core/KeyValueData.hpp"
-#include "spider/core/Task.hpp"
-#include "spider/core/TaskGraph.hpp"
-#include "spider/storage/JobSubmissionBatch.hpp"
-#include "spider/storage/mysql/mysql_stmt.hpp"
-#include "spider/storage/mysql/MySqlConnection.hpp"
-#include "spider/storage/mysql/MySqlJobSubmissionBatch.hpp"
-#include "spider/storage/StorageConnection.hpp"
+#include <spider/core/Data.hpp>
+#include <spider/core/Driver.hpp>
+#include <spider/core/Error.hpp>
+#include <spider/core/JobMetadata.hpp>
+#include <spider/core/KeyValueData.hpp>
+#include <spider/core/Task.hpp>
+#include <spider/core/TaskGraph.hpp>
+#include <spider/storage/JobSubmissionBatch.hpp>
+#include <spider/storage/mysql/mysql_stmt.hpp>
+#include <spider/storage/mysql/MySqlConnection.hpp>
+#include <spider/storage/mysql/MySqlJobSubmissionBatch.hpp>
+#include <spider/storage/StorageConnection.hpp>
 
 // mariadb-connector-cpp does not define SQL errcode. Just include some useful ones.
 enum MariadbErr : uint16_t {

--- a/src/spider/storage/mysql/MySqlStorage.cpp
+++ b/src/spider/storage/mysql/MySqlStorage.cpp
@@ -36,10 +36,10 @@
 #include "spider/core/Task.hpp"
 #include "spider/core/TaskGraph.hpp"
 #include "spider/storage/JobSubmissionBatch.hpp"
-#include "spider/storage/StorageConnection.hpp"
 #include "spider/storage/mysql/mysql_stmt.hpp"
 #include "spider/storage/mysql/MySqlConnection.hpp"
 #include "spider/storage/mysql/MySqlJobSubmissionBatch.hpp"
+#include "spider/storage/StorageConnection.hpp"
 
 // mariadb-connector-cpp does not define SQL errcode. Just include some useful ones.
 enum MariadbErr : uint16_t {

--- a/src/spider/storage/mysql/MySqlStorage.hpp
+++ b/src/spider/storage/mysql/MySqlStorage.hpp
@@ -10,19 +10,19 @@
 #include <mariadb/conncpp/CArray.hpp>
 #include <mariadb/conncpp/ResultSet.hpp>
 
-#include "../../core/Data.hpp"
-#include "../../core/Driver.hpp"
-#include "../../core/Error.hpp"
-#include "../../core/JobMetadata.hpp"
-#include "../../core/KeyValueData.hpp"
-#include "../../core/Task.hpp"
-#include "../../core/TaskGraph.hpp"
-#include "../DataStorage.hpp"
-#include "../JobSubmissionBatch.hpp"
-#include "../MetadataStorage.hpp"
-#include "../StorageConnection.hpp"
-#include "MySqlConnection.hpp"
-#include "MySqlJobSubmissionBatch.hpp"
+#include "spider/core/Data.hpp"
+#include "spider/core/Driver.hpp"
+#include "spider/core/Error.hpp"
+#include "spider/core/JobMetadata.hpp"
+#include "spider/core/KeyValueData.hpp"
+#include "spider/core/Task.hpp"
+#include "spider/core/TaskGraph.hpp"
+#include "spider/storage/DataStorage.hpp"
+#include "spider/storage/JobSubmissionBatch.hpp"
+#include "spider/storage/MetadataStorage.hpp"
+#include "spider/storage/StorageConnection.hpp"
+#include "spider/storage/mysql/MySqlConnection.hpp"
+#include "spider/storage/mysql/MySqlJobSubmissionBatch.hpp"
 
 namespace spider::core {
 // Forward declaration for friend class

--- a/src/spider/storage/mysql/MySqlStorage.hpp
+++ b/src/spider/storage/mysql/MySqlStorage.hpp
@@ -10,19 +10,19 @@
 #include <mariadb/conncpp/CArray.hpp>
 #include <mariadb/conncpp/ResultSet.hpp>
 
-#include "spider/core/Data.hpp"
-#include "spider/core/Driver.hpp"
-#include "spider/core/Error.hpp"
-#include "spider/core/JobMetadata.hpp"
-#include "spider/core/KeyValueData.hpp"
-#include "spider/core/Task.hpp"
-#include "spider/core/TaskGraph.hpp"
-#include "spider/storage/DataStorage.hpp"
-#include "spider/storage/JobSubmissionBatch.hpp"
-#include "spider/storage/MetadataStorage.hpp"
-#include "spider/storage/mysql/MySqlConnection.hpp"
-#include "spider/storage/mysql/MySqlJobSubmissionBatch.hpp"
-#include "spider/storage/StorageConnection.hpp"
+#include <spider/core/Data.hpp>
+#include <spider/core/Driver.hpp>
+#include <spider/core/Error.hpp>
+#include <spider/core/JobMetadata.hpp>
+#include <spider/core/KeyValueData.hpp>
+#include <spider/core/Task.hpp>
+#include <spider/core/TaskGraph.hpp>
+#include <spider/storage/DataStorage.hpp>
+#include <spider/storage/JobSubmissionBatch.hpp>
+#include <spider/storage/MetadataStorage.hpp>
+#include <spider/storage/mysql/MySqlConnection.hpp>
+#include <spider/storage/mysql/MySqlJobSubmissionBatch.hpp>
+#include <spider/storage/StorageConnection.hpp>
 
 namespace spider::core {
 // Forward declaration for friend class

--- a/src/spider/storage/mysql/MySqlStorage.hpp
+++ b/src/spider/storage/mysql/MySqlStorage.hpp
@@ -20,9 +20,9 @@
 #include "spider/storage/DataStorage.hpp"
 #include "spider/storage/JobSubmissionBatch.hpp"
 #include "spider/storage/MetadataStorage.hpp"
-#include "spider/storage/StorageConnection.hpp"
 #include "spider/storage/mysql/MySqlConnection.hpp"
 #include "spider/storage/mysql/MySqlJobSubmissionBatch.hpp"
+#include "spider/storage/StorageConnection.hpp"
 
 namespace spider::core {
 // Forward declaration for friend class

--- a/src/spider/storage/mysql/MySqlStorageFactory.cpp
+++ b/src/spider/storage/mysql/MySqlStorageFactory.cpp
@@ -9,10 +9,10 @@
 #include "spider/storage/DataStorage.hpp"
 #include "spider/storage/JobSubmissionBatch.hpp"
 #include "spider/storage/MetadataStorage.hpp"
-#include "spider/storage/StorageConnection.hpp"
 #include "spider/storage/mysql/MySqlConnection.hpp"
 #include "spider/storage/mysql/MySqlJobSubmissionBatch.hpp"
 #include "spider/storage/mysql/MySqlStorage.hpp"
+#include "spider/storage/StorageConnection.hpp"
 
 namespace spider::core {
 MySqlStorageFactory::MySqlStorageFactory(std::string url) : m_url{std::move(url)} {}

--- a/src/spider/storage/mysql/MySqlStorageFactory.cpp
+++ b/src/spider/storage/mysql/MySqlStorageFactory.cpp
@@ -5,14 +5,14 @@
 #include <utility>
 #include <variant>
 
-#include "spider/core/Error.hpp"
-#include "spider/storage/DataStorage.hpp"
-#include "spider/storage/JobSubmissionBatch.hpp"
-#include "spider/storage/MetadataStorage.hpp"
-#include "spider/storage/mysql/MySqlConnection.hpp"
-#include "spider/storage/mysql/MySqlJobSubmissionBatch.hpp"
-#include "spider/storage/mysql/MySqlStorage.hpp"
-#include "spider/storage/StorageConnection.hpp"
+#include <spider/core/Error.hpp>
+#include <spider/storage/DataStorage.hpp>
+#include <spider/storage/JobSubmissionBatch.hpp>
+#include <spider/storage/MetadataStorage.hpp>
+#include <spider/storage/mysql/MySqlConnection.hpp>
+#include <spider/storage/mysql/MySqlJobSubmissionBatch.hpp>
+#include <spider/storage/mysql/MySqlStorage.hpp>
+#include <spider/storage/StorageConnection.hpp>
 
 namespace spider::core {
 MySqlStorageFactory::MySqlStorageFactory(std::string url) : m_url{std::move(url)} {}

--- a/src/spider/storage/mysql/MySqlStorageFactory.cpp
+++ b/src/spider/storage/mysql/MySqlStorageFactory.cpp
@@ -5,14 +5,14 @@
 #include <utility>
 #include <variant>
 
-#include "../../core/Error.hpp"
-#include "../DataStorage.hpp"
-#include "../JobSubmissionBatch.hpp"
-#include "../MetadataStorage.hpp"
-#include "../StorageConnection.hpp"
-#include "MySqlConnection.hpp"
-#include "MySqlJobSubmissionBatch.hpp"
-#include "MySqlStorage.hpp"
+#include "spider/core/Error.hpp"
+#include "spider/storage/DataStorage.hpp"
+#include "spider/storage/JobSubmissionBatch.hpp"
+#include "spider/storage/MetadataStorage.hpp"
+#include "spider/storage/StorageConnection.hpp"
+#include "spider/storage/mysql/MySqlConnection.hpp"
+#include "spider/storage/mysql/MySqlJobSubmissionBatch.hpp"
+#include "spider/storage/mysql/MySqlStorage.hpp"
 
 namespace spider::core {
 MySqlStorageFactory::MySqlStorageFactory(std::string url) : m_url{std::move(url)} {}

--- a/src/spider/storage/mysql/MySqlStorageFactory.hpp
+++ b/src/spider/storage/mysql/MySqlStorageFactory.hpp
@@ -5,12 +5,12 @@
 #include <string>
 #include <variant>
 
-#include "../../core/Error.hpp"
-#include "../DataStorage.hpp"
-#include "../JobSubmissionBatch.hpp"
-#include "../MetadataStorage.hpp"
-#include "../StorageConnection.hpp"
-#include "../StorageFactory.hpp"
+#include "spider/core/Error.hpp"
+#include "spider/storage/DataStorage.hpp"
+#include "spider/storage/JobSubmissionBatch.hpp"
+#include "spider/storage/MetadataStorage.hpp"
+#include "spider/storage/StorageConnection.hpp"
+#include "spider/storage/StorageFactory.hpp"
 
 namespace spider::core {
 class MySqlStorageFactory : public StorageFactory {

--- a/src/spider/storage/mysql/MySqlStorageFactory.hpp
+++ b/src/spider/storage/mysql/MySqlStorageFactory.hpp
@@ -5,12 +5,12 @@
 #include <string>
 #include <variant>
 
-#include "spider/core/Error.hpp"
-#include "spider/storage/DataStorage.hpp"
-#include "spider/storage/JobSubmissionBatch.hpp"
-#include "spider/storage/MetadataStorage.hpp"
-#include "spider/storage/StorageConnection.hpp"
-#include "spider/storage/StorageFactory.hpp"
+#include <spider/core/Error.hpp>
+#include <spider/storage/DataStorage.hpp>
+#include <spider/storage/JobSubmissionBatch.hpp>
+#include <spider/storage/MetadataStorage.hpp>
+#include <spider/storage/StorageConnection.hpp>
+#include <spider/storage/StorageFactory.hpp>
 
 namespace spider::core {
 class MySqlStorageFactory : public StorageFactory {

--- a/src/spider/worker/DllLoader.cpp
+++ b/src/spider/worker/DllLoader.cpp
@@ -8,8 +8,8 @@
 #include <boost/dll/shared_library.hpp>
 #include <spdlog/spdlog.h>
 
-#include "../worker/FunctionManager.hpp"
-#include "../worker/FunctionNameManager.hpp"
+#include "spider/worker/FunctionManager.hpp"
+#include "spider/worker/FunctionNameManager.hpp"
 
 namespace spider::worker {
 auto DllLoader::load_dll(std::string const& path_str) -> bool {

--- a/src/spider/worker/DllLoader.cpp
+++ b/src/spider/worker/DllLoader.cpp
@@ -8,8 +8,8 @@
 #include <boost/dll/shared_library.hpp>
 #include <spdlog/spdlog.h>
 
-#include "spider/worker/FunctionManager.hpp"
-#include "spider/worker/FunctionNameManager.hpp"
+#include <spider/worker/FunctionManager.hpp>
+#include <spider/worker/FunctionNameManager.hpp>
 
 namespace spider::worker {
 auto DllLoader::load_dll(std::string const& path_str) -> bool {

--- a/src/spider/worker/FunctionManager.cpp
+++ b/src/spider/worker/FunctionManager.cpp
@@ -11,8 +11,8 @@
 #include <boost/dll/alias.hpp>
 #include <spdlog/spdlog.h>
 
-#include "../io/MsgPack.hpp"  // IWYU pragma: keep
-#include "TaskExecutorMessage.hpp"
+#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
+#include "spider/worker/TaskExecutorMessage.hpp"
 
 namespace spider::core {
 auto response_get_error(msgpack::sbuffer const& buffer)

--- a/src/spider/worker/FunctionManager.cpp
+++ b/src/spider/worker/FunctionManager.cpp
@@ -11,8 +11,8 @@
 #include <boost/dll/alias.hpp>
 #include <spdlog/spdlog.h>
 
-#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
-#include "spider/worker/TaskExecutorMessage.hpp"
+#include <spider/io/MsgPack.hpp>  // IWYU pragma: keep
+#include <spider/worker/TaskExecutorMessage.hpp>
 
 namespace spider::core {
 auto response_get_error(msgpack::sbuffer const& buffer)

--- a/src/spider/worker/FunctionManager.hpp
+++ b/src/spider/worker/FunctionManager.hpp
@@ -17,17 +17,17 @@
 #include <boost/uuid/uuid.hpp>
 #include <fmt/format.h>
 
-#include "spider/client/Data.hpp"
-#include "spider/client/task.hpp"
-#include "spider/client/TaskContext.hpp"
-#include "spider/core/DataImpl.hpp"
-#include "spider/core/Error.hpp"
-#include "spider/core/TaskContextImpl.hpp"
-#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
-#include "spider/io/Serializer.hpp"
-#include "spider/storage/DataStorage.hpp"
-#include "spider/storage/StorageConnection.hpp"
-#include "spider/worker/TaskExecutorMessage.hpp"
+#include <spider/client/Data.hpp>
+#include <spider/client/task.hpp>
+#include <spider/client/TaskContext.hpp>
+#include <spider/core/DataImpl.hpp>
+#include <spider/core/Error.hpp>
+#include <spider/core/TaskContextImpl.hpp>
+#include <spider/io/MsgPack.hpp>  // IWYU pragma: keep
+#include <spider/io/Serializer.hpp>
+#include <spider/storage/DataStorage.hpp>
+#include <spider/storage/StorageConnection.hpp>
+#include <spider/worker/TaskExecutorMessage.hpp>
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)
 #define CONCAT_DIRECT(s1, s2) s1##s2

--- a/src/spider/worker/FunctionManager.hpp
+++ b/src/spider/worker/FunctionManager.hpp
@@ -17,17 +17,17 @@
 #include <boost/uuid/uuid.hpp>
 #include <fmt/format.h>
 
-#include "../client/Data.hpp"
-#include "../client/task.hpp"
-#include "../client/TaskContext.hpp"
-#include "../core/DataImpl.hpp"
-#include "../core/Error.hpp"
-#include "../core/TaskContextImpl.hpp"
-#include "../io/MsgPack.hpp"  // IWYU pragma: keep
-#include "../io/Serializer.hpp"
-#include "../storage/DataStorage.hpp"
-#include "../storage/StorageConnection.hpp"
-#include "TaskExecutorMessage.hpp"
+#include "spider/client/Data.hpp"
+#include "spider/client/task.hpp"
+#include "spider/client/TaskContext.hpp"
+#include "spider/core/DataImpl.hpp"
+#include "spider/core/Error.hpp"
+#include "spider/core/TaskContextImpl.hpp"
+#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
+#include "spider/io/Serializer.hpp"
+#include "spider/storage/DataStorage.hpp"
+#include "spider/storage/StorageConnection.hpp"
+#include "spider/worker/TaskExecutorMessage.hpp"
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)
 #define CONCAT_DIRECT(s1, s2) s1##s2

--- a/src/spider/worker/TaskExecutor.cpp
+++ b/src/spider/worker/TaskExecutor.cpp
@@ -10,11 +10,11 @@
 
 #include <fmt/format.h>
 
-#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
-#include "spider/worker/FunctionManager.hpp"
-#include "spider/worker/message_pipe.hpp"
-#include "spider/worker/TaskExecutorMessage.hpp"
+#include <spider/io/BoostAsio.hpp>  // IWYU pragma: keep
+#include <spider/io/MsgPack.hpp>  // IWYU pragma: keep
+#include <spider/worker/FunctionManager.hpp>
+#include <spider/worker/message_pipe.hpp>
+#include <spider/worker/TaskExecutorMessage.hpp>
 
 namespace spider::worker {
 auto TaskExecutor::get_pid() const -> pid_t {

--- a/src/spider/worker/TaskExecutor.cpp
+++ b/src/spider/worker/TaskExecutor.cpp
@@ -10,11 +10,11 @@
 
 #include <fmt/format.h>
 
-#include "../io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "../io/MsgPack.hpp"  // IWYU pragma: keep
-#include "FunctionManager.hpp"
-#include "message_pipe.hpp"
-#include "TaskExecutorMessage.hpp"
+#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
+#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
+#include "spider/worker/FunctionManager.hpp"
+#include "spider/worker/message_pipe.hpp"
+#include "spider/worker/TaskExecutorMessage.hpp"
 
 namespace spider::worker {
 auto TaskExecutor::get_pid() const -> pid_t {

--- a/src/spider/worker/TaskExecutor.hpp
+++ b/src/spider/worker/TaskExecutor.hpp
@@ -21,11 +21,11 @@
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_io.hpp>
 
-#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
-#include "spider/worker/FunctionManager.hpp"
-#include "spider/worker/message_pipe.hpp"
-#include "spider/worker/Process.hpp"
+#include <spider/io/BoostAsio.hpp>  // IWYU pragma: keep
+#include <spider/io/MsgPack.hpp>  // IWYU pragma: keep
+#include <spider/worker/FunctionManager.hpp>
+#include <spider/worker/message_pipe.hpp>
+#include <spider/worker/Process.hpp>
 
 namespace spider::worker {
 enum class TaskExecutorState : std::uint8_t {

--- a/src/spider/worker/TaskExecutor.hpp
+++ b/src/spider/worker/TaskExecutor.hpp
@@ -21,11 +21,11 @@
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_io.hpp>
 
-#include "../io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "../io/MsgPack.hpp"  // IWYU pragma: keep
-#include "FunctionManager.hpp"
-#include "message_pipe.hpp"
-#include "Process.hpp"
+#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
+#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
+#include "spider/worker/FunctionManager.hpp"
+#include "spider/worker/message_pipe.hpp"
+#include "spider/worker/Process.hpp"
 
 namespace spider::worker {
 enum class TaskExecutorState : std::uint8_t {

--- a/src/spider/worker/TaskExecutorMessage.hpp
+++ b/src/spider/worker/TaskExecutorMessage.hpp
@@ -3,7 +3,7 @@
 
 #include <cstdint>
 
-#include "../io/MsgPack.hpp"  // IWYU pragma: keep
+#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
 
 namespace spider::worker {
 enum class TaskExecutorResponseType : std::uint8_t {

--- a/src/spider/worker/TaskExecutorMessage.hpp
+++ b/src/spider/worker/TaskExecutorMessage.hpp
@@ -3,7 +3,7 @@
 
 #include <cstdint>
 
-#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
+#include <spider/io/MsgPack.hpp>  // IWYU pragma: keep
 
 namespace spider::worker {
 enum class TaskExecutorResponseType : std::uint8_t {

--- a/src/spider/worker/WorkerClient.cpp
+++ b/src/spider/worker/WorkerClient.cpp
@@ -15,17 +15,17 @@
 #include <boost/uuid/uuid.hpp>
 #include <spdlog/spdlog.h>
 
-#include "spider/core/Driver.hpp"
-#include "spider/core/Error.hpp"
-#include "spider/core/Task.hpp"
-#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
-#include "spider/io/msgpack_message.hpp"
-#include "spider/scheduler/SchedulerMessage.hpp"
-#include "spider/storage/DataStorage.hpp"
-#include "spider/storage/MetadataStorage.hpp"
-#include "spider/storage/StorageConnection.hpp"
-#include "spider/storage/StorageFactory.hpp"
+#include <spider/core/Driver.hpp>
+#include <spider/core/Error.hpp>
+#include <spider/core/Task.hpp>
+#include <spider/io/BoostAsio.hpp>  // IWYU pragma: keep
+#include <spider/io/MsgPack.hpp>  // IWYU pragma: keep
+#include <spider/io/msgpack_message.hpp>
+#include <spider/scheduler/SchedulerMessage.hpp>
+#include <spider/storage/DataStorage.hpp>
+#include <spider/storage/MetadataStorage.hpp>
+#include <spider/storage/StorageConnection.hpp>
+#include <spider/storage/StorageFactory.hpp>
 
 namespace spider::worker {
 WorkerClient::WorkerClient(

--- a/src/spider/worker/WorkerClient.cpp
+++ b/src/spider/worker/WorkerClient.cpp
@@ -15,17 +15,17 @@
 #include <boost/uuid/uuid.hpp>
 #include <spdlog/spdlog.h>
 
-#include "../core/Driver.hpp"
-#include "../core/Error.hpp"
-#include "../core/Task.hpp"
-#include "../io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "../io/MsgPack.hpp"  // IWYU pragma: keep
-#include "../io/msgpack_message.hpp"
-#include "../scheduler/SchedulerMessage.hpp"
-#include "../storage/DataStorage.hpp"
-#include "../storage/MetadataStorage.hpp"
-#include "../storage/StorageConnection.hpp"
-#include "../storage/StorageFactory.hpp"
+#include "spider/core/Driver.hpp"
+#include "spider/core/Error.hpp"
+#include "spider/core/Task.hpp"
+#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
+#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
+#include "spider/io/msgpack_message.hpp"
+#include "spider/scheduler/SchedulerMessage.hpp"
+#include "spider/storage/DataStorage.hpp"
+#include "spider/storage/MetadataStorage.hpp"
+#include "spider/storage/StorageConnection.hpp"
+#include "spider/storage/StorageFactory.hpp"
 
 namespace spider::worker {
 WorkerClient::WorkerClient(

--- a/src/spider/worker/WorkerClient.hpp
+++ b/src/spider/worker/WorkerClient.hpp
@@ -8,10 +8,10 @@
 
 #include <boost/uuid/uuid.hpp>
 
-#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "spider/storage/DataStorage.hpp"
-#include "spider/storage/MetadataStorage.hpp"
-#include "spider/storage/StorageFactory.hpp"
+#include <spider/io/BoostAsio.hpp>  // IWYU pragma: keep
+#include <spider/storage/DataStorage.hpp>
+#include <spider/storage/MetadataStorage.hpp>
+#include <spider/storage/StorageFactory.hpp>
 
 namespace spider::worker {
 class WorkerClient {

--- a/src/spider/worker/WorkerClient.hpp
+++ b/src/spider/worker/WorkerClient.hpp
@@ -8,10 +8,10 @@
 
 #include <boost/uuid/uuid.hpp>
 
-#include "../io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "../storage/DataStorage.hpp"
-#include "../storage/MetadataStorage.hpp"
-#include "../storage/StorageFactory.hpp"
+#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
+#include "spider/storage/DataStorage.hpp"
+#include "spider/storage/MetadataStorage.hpp"
+#include "spider/storage/StorageFactory.hpp"
 
 namespace spider::worker {
 class WorkerClient {

--- a/src/spider/worker/message_pipe.cpp
+++ b/src/spider/worker/message_pipe.cpp
@@ -11,8 +11,8 @@
 #include <fmt/format.h>
 #include <spdlog/spdlog.h>
 
-#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
+#include <spider/io/BoostAsio.hpp>  // IWYU pragma: keep
+#include <spider/io/MsgPack.hpp>  // IWYU pragma: keep
 
 namespace spider::worker {
 constexpr size_t cHeaderSize = 16;

--- a/src/spider/worker/message_pipe.cpp
+++ b/src/spider/worker/message_pipe.cpp
@@ -11,8 +11,8 @@
 #include <fmt/format.h>
 #include <spdlog/spdlog.h>
 
-#include "../io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "../io/MsgPack.hpp"  // IWYU pragma: keep
+#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
+#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
 
 namespace spider::worker {
 constexpr size_t cHeaderSize = 16;

--- a/src/spider/worker/message_pipe.hpp
+++ b/src/spider/worker/message_pipe.hpp
@@ -4,8 +4,8 @@
 #include <functional>
 #include <optional>
 
-#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
+#include <spider/io/BoostAsio.hpp>  // IWYU pragma: keep
+#include <spider/io/MsgPack.hpp>  // IWYU pragma: keep
 
 namespace spider::worker {
 auto send_message(boost::asio::writable_pipe& pipe, msgpack::sbuffer const& request) -> bool;

--- a/src/spider/worker/message_pipe.hpp
+++ b/src/spider/worker/message_pipe.hpp
@@ -4,8 +4,8 @@
 #include <functional>
 #include <optional>
 
-#include "../io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "../io/MsgPack.hpp"  // IWYU pragma: keep
+#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
+#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
 
 namespace spider::worker {
 auto send_message(boost::asio::writable_pipe& pipe, msgpack::sbuffer const& request) -> bool;

--- a/src/spider/worker/task_executor.cpp
+++ b/src/spider/worker/task_executor.cpp
@@ -20,17 +20,17 @@
 #include <spdlog/sinks/stdout_color_sinks.h>  // IWYU pragma: keep
 #include <spdlog/spdlog.h>
 
-#include "../client/TaskContext.hpp"
-#include "../io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "../io/MsgPack.hpp"  // IWYU pragma: keep
-#include "../storage/DataStorage.hpp"
-#include "../storage/MetadataStorage.hpp"
-#include "../storage/mysql/MySqlStorageFactory.hpp"
-#include "../storage/StorageFactory.hpp"
-#include "DllLoader.hpp"
-#include "FunctionManager.hpp"
-#include "message_pipe.hpp"
-#include "TaskExecutorMessage.hpp"
+#include "spider/client/TaskContext.hpp"
+#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
+#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
+#include "spider/storage/DataStorage.hpp"
+#include "spider/storage/MetadataStorage.hpp"
+#include "spider/storage/mysql/MySqlStorageFactory.hpp"
+#include "spider/storage/StorageFactory.hpp"
+#include "spider/worker/DllLoader.hpp"
+#include "spider/worker/FunctionManager.hpp"
+#include "spider/worker/message_pipe.hpp"
+#include "spider/worker/TaskExecutorMessage.hpp"
 
 namespace {
 auto parse_arg(int const argc, char** const& argv) -> boost::program_options::variables_map {

--- a/src/spider/worker/task_executor.cpp
+++ b/src/spider/worker/task_executor.cpp
@@ -20,17 +20,17 @@
 #include <spdlog/sinks/stdout_color_sinks.h>  // IWYU pragma: keep
 #include <spdlog/spdlog.h>
 
-#include "spider/client/TaskContext.hpp"
-#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
-#include "spider/storage/DataStorage.hpp"
-#include "spider/storage/MetadataStorage.hpp"
-#include "spider/storage/mysql/MySqlStorageFactory.hpp"
-#include "spider/storage/StorageFactory.hpp"
-#include "spider/worker/DllLoader.hpp"
-#include "spider/worker/FunctionManager.hpp"
-#include "spider/worker/message_pipe.hpp"
-#include "spider/worker/TaskExecutorMessage.hpp"
+#include <spider/client/TaskContext.hpp>
+#include <spider/io/BoostAsio.hpp>  // IWYU pragma: keep
+#include <spider/io/MsgPack.hpp>  // IWYU pragma: keep
+#include <spider/storage/DataStorage.hpp>
+#include <spider/storage/MetadataStorage.hpp>
+#include <spider/storage/mysql/MySqlStorageFactory.hpp>
+#include <spider/storage/StorageFactory.hpp>
+#include <spider/worker/DllLoader.hpp>
+#include <spider/worker/FunctionManager.hpp>
+#include <spider/worker/message_pipe.hpp>
+#include <spider/worker/TaskExecutorMessage.hpp>
 
 namespace {
 auto parse_arg(int const argc, char** const& argv) -> boost::program_options::variables_map {

--- a/src/spider/worker/worker.cpp
+++ b/src/spider/worker/worker.cpp
@@ -33,22 +33,22 @@
 #include <spdlog/sinks/stdout_color_sinks.h>  // IWYU pragma: keep
 #include <spdlog/spdlog.h>
 
-#include "../core/Data.hpp"
-#include "../core/Driver.hpp"
-#include "../core/Error.hpp"
-#include "../core/Task.hpp"
-#include "../io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "../io/MsgPack.hpp"  // IWYU pragma: keep
-#include "../io/Serializer.hpp"  // IWYU pragma: keep
-#include "../storage/DataStorage.hpp"
-#include "../storage/MetadataStorage.hpp"
-#include "../storage/mysql/MySqlStorageFactory.hpp"
-#include "../storage/StorageConnection.hpp"
-#include "../storage/StorageFactory.hpp"
-#include "../utils/StopFlag.hpp"
-#include "ChildPid.hpp"
-#include "TaskExecutor.hpp"
-#include "WorkerClient.hpp"
+#include "spider/core/Data.hpp"
+#include "spider/core/Driver.hpp"
+#include "spider/core/Error.hpp"
+#include "spider/core/Task.hpp"
+#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
+#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
+#include "spider/io/Serializer.hpp"  // IWYU pragma: keep
+#include "spider/storage/DataStorage.hpp"
+#include "spider/storage/MetadataStorage.hpp"
+#include "spider/storage/mysql/MySqlStorageFactory.hpp"
+#include "spider/storage/StorageConnection.hpp"
+#include "spider/storage/StorageFactory.hpp"
+#include "spider/utils/StopFlag.hpp"
+#include "spider/worker/ChildPid.hpp"
+#include "spider/worker/TaskExecutor.hpp"
+#include "spider/worker/WorkerClient.hpp"
 
 constexpr int cCmdArgParseErr = 1;
 constexpr int cSignalHandleErr = 2;

--- a/src/spider/worker/worker.cpp
+++ b/src/spider/worker/worker.cpp
@@ -33,22 +33,22 @@
 #include <spdlog/sinks/stdout_color_sinks.h>  // IWYU pragma: keep
 #include <spdlog/spdlog.h>
 
-#include "spider/core/Data.hpp"
-#include "spider/core/Driver.hpp"
-#include "spider/core/Error.hpp"
-#include "spider/core/Task.hpp"
-#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
-#include "spider/io/Serializer.hpp"  // IWYU pragma: keep
-#include "spider/storage/DataStorage.hpp"
-#include "spider/storage/MetadataStorage.hpp"
-#include "spider/storage/mysql/MySqlStorageFactory.hpp"
-#include "spider/storage/StorageConnection.hpp"
-#include "spider/storage/StorageFactory.hpp"
-#include "spider/utils/StopFlag.hpp"
-#include "spider/worker/ChildPid.hpp"
-#include "spider/worker/TaskExecutor.hpp"
-#include "spider/worker/WorkerClient.hpp"
+#include <spider/core/Data.hpp>
+#include <spider/core/Driver.hpp>
+#include <spider/core/Error.hpp>
+#include <spider/core/Task.hpp>
+#include <spider/io/BoostAsio.hpp>  // IWYU pragma: keep
+#include <spider/io/MsgPack.hpp>  // IWYU pragma: keep
+#include <spider/io/Serializer.hpp>  // IWYU pragma: keep
+#include <spider/storage/DataStorage.hpp>
+#include <spider/storage/MetadataStorage.hpp>
+#include <spider/storage/mysql/MySqlStorageFactory.hpp>
+#include <spider/storage/StorageConnection.hpp>
+#include <spider/storage/StorageFactory.hpp>
+#include <spider/utils/StopFlag.hpp>
+#include <spider/worker/ChildPid.hpp>
+#include <spider/worker/TaskExecutor.hpp>
+#include <spider/worker/WorkerClient.hpp>
 
 constexpr int cCmdArgParseErr = 1;
 constexpr int cSignalHandleErr = 2;

--- a/tests/.clang-format
+++ b/tests/.clang-format
@@ -2,9 +2,6 @@ BasedOnStyle: "InheritParentConfig"
 
 IncludeCategories:
   # NOTE: A header is grouped by first matching regex
-  # Project relative headers
-  - Regex: "^\"tests"
-    Priority: 5
   # Project library headers
   - Regex: "^<spider"
     Priority: 4
@@ -23,3 +20,6 @@ IncludeCategories:
   # C++ standard libraries
   - Regex: "^<.+>"
     Priority: 2
+  # Project relative headers
+  - Regex: "^\".+\""
+    Priority: 5

--- a/tests/.clang-format
+++ b/tests/.clang-format
@@ -2,15 +2,20 @@ BasedOnStyle: "InheritParentConfig"
 
 IncludeCategories:
   # NOTE: A header is grouped by first matching regex
-  # Project headers
+  # Project relative headers
+  - Regex: "^\"tests"
+    Priority: 5
+  # Project library headers
   - Regex: "^<spider"
+    Priority: 4
+  - Regex: "^<tests"
     Priority: 4
   # Library headers. Update when adding new libraries.
   # NOTE: clang-format retains leading white-space on a line in violation of the YAML spec.
   # Ex:
   # - Regex: "<(fmt|spdlog)"
   #   Priority: 3
-  - Regex: "^<(absl|boost|catch2|fmt|mariadb|msgpack|spdlog)"
+  - Regex: "^<(absl|boost|catch2|fmt|mariadb|msgpack|spdlog|ystdlib)"
     Priority: 3
   # C system headers
   - Regex: "^<.+\\.h>"

--- a/tests/.clang-format
+++ b/tests/.clang-format
@@ -1,15 +1,12 @@
 BasedOnStyle: "InheritParentConfig"
 
 IncludeCategories:
-  # NOTE: A header is grouped by first matching regex
+  # NOTE: A header is grouped by first matching regex library headers.
+  # NOTE: clang-format retains leading white-space on a line in violation of the YAML spec.
   # Project library headers
   - Regex: "^<(spider|tests)"
     Priority: 4
-  # Library headers. Update when adding new libraries.
-  # NOTE: clang-format retains leading white-space on a line in violation of the YAML spec.
-  # Ex:
-  # - Regex: "<(fmt|spdlog)"
-  #   Priority: 3
+  # External library headers. Update when adding new libraries.
   - Regex: "^<(absl|boost|catch2|fmt|mariadb|msgpack|spdlog|ystdlib)"
     Priority: 3
   # C system headers

--- a/tests/.clang-format
+++ b/tests/.clang-format
@@ -3,9 +3,7 @@ BasedOnStyle: "InheritParentConfig"
 IncludeCategories:
   # NOTE: A header is grouped by first matching regex
   # Project library headers
-  - Regex: "^<spider"
-    Priority: 4
-  - Regex: "^<tests"
+  - Regex: "^<(spider|tests)"
     Priority: 4
   # Library headers. Update when adding new libraries.
   # NOTE: clang-format retains leading white-space on a line in violation of the YAML spec.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(SPIDER_TEST_SOURCES
 
 add_executable(unitTest)
 target_sources(unitTest PRIVATE ${SPIDER_TEST_SOURCES})
+target_include_directories(unitTest PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
 set(SPIDER_TEST_WORKER_SOURCES)
 foreach(worker_source ${SPIDER_WORKER_SOURCES})
@@ -54,6 +55,7 @@ add_dependencies(unitTest worker_test)
 add_library(worker_test SHARED)
 target_sources(worker_test PUBLIC worker/worker-test.hpp)
 target_sources(worker_test PRIVATE worker/worker-test.cpp)
+target_include_directories(worker_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
 target_link_libraries(
     worker_test
     PRIVATE
@@ -76,6 +78,7 @@ target_link_libraries(
 add_library(signal_test SHARED)
 target_sources(signal_test PUBLIC worker/signal-test.hpp)
 target_sources(signal_test PRIVATE worker/signal-test.cpp)
+target_include_directories(signal_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
 target_link_libraries(
     signal_test
     PRIVATE

--- a/tests/client/client-test.cpp
+++ b/tests/client/client-test.cpp
@@ -16,8 +16,7 @@
 #include <spider/client/Driver.hpp>
 #include <spider/client/Job.hpp>
 #include <spider/client/TaskGraph.hpp>
-
-#include "tests/worker/worker-test.hpp"
+#include <tests/worker/worker-test.hpp>
 
 namespace {
 auto parse_args(int const argc, char** argv) -> boost::program_options::variables_map {

--- a/tests/client/client-test.cpp
+++ b/tests/client/client-test.cpp
@@ -12,10 +12,11 @@
 #include <spdlog/sinks/stdout_color_sinks.h>  // IWYU pragma: keep
 #include <spdlog/spdlog.h>
 
-#include "spider/client/Data.hpp"
-#include "spider/client/Driver.hpp"
-#include "spider/client/Job.hpp"
-#include "spider/client/TaskGraph.hpp"
+#include <spider/client/Data.hpp>
+#include <spider/client/Driver.hpp>
+#include <spider/client/Job.hpp>
+#include <spider/client/TaskGraph.hpp>
+
 #include "tests/worker/worker-test.hpp"
 
 namespace {

--- a/tests/client/client-test.cpp
+++ b/tests/client/client-test.cpp
@@ -12,11 +12,11 @@
 #include <spdlog/sinks/stdout_color_sinks.h>  // IWYU pragma: keep
 #include <spdlog/spdlog.h>
 
-#include "../../src/spider/client/Data.hpp"
-#include "../../src/spider/client/Driver.hpp"
-#include "../../src/spider/client/Job.hpp"
-#include "../../src/spider/client/TaskGraph.hpp"
-#include "../worker/worker-test.hpp"
+#include "spider/client/Data.hpp"
+#include "spider/client/Driver.hpp"
+#include "spider/client/Job.hpp"
+#include "spider/client/TaskGraph.hpp"
+#include "tests/worker/worker-test.hpp"
 
 namespace {
 auto parse_args(int const argc, char** argv) -> boost::program_options::variables_map {

--- a/tests/client/test-Driver.cpp
+++ b/tests/client/test-Driver.cpp
@@ -6,11 +6,11 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-#include "../../src/spider/client/Data.hpp"
-#include "../../src/spider/client/Driver.hpp"
-#include "../../src/spider/client/TaskContext.hpp"
-#include "../../src/spider/client/TaskGraph.hpp"
-#include "../storage/StorageTestHelper.hpp"
+#include "spider/client/Data.hpp"
+#include "spider/client/Driver.hpp"
+#include "spider/client/TaskContext.hpp"
+#include "spider/client/TaskGraph.hpp"
+#include "tests/storage/StorageTestHelper.hpp"
 
 namespace {
 TEMPLATE_LIST_TEST_CASE(

--- a/tests/client/test-Driver.cpp
+++ b/tests/client/test-Driver.cpp
@@ -6,10 +6,11 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-#include "spider/client/Data.hpp"
-#include "spider/client/Driver.hpp"
-#include "spider/client/TaskContext.hpp"
-#include "spider/client/TaskGraph.hpp"
+#include <spider/client/Data.hpp>
+#include <spider/client/Driver.hpp>
+#include <spider/client/TaskContext.hpp>
+#include <spider/client/TaskGraph.hpp>
+
 #include "tests/storage/StorageTestHelper.hpp"
 
 namespace {

--- a/tests/client/test-Driver.cpp
+++ b/tests/client/test-Driver.cpp
@@ -10,8 +10,7 @@
 #include <spider/client/Driver.hpp>
 #include <spider/client/TaskContext.hpp>
 #include <spider/client/TaskGraph.hpp>
-
-#include "tests/storage/StorageTestHelper.hpp"
+#include <tests/storage/StorageTestHelper.hpp>
 
 namespace {
 TEMPLATE_LIST_TEST_CASE(

--- a/tests/io/test-MsgpackMessage.cpp
+++ b/tests/io/test-MsgpackMessage.cpp
@@ -10,9 +10,9 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
-#include "spider/io/msgpack_message.hpp"
+#include <spider/io/BoostAsio.hpp>  // IWYU pragma: keep
+#include <spider/io/MsgPack.hpp>  // IWYU pragma: keep
+#include <spider/io/msgpack_message.hpp>
 
 namespace {
 using namespace boost::asio::ip;

--- a/tests/io/test-MsgpackMessage.cpp
+++ b/tests/io/test-MsgpackMessage.cpp
@@ -10,9 +10,9 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-#include "../../src/spider/io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "../../src/spider/io/MsgPack.hpp"  // IWYU pragma: keep
-#include "../../src/spider/io/msgpack_message.hpp"
+#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
+#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
+#include "spider/io/msgpack_message.hpp"
 
 namespace {
 using namespace boost::asio::ip;

--- a/tests/scheduler/test-SchedulerPolicy.cpp
+++ b/tests/scheduler/test-SchedulerPolicy.cpp
@@ -12,16 +12,17 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-#include "spider/core/Data.hpp"
-#include "spider/core/Driver.hpp"
-#include "spider/core/Error.hpp"
-#include "spider/core/Task.hpp"
-#include "spider/core/TaskGraph.hpp"
-#include "spider/scheduler/FifoPolicy.hpp"
-#include "spider/storage/DataStorage.hpp"
-#include "spider/storage/MetadataStorage.hpp"
-#include "spider/storage/StorageConnection.hpp"
-#include "spider/storage/StorageFactory.hpp"
+#include <spider/core/Data.hpp>
+#include <spider/core/Driver.hpp>
+#include <spider/core/Error.hpp>
+#include <spider/core/Task.hpp>
+#include <spider/core/TaskGraph.hpp>
+#include <spider/scheduler/FifoPolicy.hpp>
+#include <spider/storage/DataStorage.hpp>
+#include <spider/storage/MetadataStorage.hpp>
+#include <spider/storage/StorageConnection.hpp>
+#include <spider/storage/StorageFactory.hpp>
+
 #include "tests/storage/StorageTestHelper.hpp"
 
 namespace {

--- a/tests/scheduler/test-SchedulerPolicy.cpp
+++ b/tests/scheduler/test-SchedulerPolicy.cpp
@@ -12,17 +12,17 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-#include "../../src/spider/core/Data.hpp"
-#include "../../src/spider/core/Driver.hpp"
-#include "../../src/spider/core/Error.hpp"
-#include "../../src/spider/core/Task.hpp"
-#include "../../src/spider/core/TaskGraph.hpp"
-#include "../../src/spider/scheduler/FifoPolicy.hpp"
-#include "../../src/spider/storage/DataStorage.hpp"
-#include "../../src/spider/storage/MetadataStorage.hpp"
-#include "../../src/spider/storage/StorageConnection.hpp"
-#include "../../src/spider/storage/StorageFactory.hpp"
-#include "../storage/StorageTestHelper.hpp"
+#include "spider/core/Data.hpp"
+#include "spider/core/Driver.hpp"
+#include "spider/core/Error.hpp"
+#include "spider/core/Task.hpp"
+#include "spider/core/TaskGraph.hpp"
+#include "spider/scheduler/FifoPolicy.hpp"
+#include "spider/storage/DataStorage.hpp"
+#include "spider/storage/MetadataStorage.hpp"
+#include "spider/storage/StorageConnection.hpp"
+#include "spider/storage/StorageFactory.hpp"
+#include "tests/storage/StorageTestHelper.hpp"
 
 namespace {
 TEMPLATE_LIST_TEST_CASE(

--- a/tests/scheduler/test-SchedulerPolicy.cpp
+++ b/tests/scheduler/test-SchedulerPolicy.cpp
@@ -22,8 +22,7 @@
 #include <spider/storage/MetadataStorage.hpp>
 #include <spider/storage/StorageConnection.hpp>
 #include <spider/storage/StorageFactory.hpp>
-
-#include "tests/storage/StorageTestHelper.hpp"
+#include <tests/storage/StorageTestHelper.hpp>
 
 namespace {
 TEMPLATE_LIST_TEST_CASE(

--- a/tests/scheduler/test-SchedulerServer.cpp
+++ b/tests/scheduler/test-SchedulerServer.cpp
@@ -26,8 +26,7 @@
 #include <spider/storage/MetadataStorage.hpp>
 #include <spider/storage/StorageConnection.hpp>
 #include <spider/storage/StorageFactory.hpp>
-
-#include "tests/storage/StorageTestHelper.hpp"
+#include <tests/storage/StorageTestHelper.hpp>
 
 namespace {
 constexpr int cServerWarmupTime = 5;

--- a/tests/scheduler/test-SchedulerServer.cpp
+++ b/tests/scheduler/test-SchedulerServer.cpp
@@ -12,21 +12,21 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-#include "../../src/spider/core/Error.hpp"
-#include "../../src/spider/core/Task.hpp"
-#include "../../src/spider/core/TaskGraph.hpp"
-#include "../../src/spider/io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "../../src/spider/io/MsgPack.hpp"  // IWYU pragma: keep
-#include "../../src/spider/io/msgpack_message.hpp"
-#include "../../src/spider/scheduler/FifoPolicy.hpp"
-#include "../../src/spider/scheduler/SchedulerMessage.hpp"
-#include "../../src/spider/scheduler/SchedulerPolicy.hpp"
-#include "../../src/spider/scheduler/SchedulerServer.hpp"
-#include "../../src/spider/storage/DataStorage.hpp"
-#include "../../src/spider/storage/MetadataStorage.hpp"
-#include "../../src/spider/storage/StorageConnection.hpp"
-#include "../../src/spider/storage/StorageFactory.hpp"
-#include "../storage/StorageTestHelper.hpp"
+#include "spider/core/Error.hpp"
+#include "spider/core/Task.hpp"
+#include "spider/core/TaskGraph.hpp"
+#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
+#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
+#include "spider/io/msgpack_message.hpp"
+#include "spider/scheduler/FifoPolicy.hpp"
+#include "spider/scheduler/SchedulerMessage.hpp"
+#include "spider/scheduler/SchedulerPolicy.hpp"
+#include "spider/scheduler/SchedulerServer.hpp"
+#include "spider/storage/DataStorage.hpp"
+#include "spider/storage/MetadataStorage.hpp"
+#include "spider/storage/StorageConnection.hpp"
+#include "spider/storage/StorageFactory.hpp"
+#include "tests/storage/StorageTestHelper.hpp"
 
 namespace {
 constexpr int cServerWarmupTime = 5;

--- a/tests/scheduler/test-SchedulerServer.cpp
+++ b/tests/scheduler/test-SchedulerServer.cpp
@@ -12,20 +12,21 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-#include "spider/core/Error.hpp"
-#include "spider/core/Task.hpp"
-#include "spider/core/TaskGraph.hpp"
-#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
-#include "spider/io/msgpack_message.hpp"
-#include "spider/scheduler/FifoPolicy.hpp"
-#include "spider/scheduler/SchedulerMessage.hpp"
-#include "spider/scheduler/SchedulerPolicy.hpp"
-#include "spider/scheduler/SchedulerServer.hpp"
-#include "spider/storage/DataStorage.hpp"
-#include "spider/storage/MetadataStorage.hpp"
-#include "spider/storage/StorageConnection.hpp"
-#include "spider/storage/StorageFactory.hpp"
+#include <spider/core/Error.hpp>
+#include <spider/core/Task.hpp>
+#include <spider/core/TaskGraph.hpp>
+#include <spider/io/BoostAsio.hpp>  // IWYU pragma: keep
+#include <spider/io/MsgPack.hpp>  // IWYU pragma: keep
+#include <spider/io/msgpack_message.hpp>
+#include <spider/scheduler/FifoPolicy.hpp>
+#include <spider/scheduler/SchedulerMessage.hpp>
+#include <spider/scheduler/SchedulerPolicy.hpp>
+#include <spider/scheduler/SchedulerServer.hpp>
+#include <spider/storage/DataStorage.hpp>
+#include <spider/storage/MetadataStorage.hpp>
+#include <spider/storage/StorageConnection.hpp>
+#include <spider/storage/StorageFactory.hpp>
+
 #include "tests/storage/StorageTestHelper.hpp"
 
 namespace {

--- a/tests/storage/StorageTestHelper.hpp
+++ b/tests/storage/StorageTestHelper.hpp
@@ -7,8 +7,8 @@
 #include <string>
 #include <tuple>
 
-#include "spider/storage/mysql/MySqlStorageFactory.hpp"
-#include "spider/storage/StorageFactory.hpp"
+#include <spider/storage/mysql/MySqlStorageFactory.hpp>
+#include <spider/storage/StorageFactory.hpp>
 
 namespace spider::test {
 std::string const cMySqlStorageUrl

--- a/tests/storage/StorageTestHelper.hpp
+++ b/tests/storage/StorageTestHelper.hpp
@@ -7,8 +7,8 @@
 #include <string>
 #include <tuple>
 
-#include "../../src/spider/storage/mysql/MySqlStorageFactory.hpp"
-#include "../../src/spider/storage/StorageFactory.hpp"
+#include "spider/storage/mysql/MySqlStorageFactory.hpp"
+#include "spider/storage/StorageFactory.hpp"
 
 namespace spider::test {
 std::string const cMySqlStorageUrl

--- a/tests/storage/test-DataStorage.cpp
+++ b/tests/storage/test-DataStorage.cpp
@@ -8,16 +8,17 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-#include "spider/core/Data.hpp"
-#include "spider/core/Driver.hpp"
-#include "spider/core/Error.hpp"
-#include "spider/core/KeyValueData.hpp"
-#include "spider/core/Task.hpp"
-#include "spider/core/TaskGraph.hpp"
-#include "spider/storage/DataStorage.hpp"
-#include "spider/storage/MetadataStorage.hpp"
-#include "spider/storage/StorageConnection.hpp"
-#include "spider/storage/StorageFactory.hpp"
+#include <spider/core/Data.hpp>
+#include <spider/core/Driver.hpp>
+#include <spider/core/Error.hpp>
+#include <spider/core/KeyValueData.hpp>
+#include <spider/core/Task.hpp>
+#include <spider/core/TaskGraph.hpp>
+#include <spider/storage/DataStorage.hpp>
+#include <spider/storage/MetadataStorage.hpp>
+#include <spider/storage/StorageConnection.hpp>
+#include <spider/storage/StorageFactory.hpp>
+
 #include "tests/storage/StorageTestHelper.hpp"
 #include "tests/utils/CoreDataUtils.hpp"
 

--- a/tests/storage/test-DataStorage.cpp
+++ b/tests/storage/test-DataStorage.cpp
@@ -18,9 +18,8 @@
 #include <spider/storage/MetadataStorage.hpp>
 #include <spider/storage/StorageConnection.hpp>
 #include <spider/storage/StorageFactory.hpp>
-
-#include "tests/storage/StorageTestHelper.hpp"
-#include "tests/utils/CoreDataUtils.hpp"
+#include <tests/storage/StorageTestHelper.hpp>
+#include <tests/utils/CoreDataUtils.hpp>
 
 namespace {
 TEMPLATE_LIST_TEST_CASE(

--- a/tests/storage/test-DataStorage.cpp
+++ b/tests/storage/test-DataStorage.cpp
@@ -8,18 +8,18 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-#include "../../src/spider/core/Data.hpp"
-#include "../../src/spider/core/Driver.hpp"
-#include "../../src/spider/core/Error.hpp"
-#include "../../src/spider/core/KeyValueData.hpp"
-#include "../../src/spider/core/Task.hpp"
-#include "../../src/spider/core/TaskGraph.hpp"
-#include "../../src/spider/storage/DataStorage.hpp"
-#include "../../src/spider/storage/MetadataStorage.hpp"
-#include "../../src/spider/storage/StorageConnection.hpp"
-#include "../../src/spider/storage/StorageFactory.hpp"
-#include "../utils/CoreDataUtils.hpp"
-#include "StorageTestHelper.hpp"
+#include "spider/core/Data.hpp"
+#include "spider/core/Driver.hpp"
+#include "spider/core/Error.hpp"
+#include "spider/core/KeyValueData.hpp"
+#include "spider/core/Task.hpp"
+#include "spider/core/TaskGraph.hpp"
+#include "spider/storage/DataStorage.hpp"
+#include "spider/storage/MetadataStorage.hpp"
+#include "spider/storage/StorageConnection.hpp"
+#include "spider/storage/StorageFactory.hpp"
+#include "tests/storage/StorageTestHelper.hpp"
+#include "tests/utils/CoreDataUtils.hpp"
 
 namespace {
 TEMPLATE_LIST_TEST_CASE(

--- a/tests/storage/test-MetadataStorage.cpp
+++ b/tests/storage/test-MetadataStorage.cpp
@@ -13,15 +13,16 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-#include "spider/core/Driver.hpp"
-#include "spider/core/Error.hpp"
-#include "spider/core/JobMetadata.hpp"
-#include "spider/core/Task.hpp"
-#include "spider/core/TaskGraph.hpp"
-#include "spider/storage/JobSubmissionBatch.hpp"
-#include "spider/storage/MetadataStorage.hpp"
-#include "spider/storage/StorageConnection.hpp"
-#include "spider/storage/StorageFactory.hpp"
+#include <spider/core/Driver.hpp>
+#include <spider/core/Error.hpp>
+#include <spider/core/JobMetadata.hpp>
+#include <spider/core/Task.hpp>
+#include <spider/core/TaskGraph.hpp>
+#include <spider/storage/JobSubmissionBatch.hpp>
+#include <spider/storage/MetadataStorage.hpp>
+#include <spider/storage/StorageConnection.hpp>
+#include <spider/storage/StorageFactory.hpp>
+
 #include "tests/storage/StorageTestHelper.hpp"
 #include "tests/utils/CoreTaskUtils.hpp"
 

--- a/tests/storage/test-MetadataStorage.cpp
+++ b/tests/storage/test-MetadataStorage.cpp
@@ -13,17 +13,17 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-#include "../../src/spider/core/Driver.hpp"
-#include "../../src/spider/core/Error.hpp"
-#include "../../src/spider/core/JobMetadata.hpp"
-#include "../../src/spider/core/Task.hpp"
-#include "../../src/spider/core/TaskGraph.hpp"
-#include "../../src/spider/storage/JobSubmissionBatch.hpp"
-#include "../../src/spider/storage/MetadataStorage.hpp"
-#include "../../src/spider/storage/StorageConnection.hpp"
-#include "../../src/spider/storage/StorageFactory.hpp"
-#include "../utils/CoreTaskUtils.hpp"
-#include "StorageTestHelper.hpp"
+#include "spider/core/Driver.hpp"
+#include "spider/core/Error.hpp"
+#include "spider/core/JobMetadata.hpp"
+#include "spider/core/Task.hpp"
+#include "spider/core/TaskGraph.hpp"
+#include "spider/storage/JobSubmissionBatch.hpp"
+#include "spider/storage/MetadataStorage.hpp"
+#include "spider/storage/StorageConnection.hpp"
+#include "spider/storage/StorageFactory.hpp"
+#include "tests/storage/StorageTestHelper.hpp"
+#include "tests/utils/CoreTaskUtils.hpp"
 
 namespace {
 TEMPLATE_LIST_TEST_CASE("Driver heartbeat", "[storage]", spider::test::StorageFactoryTypeList) {

--- a/tests/storage/test-MetadataStorage.cpp
+++ b/tests/storage/test-MetadataStorage.cpp
@@ -22,9 +22,8 @@
 #include <spider/storage/MetadataStorage.hpp>
 #include <spider/storage/StorageConnection.hpp>
 #include <spider/storage/StorageFactory.hpp>
-
-#include "tests/storage/StorageTestHelper.hpp"
-#include "tests/utils/CoreTaskUtils.hpp"
+#include <tests/storage/StorageTestHelper.hpp>
+#include <tests/utils/CoreTaskUtils.hpp>
 
 namespace {
 TEMPLATE_LIST_TEST_CASE("Driver heartbeat", "[storage]", spider::test::StorageFactoryTypeList) {

--- a/tests/utils/CoreDataUtils.hpp
+++ b/tests/utils/CoreDataUtils.hpp
@@ -1,6 +1,6 @@
 #ifndef SPIDER_TESTS_COREDATAUTILS_HPP
 #define SPIDER_TESTS_COREDATAUTILS_HPP
-#include "../../src/spider/core/Data.hpp"
+#include "spider/core/Data.hpp"
 
 namespace spider::test {
 inline auto data_equal(core::Data const& d1, core::Data const& d2) -> bool {

--- a/tests/utils/CoreDataUtils.hpp
+++ b/tests/utils/CoreDataUtils.hpp
@@ -1,6 +1,6 @@
 #ifndef SPIDER_TESTS_COREDATAUTILS_HPP
 #define SPIDER_TESTS_COREDATAUTILS_HPP
-#include "spider/core/Data.hpp"
+#include <spider/core/Data.hpp>
 
 namespace spider::test {
 inline auto data_equal(core::Data const& d1, core::Data const& d2) -> bool {

--- a/tests/utils/CoreTaskUtils.cpp
+++ b/tests/utils/CoreTaskUtils.cpp
@@ -13,8 +13,8 @@
 #include <absl/container/flat_hash_map.h>
 #include <boost/uuid/uuid.hpp>
 
-#include "../../src/spider/core/Task.hpp"
-#include "../../src/spider/core/TaskGraph.hpp"
+#include "spider/core/Task.hpp"
+#include "spider/core/TaskGraph.hpp"
 
 namespace spider::test {
 namespace {

--- a/tests/utils/CoreTaskUtils.cpp
+++ b/tests/utils/CoreTaskUtils.cpp
@@ -13,8 +13,8 @@
 #include <absl/container/flat_hash_map.h>
 #include <boost/uuid/uuid.hpp>
 
-#include "spider/core/Task.hpp"
-#include "spider/core/TaskGraph.hpp"
+#include <spider/core/Task.hpp>
+#include <spider/core/TaskGraph.hpp>
 
 namespace spider::test {
 namespace {

--- a/tests/utils/CoreTaskUtils.hpp
+++ b/tests/utils/CoreTaskUtils.hpp
@@ -1,8 +1,8 @@
 #ifndef SPIDER_TESTS_CORETASKUTILS_HPP
 #define SPIDER_TESTS_CORETASKUTILS_HPP
 
-#include "../../src/spider/core/Task.hpp"
-#include "../../src/spider/core/TaskGraph.hpp"
+#include "spider/core/Task.hpp"
+#include "spider/core/TaskGraph.hpp"
 
 namespace spider::test {
 auto task_equal(core::Task const& t1, core::Task const& t2) -> bool;

--- a/tests/utils/CoreTaskUtils.hpp
+++ b/tests/utils/CoreTaskUtils.hpp
@@ -1,8 +1,8 @@
 #ifndef SPIDER_TESTS_CORETASKUTILS_HPP
 #define SPIDER_TESTS_CORETASKUTILS_HPP
 
-#include "spider/core/Task.hpp"
-#include "spider/core/TaskGraph.hpp"
+#include <spider/core/Task.hpp>
+#include <spider/core/TaskGraph.hpp>
 
 namespace spider::test {
 auto task_equal(core::Task const& t1, core::Task const& t2) -> bool;

--- a/tests/worker/test-FunctionManager.cpp
+++ b/tests/worker/test-FunctionManager.cpp
@@ -25,8 +25,7 @@
 #include <spider/storage/StorageFactory.hpp>
 #include <spider/worker/FunctionManager.hpp>
 #include <spider/worker/FunctionNameManager.hpp>
-
-#include "tests/storage/StorageTestHelper.hpp"
+#include <tests/storage/StorageTestHelper.hpp>
 
 namespace {
 auto int_test(spider::TaskContext& /*context*/, int const x, int const y) -> int {

--- a/tests/worker/test-FunctionManager.cpp
+++ b/tests/worker/test-FunctionManager.cpp
@@ -11,21 +11,21 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-#include "../../src/spider/client/Data.hpp"
-#include "../../src/spider/client/TaskContext.hpp"
-#include "../../src/spider/core/Driver.hpp"
-#include "../../src/spider/core/Error.hpp"
-#include "../../src/spider/core/Task.hpp"
-#include "../../src/spider/core/TaskContextImpl.hpp"
-#include "../../src/spider/core/TaskGraph.hpp"
-#include "../../src/spider/io/MsgPack.hpp"  // IWYU pragma: keep
-#include "../../src/spider/storage/DataStorage.hpp"
-#include "../../src/spider/storage/MetadataStorage.hpp"
-#include "../../src/spider/storage/StorageConnection.hpp"
-#include "../../src/spider/storage/StorageFactory.hpp"
-#include "../../src/spider/worker/FunctionManager.hpp"
-#include "../../src/spider/worker/FunctionNameManager.hpp"
-#include "../storage/StorageTestHelper.hpp"
+#include "spider/client/Data.hpp"
+#include "spider/client/TaskContext.hpp"
+#include "spider/core/Driver.hpp"
+#include "spider/core/Error.hpp"
+#include "spider/core/Task.hpp"
+#include "spider/core/TaskContextImpl.hpp"
+#include "spider/core/TaskGraph.hpp"
+#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
+#include "spider/storage/DataStorage.hpp"
+#include "spider/storage/MetadataStorage.hpp"
+#include "spider/storage/StorageConnection.hpp"
+#include "spider/storage/StorageFactory.hpp"
+#include "spider/worker/FunctionManager.hpp"
+#include "spider/worker/FunctionNameManager.hpp"
+#include "tests/storage/StorageTestHelper.hpp"
 
 namespace {
 auto int_test(spider::TaskContext& /*context*/, int const x, int const y) -> int {

--- a/tests/worker/test-FunctionManager.cpp
+++ b/tests/worker/test-FunctionManager.cpp
@@ -11,20 +11,21 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-#include "spider/client/Data.hpp"
-#include "spider/client/TaskContext.hpp"
-#include "spider/core/Driver.hpp"
-#include "spider/core/Error.hpp"
-#include "spider/core/Task.hpp"
-#include "spider/core/TaskContextImpl.hpp"
-#include "spider/core/TaskGraph.hpp"
-#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
-#include "spider/storage/DataStorage.hpp"
-#include "spider/storage/MetadataStorage.hpp"
-#include "spider/storage/StorageConnection.hpp"
-#include "spider/storage/StorageFactory.hpp"
-#include "spider/worker/FunctionManager.hpp"
-#include "spider/worker/FunctionNameManager.hpp"
+#include <spider/client/Data.hpp>
+#include <spider/client/TaskContext.hpp>
+#include <spider/core/Driver.hpp>
+#include <spider/core/Error.hpp>
+#include <spider/core/Task.hpp>
+#include <spider/core/TaskContextImpl.hpp>
+#include <spider/core/TaskGraph.hpp>
+#include <spider/io/MsgPack.hpp>  // IWYU pragma: keep
+#include <spider/storage/DataStorage.hpp>
+#include <spider/storage/MetadataStorage.hpp>
+#include <spider/storage/StorageConnection.hpp>
+#include <spider/storage/StorageFactory.hpp>
+#include <spider/worker/FunctionManager.hpp>
+#include <spider/worker/FunctionNameManager.hpp>
+
 #include "tests/storage/StorageTestHelper.hpp"
 
 namespace {

--- a/tests/worker/test-MessagePipe.cpp
+++ b/tests/worker/test-MessagePipe.cpp
@@ -6,11 +6,11 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-#include "spider/io/BoostAsio.hpp"
-#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
-#include "spider/worker/FunctionManager.hpp"
-#include "spider/worker/message_pipe.hpp"
-#include "spider/worker/TaskExecutorMessage.hpp"
+#include <spider/io/BoostAsio.hpp>
+#include <spider/io/MsgPack.hpp>  // IWYU pragma: keep
+#include <spider/worker/FunctionManager.hpp>
+#include <spider/worker/message_pipe.hpp>
+#include <spider/worker/TaskExecutorMessage.hpp>
 
 // NOLINTBEGIN(cert-err58-cpp,cppcoreguidelines-avoid-do-while,readability-function-cognitive-complexity,cppcoreguidelines-avoid-non-const-global-variables,cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
 namespace {

--- a/tests/worker/test-MessagePipe.cpp
+++ b/tests/worker/test-MessagePipe.cpp
@@ -6,11 +6,11 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-#include "../../src/spider/io/BoostAsio.hpp"
-#include "../../src/spider/io/MsgPack.hpp"  // IWYU pragma: keep
-#include "../../src/spider/worker/FunctionManager.hpp"
-#include "../../src/spider/worker/message_pipe.hpp"
-#include "../../src/spider/worker/TaskExecutorMessage.hpp"
+#include "spider/io/BoostAsio.hpp"
+#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
+#include "spider/worker/FunctionManager.hpp"
+#include "spider/worker/message_pipe.hpp"
+#include "spider/worker/TaskExecutorMessage.hpp"
 
 // NOLINTBEGIN(cert-err58-cpp,cppcoreguidelines-avoid-do-while,readability-function-cognitive-complexity,cppcoreguidelines-avoid-non-const-global-variables,cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
 namespace {

--- a/tests/worker/test-Process.cpp
+++ b/tests/worker/test-Process.cpp
@@ -7,8 +7,8 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-#include "../../src/spider/io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "../../src/spider/worker/Process.hpp"
+#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
+#include "spider/worker/Process.hpp"
 
 namespace {
 TEST_CASE("Process exit", "[worker]") {

--- a/tests/worker/test-Process.cpp
+++ b/tests/worker/test-Process.cpp
@@ -7,8 +7,8 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "spider/worker/Process.hpp"
+#include <spider/io/BoostAsio.hpp>  // IWYU pragma: keep
+#include <spider/worker/Process.hpp>
 
 namespace {
 TEST_CASE("Process exit", "[worker]") {

--- a/tests/worker/test-TaskExecutor.cpp
+++ b/tests/worker/test-TaskExecutor.cpp
@@ -29,8 +29,7 @@
 #include <spider/storage/StorageFactory.hpp>
 #include <spider/worker/FunctionManager.hpp>
 #include <spider/worker/TaskExecutor.hpp>
-
-#include "tests/storage/StorageTestHelper.hpp"
+#include <tests/storage/StorageTestHelper.hpp>
 
 // NOLINTBEGIN(cert-err58-cpp,cppcoreguidelines-avoid-do-while,readability-function-cognitive-complexity,cppcoreguidelines-avoid-non-const-global-variables,cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays,clang-analyzer-unix.BlockInCriticalSection)
 

--- a/tests/worker/test-TaskExecutor.cpp
+++ b/tests/worker/test-TaskExecutor.cpp
@@ -16,20 +16,20 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-#include "../../src/spider/core/Data.hpp"
-#include "../../src/spider/core/Driver.hpp"
-#include "../../src/spider/core/Error.hpp"
-#include "../../src/spider/core/Task.hpp"
-#include "../../src/spider/core/TaskGraph.hpp"
-#include "../../src/spider/io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "../../src/spider/io/MsgPack.hpp"  // IWYU pragma: keep
-#include "../../src/spider/storage/DataStorage.hpp"
-#include "../../src/spider/storage/MetadataStorage.hpp"
-#include "../../src/spider/storage/StorageConnection.hpp"
-#include "../../src/spider/storage/StorageFactory.hpp"
-#include "../../src/spider/worker/FunctionManager.hpp"
-#include "../../src/spider/worker/TaskExecutor.hpp"
-#include "../storage/StorageTestHelper.hpp"
+#include "spider/core/Data.hpp"
+#include "spider/core/Driver.hpp"
+#include "spider/core/Error.hpp"
+#include "spider/core/Task.hpp"
+#include "spider/core/TaskGraph.hpp"
+#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
+#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
+#include "spider/storage/DataStorage.hpp"
+#include "spider/storage/MetadataStorage.hpp"
+#include "spider/storage/StorageConnection.hpp"
+#include "spider/storage/StorageFactory.hpp"
+#include "spider/worker/FunctionManager.hpp"
+#include "spider/worker/TaskExecutor.hpp"
+#include "tests/storage/StorageTestHelper.hpp"
 
 // NOLINTBEGIN(cert-err58-cpp,cppcoreguidelines-avoid-do-while,readability-function-cognitive-complexity,cppcoreguidelines-avoid-non-const-global-variables,cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays,clang-analyzer-unix.BlockInCriticalSection)
 

--- a/tests/worker/test-TaskExecutor.cpp
+++ b/tests/worker/test-TaskExecutor.cpp
@@ -16,19 +16,20 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-#include "spider/core/Data.hpp"
-#include "spider/core/Driver.hpp"
-#include "spider/core/Error.hpp"
-#include "spider/core/Task.hpp"
-#include "spider/core/TaskGraph.hpp"
-#include "spider/io/BoostAsio.hpp"  // IWYU pragma: keep
-#include "spider/io/MsgPack.hpp"  // IWYU pragma: keep
-#include "spider/storage/DataStorage.hpp"
-#include "spider/storage/MetadataStorage.hpp"
-#include "spider/storage/StorageConnection.hpp"
-#include "spider/storage/StorageFactory.hpp"
-#include "spider/worker/FunctionManager.hpp"
-#include "spider/worker/TaskExecutor.hpp"
+#include <spider/core/Data.hpp>
+#include <spider/core/Driver.hpp>
+#include <spider/core/Error.hpp>
+#include <spider/core/Task.hpp>
+#include <spider/core/TaskGraph.hpp>
+#include <spider/io/BoostAsio.hpp>  // IWYU pragma: keep
+#include <spider/io/MsgPack.hpp>  // IWYU pragma: keep
+#include <spider/storage/DataStorage.hpp>
+#include <spider/storage/MetadataStorage.hpp>
+#include <spider/storage/StorageConnection.hpp>
+#include <spider/storage/StorageFactory.hpp>
+#include <spider/worker/FunctionManager.hpp>
+#include <spider/worker/TaskExecutor.hpp>
+
 #include "tests/storage/StorageTestHelper.hpp"
 
 // NOLINTBEGIN(cert-err58-cpp,cppcoreguidelines-avoid-do-while,readability-function-cognitive-complexity,cppcoreguidelines-avoid-non-const-global-variables,cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays,clang-analyzer-unix.BlockInCriticalSection)


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description

Use non-relative header include paths for `src/spider` and `tests`.



# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* [x] GitHub workflows pass.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Standardized all internal include paths across the codebase and tests to use fully qualified, project-root-relative paths (e.g., spider/core/...), replacing previous relative paths for improved clarity and consistency.
  - Updated build configuration files to ensure correct include directories are set for both source and test targets.
  - Enhanced code formatting rules to better distinguish project relative headers from project library headers.

- **Chores**
  - No changes to functionality or public interfaces; all updates are internal refactoring for maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->