### PR TITLE
fix(lint): Fix a typo in the Ruff config.

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -11,6 +11,7 @@ ignore = [
     "D400",  # First line of docstrings may not end in period
     "D401",  # Docstrings should be written in present tense (not imperative)
     "D415",  # First line of docstrings may not end in a period, question mark, or exclamation point
+    "FA102", # Allow use of PEP 604 union in type annotations
     "FBT",  # Allow bool positional parameters since other value positions are allowed
     "FIX002",  # Allow todo statements
     "PERF401",  # Allow for loops when creating lists
@@ -26,7 +27,7 @@ isort.order-by-type = false
 [lint.per-file-ignores]
 "tests/integration/test_*.py" = [
     "S101",    # Allow use of `assert` (security warning)
-    "S603",    # Allow use of subprocess.Popen (security warning)
+    "S603",    # Allow use of `subprocess.Popen` (security warning)
     "T201",    # Allow use of `print` (testing)
 ]
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -11,7 +11,6 @@ ignore = [
     "D400",  # First line of docstrings may not end in period
     "D401",  # Docstrings should be written in present tense (not imperative)
     "D415",  # First line of docstrings may not end in a period, question mark, or exclamation point
-    "FA102", # Allow use of PEP 604 union in type annotations
     "FBT",  # Allow bool positional parameters since other value positions are allowed
     "FIX002",  # Allow todo statements
     "PERF401",  # Allow for loops when creating lists
@@ -27,7 +26,7 @@ isort.order-by-type = false
 [lint.per-file-ignores]
 "tests/integration/test_*.py" = [
     "S101",    # Allow use of `assert` (security warning)
-    "S603",    # Allow user of subprocess.Popen (security warning)
+    "S603",    # Allow use of subprocess.Popen (security warning)
     "T201",    # Allow use of `print` (testing)
 ]
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR fixes a typo introduced in #173, which was uncaught by the previous review.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [ ] Ensure all workflows passed.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Corrected a typo in a comment within the configuration file to improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->