### PR TITLE
feat(tdl): Add `Tuple` AST node.

### DIFF
--- a/src/spider/CMakeLists.txt
+++ b/src/spider/CMakeLists.txt
@@ -201,6 +201,7 @@ set(SPIDER_TDL_SHARED_SOURCES
     tdl/parser/ast/node_impl/NamedVar.cpp
     tdl/parser/ast/node_impl/type_impl/container_impl/List.cpp
     tdl/parser/ast/node_impl/type_impl/container_impl/Map.cpp
+    tdl/parser/ast/node_impl/type_impl/container_impl/Tuple.cpp
     tdl/parser/ast/node_impl/type_impl/primitive_impl/Bool.cpp
     tdl/parser/ast/node_impl/type_impl/primitive_impl/Float.cpp
     tdl/parser/ast/node_impl/type_impl/primitive_impl/Int.cpp
@@ -219,6 +220,7 @@ set(SPIDER_TDL_SHARED_HEADERS
     tdl/parser/ast/node_impl/type_impl/Container.hpp
     tdl/parser/ast/node_impl/type_impl/container_impl/List.hpp
     tdl/parser/ast/node_impl/type_impl/container_impl/Map.hpp
+    tdl/parser/ast/node_impl/type_impl/container_impl/Tuple.hpp
     tdl/parser/ast/node_impl/type_impl/Primitive.hpp
     tdl/parser/ast/node_impl/type_impl/primitive_impl/Bool.hpp
     tdl/parser/ast/node_impl/type_impl/primitive_impl/Float.hpp

--- a/src/spider/tdl/parser/ast/node_impl/type_impl/container_impl/Tuple.cpp
+++ b/src/spider/tdl/parser/ast/node_impl/type_impl/container_impl/Tuple.cpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include <fmt/format.h>

--- a/src/spider/tdl/parser/ast/node_impl/type_impl/container_impl/Tuple.cpp
+++ b/src/spider/tdl/parser/ast/node_impl/type_impl/container_impl/Tuple.cpp
@@ -1,0 +1,61 @@
+#include "Tuple.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+#include <ystdlib/error_handling/Result.hpp>
+
+#include <spider/tdl/parser/ast/Node.hpp>
+#include <spider/tdl/parser/ast/node_impl/Type.hpp>
+#include <spider/tdl/parser/ast/utils.hpp>
+
+namespace spider::tdl::parser::ast::node_impl::type_impl::container_impl {
+auto Tuple::create(std::vector<std::unique_ptr<Node>> elements)
+        -> ystdlib::error_handling::Result<std::unique_ptr<Node>> {
+    for (auto const& type : elements) {
+        YSTDLIB_ERROR_HANDLING_TRYV(validate_child_node_type<Type>(type.get()));
+    }
+
+    auto tuple{std::make_unique<Tuple>(Tuple{})};
+    for (auto& type : elements) {
+        YSTDLIB_ERROR_HANDLING_TRYV(tuple->add_child(std::move(type)));
+    }
+    return tuple;
+}
+
+auto Tuple::serialize_to_str(size_t indentation_level) const
+        -> ystdlib::error_handling::Result<std::string> {
+    constexpr std::string_view cTypeTag{"[Type[Container[Tuple]]]"};
+
+    if (is_empty()) {
+        return fmt::format("{}{}:Empty", create_indentation(indentation_level), cTypeTag);
+    }
+
+    std::vector<std::string> serialized_children;
+    YSTDLIB_ERROR_HANDLING_TRYV(
+            visit_children([&](Node const& child) -> ystdlib::error_handling::Result<void> {
+                serialized_children.emplace_back(
+                        fmt::format(
+                                "{}ElementType:\n{}",
+                                create_indentation(indentation_level + 1),
+                                YSTDLIB_ERROR_HANDLING_TRYX(
+                                        child.serialize_to_str(indentation_level + 2)
+                                )
+                        )
+                );
+                return ystdlib::error_handling::success();
+            })
+    );
+    return fmt::format(
+            "{}{}:\n{}",
+            create_indentation(indentation_level),
+            cTypeTag,
+            fmt::join(serialized_children, "\n")
+    );
+}
+}  // namespace spider::tdl::parser::ast::node_impl::type_impl::container_impl

--- a/src/spider/tdl/parser/ast/node_impl/type_impl/container_impl/Tuple.cpp
+++ b/src/spider/tdl/parser/ast/node_impl/type_impl/container_impl/Tuple.cpp
@@ -42,8 +42,9 @@ auto Tuple::serialize_to_str(size_t indentation_level) const
             visit_children([&](Node const& child) -> ystdlib::error_handling::Result<void> {
                 serialized_children.emplace_back(
                         fmt::format(
-                                "{}ElementType:\n{}",
+                                "{}Element[{}]:\n{}",
                                 create_indentation(indentation_level + 1),
+                                serialized_children.size(),
                                 YSTDLIB_ERROR_HANDLING_TRYX(
                                         child.serialize_to_str(indentation_level + 2)
                                 )

--- a/src/spider/tdl/parser/ast/node_impl/type_impl/container_impl/Tuple.hpp
+++ b/src/spider/tdl/parser/ast/node_impl/type_impl/container_impl/Tuple.hpp
@@ -1,0 +1,41 @@
+#ifndef SPIDER_TDL_PARSER_AST_NODE_IMPL_TYPE_IMPL_CONTAINER_IMPL_TUPLE_HPP
+#define SPIDER_TDL_PARSER_AST_NODE_IMPL_TYPE_IMPL_CONTAINER_IMPL_TUPLE_HPP
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <ystdlib/error_handling/Result.hpp>
+
+#include <spider/tdl/parser/ast/Node.hpp>
+#include <spider/tdl/parser/ast/node_impl/Type.hpp>
+#include <spider/tdl/parser/ast/node_impl/type_impl/Container.hpp>
+
+namespace spider::tdl::parser::ast::node_impl::type_impl::container_impl {
+class Tuple : public Container {
+public:
+    // Factory function
+    /**
+     * @param elements
+     * @return A result containing a unique pointer to a new `Tuple` instance as a collection of the
+     * given element types, or an error code indicating the failure:
+     * - Forwards `validate_child_node_type`'s return values.
+     */
+    [[nodiscard]] static auto create(std::vector<std::unique_ptr<Node>> elements)
+            -> ystdlib::error_handling::Result<std::unique_ptr<Node>>;
+
+    // Methods implementing `Node`
+    [[nodiscard]] auto serialize_to_str(size_t indentation_level) const
+            -> ystdlib::error_handling::Result<std::string> override;
+
+    // Methods
+    [[nodiscard]] auto is_empty() const -> bool { return 0 == get_num_children(); }
+
+private:
+    // Constructor
+    Tuple() = default;
+};
+}  // namespace spider::tdl::parser::ast::node_impl::type_impl::container_impl
+
+#endif  // SPIDER_TDL_PARSER_AST_NODE_IMPL_TYPE_IMPL_CONTAINER_IMPL_TUPLE_HPP

--- a/src/spider/tdl/parser/ast/node_impl/type_impl/container_impl/Tuple.hpp
+++ b/src/spider/tdl/parser/ast/node_impl/type_impl/container_impl/Tuple.hpp
@@ -9,7 +9,6 @@
 #include <ystdlib/error_handling/Result.hpp>
 
 #include <spider/tdl/parser/ast/Node.hpp>
-#include <spider/tdl/parser/ast/node_impl/Type.hpp>
 #include <spider/tdl/parser/ast/node_impl/type_impl/Container.hpp>
 
 namespace spider::tdl::parser::ast::node_impl::type_impl::container_impl {

--- a/tests/tdl/test-parser-ast.cpp
+++ b/tests/tdl/test-parser-ast.cpp
@@ -1,5 +1,6 @@
 // NOLINTBEGIN(cert-err58-cpp,cppcoreguidelines-avoid-do-while,readability-function-cognitive-complexity,cppcoreguidelines-avoid-non-const-global-variables,cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
 
+#include <memory>
 #include <string>
 #include <string_view>
 #include <utility>

--- a/tests/tdl/test-parser-ast.cpp
+++ b/tests/tdl/test-parser-ast.cpp
@@ -271,11 +271,11 @@ TEST_CASE("test-ast-node", "[tdl][ast][Node]") {
 
             constexpr std::string_view cExpectedSerializedResult{
                     "[Type[Container[Tuple]]]:\n"
-                    "  ElementType:\n"
+                    "  Element[0]:\n"
                     "    [Type[Primitive[Int]]]:int64\n"
-                    "  ElementType:\n"
+                    "  Element[1]:\n"
                     "    [Type[Primitive[Float]]]:double\n"
-                    "  ElementType:\n"
+                    "  Element[2]:\n"
                     "    [Type[Container[Map]]]:\n"
                     "      KeyType:\n"
                     "        [Type[Primitive[Int]]]:int64\n"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR introduces the `Tuple` container type. A tuple can contain a list of element types. We will use a Tuple as a container to represent return values with multiple types.

Notice that a tuple can be empty, meaning that it contains no elements.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Ensure all workflows pass.
* [x] Add unit tests for `Tuple` nodes.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a Tuple container type with creation and readable serialization for empty and multi-element tuples.
  * Improves consistency of container-type output across tools that display TDL structures.

* **Tests**
  * Added tests covering Tuple creation, empty and populated cases, and exact serialization verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->