### PR TITLE
build: Limit dependency build parallelism to 1.

### DIFF
--- a/.github/workflows/code-linting-checks.yaml
+++ b/.github/workflows/code-linting-checks.yaml
@@ -47,6 +47,8 @@ jobs:
 
       - name: "Install project dependencies "
         timeout-minutes: 10
+        env:
+          SPIDER_DEP_BUILD_PARALLELISM: "1"
         run: "task deps:lib_install"
 
       - run: "task lint:check -C $(nproc)"

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -50,6 +50,8 @@ jobs:
 
       - name: "Install project dependencies "
         timeout-minutes: 10
+        env:
+          SPIDER_DEP_BUILD_PARALLELISM: "1"
         run: "task deps:lib_install"
 
       - run: "task test:non-storage-unit-tests"

--- a/dep-tasks.yaml
+++ b/dep-tasks.yaml
@@ -38,6 +38,7 @@ tasks:
           GEN_ARGS:
             - "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
             - "-DABSL_BUILD_TESTING=OFF"
+          JOBS: {{.G_DEP_BUILD_PARALLELISM}}
 
   install-Catch2:
     internal: true
@@ -53,6 +54,7 @@ tasks:
           GEN_ARGS:
             - "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
             - "-DCATCH_BUILD_TESTING=OFF"
+          JOBS: {{.G_DEP_BUILD_PARALLELISM}}
 
   download-ystdlib:
     internal: true
@@ -85,6 +87,7 @@ tasks:
             - "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
             - "-DFMT_TEST=OFF"
             - "-DFMT_DOC=OFF"
+          JOBS: {{.G_DEP_BUILD_PARALLELISM}}
 
   install-spdlog:
     internal: true
@@ -106,6 +109,7 @@ tasks:
             - "-DUSE_EXTERNAL_FMT=ON"
             - "-C {{.G_DEPS_CMAKE_SETTINGS_DIR}}/boost.cmake"
             - "-C {{.G_DEPS_CMAKE_SETTINGS_DIR}}/fmt.cmake"
+          JOBS: {{.G_DEP_BUILD_PARALLELISM}}
 
   install-mariadb-connector-cpp:
     internal: true
@@ -123,6 +127,7 @@ tasks:
             - "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
             - "-DUSE_SYSTEM_INSTALLED_LIB=ON"
             - "-DINSTALL_LAYOUT=RPM"
+          JOBS: {{.G_DEP_BUILD_PARALLELISM}}
 
   install-msgpack:
     internal: true
@@ -142,6 +147,7 @@ tasks:
             - "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
             - "-DMSGPACK_BUILD_TESTS=OFF"
             - "-C {{.G_DEPS_CMAKE_SETTINGS_DIR}}/boost.cmake"
+          JOBS: {{.G_DEP_BUILD_PARALLELISM}}
 
   install-boost:
     internal: true

--- a/dep-tasks.yaml
+++ b/dep-tasks.yaml
@@ -38,7 +38,7 @@ tasks:
           GEN_ARGS:
             - "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
             - "-DABSL_BUILD_TESTING=OFF"
-          JOBS: {{.G_DEP_BUILD_PARALLELISM}}
+          JOBS: "{{.G_DEP_BUILD_PARALLELISM}}"
 
   install-Catch2:
     internal: true
@@ -54,7 +54,7 @@ tasks:
           GEN_ARGS:
             - "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
             - "-DCATCH_BUILD_TESTING=OFF"
-          JOBS: {{.G_DEP_BUILD_PARALLELISM}}
+          JOBS: "{{.G_DEP_BUILD_PARALLELISM}}"
 
   download-ystdlib:
     internal: true
@@ -87,7 +87,7 @@ tasks:
             - "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
             - "-DFMT_TEST=OFF"
             - "-DFMT_DOC=OFF"
-          JOBS: {{.G_DEP_BUILD_PARALLELISM}}
+          JOBS: "{{.G_DEP_BUILD_PARALLELISM}}"
 
   install-spdlog:
     internal: true
@@ -109,7 +109,7 @@ tasks:
             - "-DUSE_EXTERNAL_FMT=ON"
             - "-C {{.G_DEPS_CMAKE_SETTINGS_DIR}}/boost.cmake"
             - "-C {{.G_DEPS_CMAKE_SETTINGS_DIR}}/fmt.cmake"
-          JOBS: {{.G_DEP_BUILD_PARALLELISM}}
+          JOBS: "{{.G_DEP_BUILD_PARALLELISM}}"
 
   install-mariadb-connector-cpp:
     internal: true
@@ -127,7 +127,7 @@ tasks:
             - "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
             - "-DUSE_SYSTEM_INSTALLED_LIB=ON"
             - "-DINSTALL_LAYOUT=RPM"
-          JOBS: {{.G_DEP_BUILD_PARALLELISM}}
+          JOBS: "{{.G_DEP_BUILD_PARALLELISM}}"
 
   install-msgpack:
     internal: true
@@ -147,7 +147,7 @@ tasks:
             - "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
             - "-DMSGPACK_BUILD_TESTS=OFF"
             - "-C {{.G_DEPS_CMAKE_SETTINGS_DIR}}/boost.cmake"
-          JOBS: {{.G_DEP_BUILD_PARALLELISM}}
+          JOBS: "{{.G_DEP_BUILD_PARALLELISM}}"
 
   install-boost:
     internal: true

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -20,6 +20,8 @@ vars:
   G_TEST_DIR: "{{.ROOT_DIR}}/tests"
   G_EXAMPLES_DIR: "{{.ROOT_DIR}}/examples"
 
+  G_DEP_BUILD_PARALLELISM: >-
+    {{default "" (env SPIDER_DEP_BUILD_PARALLELISM)}}
   G_DEPS_DIR: "{{.G_BUILD_DIR}}/deps"
   # These should be kept in-sync with its usage in CMakeLists.txt
   G_DEPS_CMAKE_SETTINGS_DIR: "{{.G_DEPS_DIR}}/cmake-settings"

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -21,7 +21,7 @@ vars:
   G_EXAMPLES_DIR: "{{.ROOT_DIR}}/examples"
 
   G_DEP_BUILD_PARALLELISM: >-
-    {{default "" (env SPIDER_DEP_BUILD_PARALLELISM)}}
+    {{default "" (env "SPIDER_DEP_BUILD_PARALLELISM")}}
   G_DEPS_DIR: "{{.G_BUILD_DIR}}/deps"
   # These should be kept in-sync with its usage in CMakeLists.txt
   G_DEPS_CMAKE_SETTINGS_DIR: "{{.G_DEPS_DIR}}/cmake-settings"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
Each dependency CMake build task runs in default number of parallelism, i.e. number of cores. However, `task` allows multiple build tasks to run concurrently, resulting in more parallelism than the number of cores.

This PR limits the number of dependency build parallelism by using environment variable `SPIDER_DEP_BUILD_PARALLELISM`, which is set to "1" in unit test workflow and linting workflow.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
* [x] GitHub workflows succeed.

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
