### PR TITLE
fix(storage): Stop updating start timestamp on job, task instance, and scheduler lease table change (fixes #145).

### DIFF
--- a/src/spider/storage/mysql/mysql_stmt.hpp
+++ b/src/spider/storage/mysql/mysql_stmt.hpp
@@ -24,7 +24,7 @@ std::string const cCreateSchedulerTable = R"(CREATE TABLE IF NOT EXISTS `schedul
 std::string const cCreateJobTable = R"(CREATE TABLE IF NOT EXISTS jobs (
     `id` BINARY(16) NOT NULL,
     `client_id` BINARY(16) NOT NULL,
-    `creation_time` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    `creation_time` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     `state` ENUM('running', 'success', 'cancel', 'fail') NOT NULL DEFAULT 'running',
     KEY (`client_id`) USING BTREE,
     INDEX idx_jobs_creation_time (`creation_time`),
@@ -104,7 +104,7 @@ std::string const cCreateTaskDependencyTable = R"(CREATE TABLE IF NOT EXISTS `ta
 std::string const cCreateTaskInstanceTable = R"(CREATE TABLE IF NOT EXISTS `task_instances` (
     `id` BINARY(16) NOT NULL,
     `task_id` BINARY(16) NOT NULL,
-    `start_time` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    `start_time` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT `instance_task_id` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
     PRIMARY KEY (`id`)
 ))";
@@ -112,7 +112,7 @@ std::string const cCreateTaskInstanceTable = R"(CREATE TABLE IF NOT EXISTS `task
 std::string const cCreateSchedulerLeaseTable = R"(CREATE TABLE IF NOT EXISTS `scheduler_leases` (
     `scheduler_id` BINARY(16) NOT NULL,
     `task_id`      BINARY(16) NOT NULL,
-    `lease_time`   TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    `lease_time`   TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT `lease_scheduler_id` FOREIGN KEY (`scheduler_id`) REFERENCES `schedulers` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
     CONSTRAINT `lease_task_id` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
     INDEX (`scheduler_id`),

--- a/tools/scripts/storage/init_db.sql
+++ b/tools/scripts/storage/init_db.sql
@@ -16,7 +16,7 @@ CREATE TABLE IF NOT EXISTS jobs
 (
     `id`            BINARY(16) NOT NULL,
     `client_id`     BINARY(16) NOT NULL,
-    `creation_time` TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    `creation_time` TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
     `state`         ENUM ('running', 'success', 'fail', 'cancel') NOT NULL DEFAULT 'running',
     KEY (`client_id`) USING BTREE,
     INDEX idx_jobs_creation_time (`creation_time`),
@@ -103,7 +103,7 @@ CREATE TABLE IF NOT EXISTS `task_instances`
 (
     `id`         BINARY(16) NOT NULL,
     `task_id`    BINARY(16) NOT NULL,
-    `start_time` TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    `start_time` TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT `instance_task_id` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
     PRIMARY KEY (`id`)
 );
@@ -111,7 +111,7 @@ CREATE TABLE IF NOT EXISTS `scheduler_leases`
 (
     `scheduler_id` BINARY(16) NOT NULL,
     `task_id`      BINARY(16) NOT NULL,
-    `lease_time`   TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    `lease_time`   TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT `lease_scheduler_id` FOREIGN KEY (`scheduler_id`) REFERENCES `schedulers` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
     CONSTRAINT `lease_task_id` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
     INDEX (`scheduler_id`),


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

`Spider` sets MySQL tables for jobs, task instance and schedulers start timestamp `ON UPDATE CURRENT_TIMESTAMP`, which changes the timestamp every time the table is updated, making it an update timestamp instead.

This pr solves this issue by removing the `ON UPDATE CURRENT_TIMESTAMP`.



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
* [x] GitHub workflows pass.
* [x] Unit tests pass in dev container.
* [x] Integration tests pass in dev container.

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated timestamp columns in several tables so they are set only at row creation and no longer update automatically when the row is modified. This affects the creation time in jobs, start time in task instances, and lease time in scheduler leases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->