### PR TITLE
fix: Update children's states to ready even if some children are not ready (fixes #147).

### DIFF
--- a/src/spider/storage/mysql/MySqlStorage.cpp
+++ b/src/spider/storage/mysql/MySqlStorage.cpp
@@ -1639,10 +1639,10 @@ auto MySqlMetadataStorage::task_finish(
         std::unique_ptr<sql::PreparedStatement> ready_statement(
                 static_cast<MySqlConnection&>(conn)->prepareStatement(
                         "UPDATE `tasks` SET `state` = 'ready' WHERE `id` IN (SELECT `task_id` FROM "
-                        "`task_inputs` WHERE `output_task_id` = ?) AND `state` = 'pending' AND NOT "
-                        "EXISTS (SELECT `task_id` FROM `task_inputs` WHERE `task_id` IN (SELECT "
-                        "`task_id` FROM `task_inputs` WHERE `output_task_id` = ?) AND `value` IS "
-                        "NULL AND `data_id` IS NULL)"
+                        "`task_inputs` WHERE `output_task_id` = ?) AND `state` = 'pending' AND "
+                        "`id` NOT IN (SELECT `task_id` FROM `task_inputs` WHERE `task_id` IN "
+                        "(SELECT `task_id` FROM `task_inputs` WHERE `output_task_id` = ?) AND "
+                        "`value` IS NULL AND `data_id` IS NULL)"
                 )
         );
         ready_statement->setBytes(1, &task_id_bytes);


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

MySQL `task_finish` implementation only updates children's state to ready if all children are ready. This pr fixes the problem by updating the states of ready children and leave non-ready children's state as pending.



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* [x] GitHub workflows pass.
* [x] Unit tests pass in dev container.
* [x] Integration tests pass in dev container.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved task status updates to ensure tasks only move to the 'ready' state when all required inputs are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->