### PR TITLE
feat(tdl): Add `Struct` AST node. (#190)

### DIFF
--- a/src/spider/CMakeLists.txt
+++ b/src/spider/CMakeLists.txt
@@ -206,6 +206,7 @@ set(SPIDER_TDL_SHARED_SOURCES
     tdl/parser/ast/node_impl/type_impl/primitive_impl/Bool.cpp
     tdl/parser/ast/node_impl/type_impl/primitive_impl/Float.cpp
     tdl/parser/ast/node_impl/type_impl/primitive_impl/Int.cpp
+    tdl/parser/ast/node_impl/type_impl/Struct.cpp
     tdl/parser/ast/utils.cpp
     CACHE INTERNAL
     "spider task definition language shared source files"
@@ -227,6 +228,7 @@ set(SPIDER_TDL_SHARED_HEADERS
     tdl/parser/ast/node_impl/type_impl/primitive_impl/Bool.hpp
     tdl/parser/ast/node_impl/type_impl/primitive_impl/Float.hpp
     tdl/parser/ast/node_impl/type_impl/primitive_impl/Int.hpp
+    tdl/parser/ast/node_impl/type_impl/Struct.hpp
     tdl/parser/ast/utils.hpp
     CACHE INTERNAL
     "spider task definition language shared header files"

--- a/src/spider/tdl/parser/ast/node_impl/type_impl/Struct.cpp
+++ b/src/spider/tdl/parser/ast/node_impl/type_impl/Struct.cpp
@@ -1,0 +1,72 @@
+#include "Struct.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include <fmt/format.h>
+#include <ystdlib/error_handling/ErrorCode.hpp>
+#include <ystdlib/error_handling/Result.hpp>
+
+#include <spider/tdl/parser/ast/Node.hpp>
+#include <spider/tdl/parser/ast/node_impl/StructSpec.hpp>
+#include <spider/tdl/parser/ast/utils.hpp>
+
+using spider::tdl::parser::ast::node_impl::type_impl::Struct;
+using StructErrorCodeCategory = ystdlib::error_handling::ErrorCategory<Struct::ErrorCodeEnum>;
+
+template <>
+auto StructErrorCodeCategory::name() const noexcept -> char const* {
+    return "spider::tdl::parser::ast::node_impl::type_impl::Struct";
+}
+
+template <>
+auto StructErrorCodeCategory::message(Struct::ErrorCodeEnum error_enum) const -> std::string {
+    switch (error_enum) {
+        case Struct::ErrorCodeEnum::StructSpecAlreadySet:
+            return "The struct spec is already set.";
+        case Struct::ErrorCodeEnum::StructSpecNameMismatch:
+            return "The struct spec name does not match the type name.";
+        default:
+            return "Unknown error code enum";
+    }
+}
+
+namespace spider::tdl::parser::ast::node_impl::type_impl {
+auto Struct::create(std::unique_ptr<Node> name)
+        -> ystdlib::error_handling::Result<std::unique_ptr<Node>> {
+    YSTDLIB_ERROR_HANDLING_TRYV(validate_child_node_type<Identifier>(name.get()));
+
+    auto struct_node{std::make_unique<Struct>(Struct{})};
+    YSTDLIB_ERROR_HANDLING_TRYV(struct_node->add_child(std::move(name)));
+    return struct_node;
+}
+
+auto Struct::serialize_to_str(size_t indentation_level) const
+        -> ystdlib::error_handling::Result<std::string> {
+    return fmt::format(
+            "{}[Type[Struct]]:\n{}Name:\n{}",
+            create_indentation(indentation_level),
+            create_indentation(indentation_level + 1),
+            YSTDLIB_ERROR_HANDLING_TRYX(
+                    // The factory function ensures that the first child is of type `Identifier`.
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+                    get_child_unsafe(0)->serialize_to_str(indentation_level + 2)
+            )
+    );
+}
+
+auto Struct::set_spec(std::shared_ptr<StructSpec> spec) -> ystdlib::error_handling::Result<void> {
+    if (nullptr != m_spec) {
+        return Struct::ErrorCode{Struct::ErrorCodeEnum::StructSpecAlreadySet};
+    }
+
+    if (get_name() != spec->get_name()) {
+        return Struct::ErrorCode{Struct::ErrorCodeEnum::StructSpecNameMismatch};
+    }
+
+    m_spec = std::move(spec);
+    return ystdlib::error_handling::success();
+}
+}  // namespace spider::tdl::parser::ast::node_impl::type_impl

--- a/src/spider/tdl/parser/ast/node_impl/type_impl/Struct.hpp
+++ b/src/spider/tdl/parser/ast/node_impl/type_impl/Struct.hpp
@@ -1,0 +1,75 @@
+#ifndef SPIDER_TDL_PARSER_AST_NODE_IMPL_TYPE_IMPL_STRUCT_HPP
+#define SPIDER_TDL_PARSER_AST_NODE_IMPL_TYPE_IMPL_STRUCT_HPP
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include <ystdlib/error_handling/ErrorCode.hpp>
+#include <ystdlib/error_handling/Result.hpp>
+
+#include <spider/tdl/parser/ast/Node.hpp>
+#include <spider/tdl/parser/ast/node_impl/Identifier.hpp>
+#include <spider/tdl/parser/ast/node_impl/StructSpec.hpp>
+#include <spider/tdl/parser/ast/node_impl/Type.hpp>
+
+namespace spider::tdl::parser::ast::node_impl::type_impl {
+class Struct : public Type {
+public:
+    // Types
+    enum class ErrorCodeEnum : uint8_t {
+        StructSpecAlreadySet = 1,
+        StructSpecNameMismatch,
+    };
+
+    using ErrorCode = ystdlib::error_handling::ErrorCode<ErrorCodeEnum>;
+
+    // Factory function
+    /**
+     * @param name
+     * @return A result containing a unique pointer to a new `Struct` instance with the given name
+     * on success, or an error code indicating the failure:
+     * - Forwards `validate_child_node_type`'s return values.
+     */
+    [[nodiscard]] static auto create(std::unique_ptr<Node> name)
+            -> ystdlib::error_handling::Result<std::unique_ptr<Node>>;
+
+    // Methods implementing `Node`
+    [[nodiscard]] auto serialize_to_str(size_t indentation_level) const
+            -> ystdlib::error_handling::Result<std::string> override;
+
+    // Methods
+    [[nodiscard]] auto get_name() const -> std::string_view {
+        // The factory function ensures that the first child is of type `Identifier`.
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+        return static_cast<Identifier const*>(get_child_unsafe(0))->get_name();
+    }
+
+    /**
+     * Sets the specification for this struct.
+     * @param spec
+     * @return A void result on success, or an error code indicating the failure:
+     * - ErrorCodeEnum::StructSpecNameMismatch if `spec`'s name does not match the underlying name.
+     * - ErrorCodeEnum::StructSpecAlreadySet if the specification has already been set.
+     */
+    [[nodiscard]] auto set_spec(std::shared_ptr<StructSpec> spec)
+            -> ystdlib::error_handling::Result<void>;
+
+    [[nodiscard]] auto get_spec() const -> StructSpec const* { return m_spec.get(); }
+
+private:
+    // Constructor
+    Struct() = default;
+
+    // Variables
+    std::shared_ptr<StructSpec> m_spec;
+};
+}  // namespace spider::tdl::parser::ast::node_impl::type_impl
+
+YSTDLIB_ERROR_HANDLING_MARK_AS_ERROR_CODE_ENUM(
+        spider::tdl::parser::ast::node_impl::type_impl::Struct::ErrorCodeEnum
+);
+
+#endif  // SPIDER_TDL_PARSER_AST_NODE_IMPL_TYPE_IMPL_STRUCT_HPP


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR adds `Struct` AST node as an implementation of `Type`. A `Struct` has only one child: the identifier. It also holds a reference to a `StructSpec` as a shared pointer. However, such a spec is not initialized during the construction. This is because the AST nodes are constructed at the parsing stage. The spec should be checked and set in the semantic analysis stage, while a symbol table is built.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Ensure all workflows pass.
* [ ] Add unit tests to cover the basic behavior of `Struct`.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
