### PR TITLE
fix(cmake): Remove unused variable `SOURCE_PATH_SIZE` (fixes #154).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,11 +40,6 @@ set(CMAKE_MODULE_PATH
     "${PROJECT_SOURCE_DIR}/cmake/Modules/"
 )
 
-# Macro providing the length of the absolute source directory path so we can
-# create a relative (rather than absolute) __FILE__ macro
-string(LENGTH "${PROJECT_SOURCE_DIR}/" SOURCE_PATH_SIZE)
-add_definitions("-DSOURCE_PATH_SIZE=${SOURCE_PATH_SIZE}")
-
 # Profiling options
 add_definitions(-DPROF_ENABLED=0)
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

Remove definition of `SOURCE_PATH_SIZE` in `CMakeLists.txt` so a definition of the same macro in a parent project would not trigger a redefinition of the macro. `SOURCE_PATH_SIZE` is unused by spider and accidentally defined.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
* [x] GitHub workflows pass.
* [x] Unit tests pass in dev container
* [x] Integration tests pass in dev container


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed a compile-time definition related to source directory path length. No impact on visible features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->