### PR TITLE
feat(tdl): Add support for tracking the source location in AST nodes.

### DIFF
--- a/src/spider/CMakeLists.txt
+++ b/src/spider/CMakeLists.txt
@@ -233,6 +233,7 @@ set(SPIDER_TDL_SHARED_HEADERS
     tdl/parser/ast/node_impl/type_impl/primitive_impl/Float.hpp
     tdl/parser/ast/node_impl/type_impl/primitive_impl/Int.hpp
     tdl/parser/ast/node_impl/type_impl/Struct.hpp
+    tdl/parser/ast/SourceLocation.hpp
     tdl/parser/ast/utils.hpp
     CACHE INTERNAL
     "spider task definition language shared header files"

--- a/src/spider/tdl/parser/ast/Node.hpp
+++ b/src/spider/tdl/parser/ast/Node.hpp
@@ -11,6 +11,8 @@
 #include <ystdlib/error_handling/ErrorCode.hpp>
 #include <ystdlib/error_handling/Result.hpp>
 
+#include <spider/tdl/parser/ast/SourceLocation.hpp>
+
 namespace spider::tdl::parser::ast {
 /**
  * Abstracted base class for all AST nodes in the TDL.
@@ -90,9 +92,13 @@ public:
             -> ystdlib::error_handling::Result<std::string>
             = 0;
 
+    [[nodiscard]] auto get_source_location() const noexcept -> SourceLocation {
+        return m_source_location;
+    }
+
 protected:
     // Constructor
-    Node() = default;
+    explicit Node(SourceLocation source_location) : m_source_location{source_location} {}
 
     /**
      * Adds a child node to this AST node.
@@ -118,6 +124,7 @@ private:
     // Variables
     std::vector<std::unique_ptr<Node>> m_children;
     Node const* m_parent = nullptr;
+    SourceLocation m_source_location;
 };
 }  // namespace spider::tdl::parser::ast
 

--- a/src/spider/tdl/parser/ast/SourceLocation.hpp
+++ b/src/spider/tdl/parser/ast/SourceLocation.hpp
@@ -1,0 +1,24 @@
+#ifndef SPIDER_TDL_AST_SOURCELOCATION_HPP
+#define SPIDER_TDL_AST_SOURCELOCATION_HPP
+
+#include <cstddef>
+
+namespace spider::tdl::parser::ast {
+class SourceLocation {
+public:
+    // Constructor
+    SourceLocation(size_t line, size_t column) : m_line{line}, m_column{column} {}
+
+    // Methods
+    [[nodiscard]] auto get_line() const noexcept -> size_t { return m_line; }
+
+    [[nodiscard]] auto get_column() const noexcept -> size_t { return m_column; }
+
+private:
+    // Variables
+    size_t m_line;
+    size_t m_column;
+};
+}  // namespace spider::tdl::parser::ast
+
+#endif  // SPIDER_TDL_AST_SOURCELOCATION_HPP

--- a/src/spider/tdl/parser/ast/node_impl/Function.cpp
+++ b/src/spider/tdl/parser/ast/node_impl/Function.cpp
@@ -17,6 +17,7 @@
 #include <spider/tdl/parser/ast/node_impl/Identifier.hpp>
 #include <spider/tdl/parser/ast/node_impl/NamedVar.hpp>
 #include <spider/tdl/parser/ast/node_impl/Type.hpp>
+#include <spider/tdl/parser/ast/SourceLocation.hpp>
 #include <spider/tdl/parser/ast/utils.hpp>
 
 using spider::tdl::parser::ast::node_impl::Function;
@@ -41,7 +42,8 @@ namespace spider::tdl::parser::ast::node_impl {
 auto Function::create(
         std::unique_ptr<Node> name,
         std::unique_ptr<Node> return_type,
-        std::vector<std::unique_ptr<Node>> params
+        std::vector<std::unique_ptr<Node>> params,
+        SourceLocation source_location
 ) -> ystdlib::error_handling::Result<std::unique_ptr<Node>> {
     YSTDLIB_ERROR_HANDLING_TRYV(validate_child_node_type<Identifier>(name.get()));
 
@@ -61,7 +63,7 @@ auto Function::create(
         param_names.emplace(param_name);
     }
 
-    auto function{std::make_unique<Function>(Function{has_return})};
+    auto function{std::make_unique<Function>(Function{has_return, source_location})};
     YSTDLIB_ERROR_HANDLING_TRYV(function->add_child(std::move(name)));
     if (has_return) {
         YSTDLIB_ERROR_HANDLING_TRYV(function->add_child(std::move(return_type)));

--- a/src/spider/tdl/parser/ast/node_impl/Function.hpp
+++ b/src/spider/tdl/parser/ast/node_impl/Function.hpp
@@ -16,6 +16,7 @@
 #include <spider/tdl/parser/ast/node_impl/Identifier.hpp>
 #include <spider/tdl/parser/ast/node_impl/NamedVar.hpp>
 #include <spider/tdl/parser/ast/node_impl/Type.hpp>
+#include <spider/tdl/parser/ast/SourceLocation.hpp>
 
 namespace spider::tdl::parser::ast::node_impl {
 class Function : public Node {
@@ -32,6 +33,7 @@ public:
      * @param name
      * @param return_type
      * @param params
+     * @param source_location
      * @return A result containing a unique pointer to a new `Function` instance with the given
      * name, return type, and parameters on success, or an error code indicating the failure:
      * - ErrorCodeEnum::DuplicatedParamName if `params` contains duplicated parameter names.
@@ -40,7 +42,8 @@ public:
     [[nodiscard]] static auto create(
             std::unique_ptr<Node> name,
             std::unique_ptr<Node> return_type,
-            std::vector<std::unique_ptr<Node>> params
+            std::vector<std::unique_ptr<Node>> params,
+            SourceLocation source_location
     ) -> ystdlib::error_handling::Result<std::unique_ptr<Node>>;
 
     // Methods implementing `Node`
@@ -101,7 +104,9 @@ public:
 
 private:
     // Constructor
-    explicit Function(bool has_return) : m_has_return{has_return} {}
+    Function(bool has_return, SourceLocation source_location)
+            : Node{source_location},
+              m_has_return{has_return} {}
 
     // Methods
     [[nodiscard]] auto get_num_non_param_children() const noexcept -> size_t {

--- a/src/spider/tdl/parser/ast/node_impl/Identifier.hpp
+++ b/src/spider/tdl/parser/ast/node_impl/Identifier.hpp
@@ -10,6 +10,7 @@
 #include <ystdlib/error_handling/Result.hpp>
 
 #include <spider/tdl/parser/ast/Node.hpp>
+#include <spider/tdl/parser/ast/SourceLocation.hpp>
 
 namespace spider::tdl::parser::ast::node_impl {
 class Identifier : public Node {
@@ -17,10 +18,11 @@ public:
     // Factory function
     /**
      * @param name
+     * @param source_location
      * @return A unique pointer to a new `Identifier` instance with the given name.
      */
-    static auto create(std::string name) -> std::unique_ptr<Node> {
-        return std::make_unique<Identifier>(Identifier{std::move(name)});
+    static auto create(std::string name, SourceLocation source_location) -> std::unique_ptr<Node> {
+        return std::make_unique<Identifier>(Identifier{std::move(name), source_location});
     }
 
     // Methods implementing `Node`
@@ -32,7 +34,9 @@ public:
 
 private:
     // Constructor
-    explicit Identifier(std::string name) noexcept : m_name{std::move(name)} {}
+    Identifier(std::string name, SourceLocation source_location) noexcept
+            : Node{source_location},
+              m_name{std::move(name)} {}
 
     // Variables
     std::string m_name;

--- a/src/spider/tdl/parser/ast/node_impl/NamedVar.cpp
+++ b/src/spider/tdl/parser/ast/node_impl/NamedVar.cpp
@@ -11,15 +11,19 @@
 #include <spider/tdl/parser/ast/Node.hpp>
 #include <spider/tdl/parser/ast/node_impl/Identifier.hpp>
 #include <spider/tdl/parser/ast/node_impl/Type.hpp>
+#include <spider/tdl/parser/ast/SourceLocation.hpp>
 #include <spider/tdl/parser/ast/utils.hpp>
 
 namespace spider::tdl::parser::ast::node_impl {
-auto NamedVar::create(std::unique_ptr<Node> id, std::unique_ptr<Node> type)
-        -> ystdlib::error_handling::Result<std::unique_ptr<Node>> {
+auto NamedVar::create(
+        std::unique_ptr<Node> id,
+        std::unique_ptr<Node> type,
+        SourceLocation source_location
+) -> ystdlib::error_handling::Result<std::unique_ptr<Node>> {
     YSTDLIB_ERROR_HANDLING_TRYV(validate_child_node_type<Identifier>(id.get()));
     YSTDLIB_ERROR_HANDLING_TRYV(validate_child_node_type<Type>(type.get()));
 
-    auto named_var{std::make_unique<NamedVar>(NamedVar{})};
+    auto named_var{std::make_unique<NamedVar>(NamedVar{source_location})};
     YSTDLIB_ERROR_HANDLING_TRYV(named_var->add_child(std::move(id)));
     YSTDLIB_ERROR_HANDLING_TRYV(named_var->add_child(std::move(type)));
     return named_var;

--- a/src/spider/tdl/parser/ast/node_impl/NamedVar.hpp
+++ b/src/spider/tdl/parser/ast/node_impl/NamedVar.hpp
@@ -10,6 +10,7 @@
 #include <spider/tdl/parser/ast/Node.hpp>
 #include <spider/tdl/parser/ast/node_impl/Identifier.hpp>
 #include <spider/tdl/parser/ast/node_impl/Type.hpp>
+#include <spider/tdl/parser/ast/SourceLocation.hpp>
 
 namespace spider::tdl::parser::ast::node_impl {
 /**
@@ -21,11 +22,13 @@ public:
     /**
      * @param id
      * @param type
+     * @param source_location
      * @return A result containing a unique pointer to a new `NamedVar` instance with the given name
      * on success, or an error code indicating the failure:
      * - Forwards `validate_child_node_type`'s return values.
      */
-    [[nodiscard]] static auto create(std::unique_ptr<Node> id, std::unique_ptr<Node> type)
+    [[nodiscard]] static auto
+    create(std::unique_ptr<Node> id, std::unique_ptr<Node> type, SourceLocation source_location)
             -> ystdlib::error_handling::Result<std::unique_ptr<Node>>;
 
     // Methods implementing `Node`
@@ -47,7 +50,7 @@ public:
 
 private:
     // Constructor
-    NamedVar() = default;
+    explicit NamedVar(SourceLocation source_location) : Node{source_location} {}
 };
 }  // namespace spider::tdl::parser::ast::node_impl
 

--- a/src/spider/tdl/parser/ast/node_impl/Namespace.cpp
+++ b/src/spider/tdl/parser/ast/node_impl/Namespace.cpp
@@ -17,6 +17,7 @@
 #include <spider/tdl/parser/ast/node_impl/Function.hpp>
 #include <spider/tdl/parser/ast/node_impl/Identifier.hpp>
 #include <spider/tdl/parser/ast/node_impl/Namespace.hpp>
+#include <spider/tdl/parser/ast/SourceLocation.hpp>
 #include <spider/tdl/parser/ast/utils.hpp>
 
 using spider::tdl::parser::ast::node_impl::Namespace;
@@ -40,8 +41,11 @@ auto NamespaceErrorCodeCategory::message(Namespace::ErrorCodeEnum error_enum) co
 }
 
 namespace spider::tdl::parser::ast::node_impl {
-auto Namespace::create(std::unique_ptr<Node> name, std::vector<std::unique_ptr<Node>> functions)
-        -> ystdlib::error_handling::Result<std::unique_ptr<Node>> {
+auto Namespace::create(
+        std::unique_ptr<Node> name,
+        std::vector<std::unique_ptr<Node>> functions,
+        SourceLocation source_location
+) -> ystdlib::error_handling::Result<std::unique_ptr<Node>> {
     YSTDLIB_ERROR_HANDLING_TRYV(validate_child_node_type<Identifier>(name.get()));
 
     if (functions.empty()) {
@@ -59,7 +63,7 @@ auto Namespace::create(std::unique_ptr<Node> name, std::vector<std::unique_ptr<N
         fun_names.emplace(func_name);
     }
 
-    auto function{std::make_unique<Namespace>(Namespace{})};
+    auto function{std::make_unique<Namespace>(Namespace{source_location})};
     YSTDLIB_ERROR_HANDLING_TRYV(function->add_child(std::move(name)));
     for (auto& func : functions) {
         YSTDLIB_ERROR_HANDLING_TRYV(function->add_child(std::move(func)));

--- a/src/spider/tdl/parser/ast/node_impl/Namespace.hpp
+++ b/src/spider/tdl/parser/ast/node_impl/Namespace.hpp
@@ -15,6 +15,7 @@
 #include <spider/tdl/parser/ast/Node.hpp>
 #include <spider/tdl/parser/ast/node_impl/Function.hpp>
 #include <spider/tdl/parser/ast/node_impl/Identifier.hpp>
+#include <spider/tdl/parser/ast/SourceLocation.hpp>
 
 namespace spider::tdl::parser::ast::node_impl {
 /**
@@ -34,6 +35,7 @@ public:
     /**
      * @param name
      * @param functions
+     * @param source_location
      * @return A result containing a unique pointer to a new `Namespace` instance with the given
      * name and functions on success, or an error code indicating the failure:
      * - ErrorCodeEnum::DuplicatedFunctionName if the `functions` contains duplicated function
@@ -41,9 +43,11 @@ public:
      * - ErrorCodeEnum::EmptyNamespace if the `functions` is empty.
      * - Forwards `validate_child_node_type`'s return values.
      */
-    [[nodiscard]] static auto
-    create(std::unique_ptr<Node> name, std::vector<std::unique_ptr<Node>> functions)
-            -> ystdlib::error_handling::Result<std::unique_ptr<Node>>;
+    [[nodiscard]] static auto create(
+            std::unique_ptr<Node> name,
+            std::vector<std::unique_ptr<Node>> functions,
+            SourceLocation source_location
+    ) -> ystdlib::error_handling::Result<std::unique_ptr<Node>>;
 
     // Methods implementing `Node`
     [[nodiscard]] auto serialize_to_str(size_t indentation_level) const
@@ -85,7 +89,7 @@ public:
 
 private:
     // Constructor
-    Namespace() = default;
+    explicit Namespace(SourceLocation source_location) : Node{source_location} {}
 };
 }  // namespace spider::tdl::parser::ast::node_impl
 

--- a/src/spider/tdl/parser/ast/node_impl/StructSpec.cpp
+++ b/src/spider/tdl/parser/ast/node_impl/StructSpec.cpp
@@ -16,6 +16,7 @@
 #include <spider/tdl/parser/ast/Node.hpp>
 #include <spider/tdl/parser/ast/node_impl/Identifier.hpp>
 #include <spider/tdl/parser/ast/node_impl/NamedVar.hpp>
+#include <spider/tdl/parser/ast/SourceLocation.hpp>
 #include <spider/tdl/parser/ast/utils.hpp>
 
 using spider::tdl::parser::ast::node_impl::StructSpec;
@@ -41,8 +42,11 @@ auto StructSpecErrorCodeCategory::message(StructSpec::ErrorCodeEnum error_enum) 
 }
 
 namespace spider::tdl::parser::ast::node_impl {
-auto StructSpec::create(std::unique_ptr<Node> name, std::vector<std::unique_ptr<Node>> fields)
-        -> ystdlib::error_handling::Result<std::shared_ptr<StructSpec>> {
+auto StructSpec::create(
+        std::unique_ptr<Node> name,
+        std::vector<std::unique_ptr<Node>> fields,
+        SourceLocation source_location
+) -> ystdlib::error_handling::Result<std::shared_ptr<StructSpec>> {
     YSTDLIB_ERROR_HANDLING_TRYV(validate_child_node_type<Identifier>(name.get()));
 
     if (fields.empty()) {
@@ -60,7 +64,7 @@ auto StructSpec::create(std::unique_ptr<Node> name, std::vector<std::unique_ptr<
         field_names.emplace(field_name);
     }
 
-    auto struct_spec{std::make_shared<StructSpec>(StructSpec{})};
+    auto struct_spec{std::make_shared<StructSpec>(StructSpec{source_location})};
     YSTDLIB_ERROR_HANDLING_TRYV(struct_spec->add_child(std::move(name)));
     for (auto& field : fields) {
         YSTDLIB_ERROR_HANDLING_TRYV(struct_spec->add_child(std::move(field)));

--- a/src/spider/tdl/parser/ast/node_impl/StructSpec.hpp
+++ b/src/spider/tdl/parser/ast/node_impl/StructSpec.hpp
@@ -15,6 +15,7 @@
 #include <spider/tdl/parser/ast/Node.hpp>
 #include <spider/tdl/parser/ast/node_impl/Identifier.hpp>
 #include <spider/tdl/parser/ast/node_impl/NamedVar.hpp>
+#include <spider/tdl/parser/ast/SourceLocation.hpp>
 
 namespace spider::tdl::parser::ast::node_impl {
 /**
@@ -34,6 +35,7 @@ public:
     /**
      * @param name
      * @param fields
+     * @param source_location
      * @return A result containing a shared pointer to a new `StructSpec` instance with the name and
      * fields on success, or an error code indicating the failure:
      * - StructSpec::ErrorCodeEnum::DuplicatedFieldName if the `fields` contains duplicated field
@@ -41,9 +43,11 @@ public:
      * - StructSpec::ErrorCodeEnum::EmptyStruct if the `fields` is empty.
      * - Forwards `validate_child_node_type`'s return values.
      */
-    [[nodiscard]] static auto
-    create(std::unique_ptr<Node> name, std::vector<std::unique_ptr<Node>> fields)
-            -> ystdlib::error_handling::Result<std::shared_ptr<StructSpec>>;
+    [[nodiscard]] static auto create(
+            std::unique_ptr<Node> name,
+            std::vector<std::unique_ptr<Node>> fields,
+            SourceLocation source_location
+    ) -> ystdlib::error_handling::Result<std::shared_ptr<StructSpec>>;
 
     // Methods implementing `Node`
     [[nodiscard]] auto serialize_to_str(size_t indentation_level) const
@@ -85,7 +89,7 @@ public:
 
 private:
     // Constructor
-    StructSpec() = default;
+    explicit StructSpec(SourceLocation source_location) : Node{source_location} {}
 };
 }  // namespace spider::tdl::parser::ast::node_impl
 

--- a/src/spider/tdl/parser/ast/node_impl/Type.hpp
+++ b/src/spider/tdl/parser/ast/node_impl/Type.hpp
@@ -2,10 +2,15 @@
 #define SPIDER_TDL_PARSER_AST_NODE_IMPL_TYPE_HPP
 
 #include <spider/tdl/parser/ast/Node.hpp>
+#include <spider/tdl/parser/ast/SourceLocation.hpp>
 
 namespace spider::tdl::parser::ast::node_impl {
 // Abstract base class for all type nodes in the AST.
-class Type : public Node {};
+class Type : public Node {
+protected:
+    // Constructor
+    explicit Type(SourceLocation source_location) : Node{source_location} {}
+};
 }  // namespace spider::tdl::parser::ast::node_impl
 
 #endif  // SPIDER_TDL_PARSER_AST_NODE_IMPL_TYPE_HPP

--- a/src/spider/tdl/parser/ast/node_impl/type_impl/Container.hpp
+++ b/src/spider/tdl/parser/ast/node_impl/type_impl/Container.hpp
@@ -2,10 +2,15 @@
 #define SPIDER_TDL_PARSER_AST_NODE_IMPL_TYPE_IMPL_CONTAINER_HPP
 
 #include <spider/tdl/parser/ast/node_impl/Type.hpp>
+#include <spider/tdl/parser/ast/SourceLocation.hpp>
 
 namespace spider::tdl::parser::ast::node_impl::type_impl {
 // Abstract base class for all container type nodes in the AST.
-class Container : public Type {};
+class Container : public Type {
+protected:
+    // Constructor
+    explicit Container(SourceLocation source_location) : Type{source_location} {}
+};
 }  // namespace spider::tdl::parser::ast::node_impl::type_impl
 
 #endif  // SPIDER_TDL_PARSER_AST_NODE_IMPL_TYPE_IMPL_CONTAINER_HPP

--- a/src/spider/tdl/parser/ast/node_impl/type_impl/Primitive.hpp
+++ b/src/spider/tdl/parser/ast/node_impl/type_impl/Primitive.hpp
@@ -2,10 +2,15 @@
 #define SPIDER_TDL_PARSER_AST_NODE_IMPL_TYPE_IMPL_PRIMITIVE_HPP
 
 #include <spider/tdl/parser/ast/node_impl/Type.hpp>
+#include <spider/tdl/parser/ast/SourceLocation.hpp>
 
 namespace spider::tdl::parser::ast::node_impl::type_impl {
 // Abstract base class for all primitive type nodes in the AST.
-class Primitive : public Type {};
+class Primitive : public Type {
+protected:
+    // Constructor
+    explicit Primitive(SourceLocation source_location) : Type{source_location} {}
+};
 }  // namespace spider::tdl::parser::ast::node_impl::type_impl
 
 #endif  // SPIDER_TDL_PARSER_AST_NODE_IMPL_TYPE_IMPL_PRIMITIVE_HPP

--- a/src/spider/tdl/parser/ast/node_impl/type_impl/Struct.cpp
+++ b/src/spider/tdl/parser/ast/node_impl/type_impl/Struct.cpp
@@ -12,6 +12,7 @@
 #include <spider/tdl/parser/ast/Node.hpp>
 #include <spider/tdl/parser/ast/node_impl/Identifier.hpp>
 #include <spider/tdl/parser/ast/node_impl/StructSpec.hpp>
+#include <spider/tdl/parser/ast/SourceLocation.hpp>
 #include <spider/tdl/parser/ast/utils.hpp>
 
 using spider::tdl::parser::ast::node_impl::type_impl::Struct;
@@ -37,11 +38,11 @@ auto StructErrorCodeCategory::message(Struct::ErrorCodeEnum error_enum) const ->
 }
 
 namespace spider::tdl::parser::ast::node_impl::type_impl {
-auto Struct::create(std::unique_ptr<Node> name)
+auto Struct::create(std::unique_ptr<Node> name, SourceLocation source_location)
         -> ystdlib::error_handling::Result<std::unique_ptr<Node>> {
     YSTDLIB_ERROR_HANDLING_TRYV(validate_child_node_type<Identifier>(name.get()));
 
-    auto struct_node{std::make_unique<Struct>(Struct{})};
+    auto struct_node{std::make_unique<Struct>(Struct{source_location})};
     YSTDLIB_ERROR_HANDLING_TRYV(struct_node->add_child(std::move(name)));
     return struct_node;
 }

--- a/src/spider/tdl/parser/ast/node_impl/type_impl/Struct.hpp
+++ b/src/spider/tdl/parser/ast/node_impl/type_impl/Struct.hpp
@@ -14,6 +14,7 @@
 #include <spider/tdl/parser/ast/node_impl/Identifier.hpp>
 #include <spider/tdl/parser/ast/node_impl/StructSpec.hpp>
 #include <spider/tdl/parser/ast/node_impl/Type.hpp>
+#include <spider/tdl/parser/ast/SourceLocation.hpp>
 
 namespace spider::tdl::parser::ast::node_impl::type_impl {
 class Struct : public Type {
@@ -30,11 +31,12 @@ public:
     // Factory function
     /**
      * @param name
+     * @param source_location
      * @return A result containing a unique pointer to a new `Struct` instance with the given name
      * on success, or an error code indicating the failure:
      * - Forwards `validate_child_node_type`'s return values.
      */
-    [[nodiscard]] static auto create(std::unique_ptr<Node> name)
+    [[nodiscard]] static auto create(std::unique_ptr<Node> name, SourceLocation source_location)
             -> ystdlib::error_handling::Result<std::unique_ptr<Node>>;
 
     // Methods implementing `Node`
@@ -63,7 +65,7 @@ public:
 
 private:
     // Constructor
-    Struct() = default;
+    explicit Struct(SourceLocation source_location) : Type{source_location} {}
 
     // Variables
     std::shared_ptr<StructSpec> m_spec;

--- a/src/spider/tdl/parser/ast/node_impl/type_impl/container_impl/List.cpp
+++ b/src/spider/tdl/parser/ast/node_impl/type_impl/container_impl/List.cpp
@@ -10,14 +10,15 @@
 
 #include <spider/tdl/parser/ast/Node.hpp>
 #include <spider/tdl/parser/ast/node_impl/Type.hpp>
+#include <spider/tdl/parser/ast/SourceLocation.hpp>
 #include <spider/tdl/parser/ast/utils.hpp>
 
 namespace spider::tdl::parser::ast::node_impl::type_impl::container_impl {
-auto List::create(std::unique_ptr<Node> element_type)
+auto List::create(std::unique_ptr<Node> element_type, SourceLocation source_location)
         -> ystdlib::error_handling::Result<std::unique_ptr<Node>> {
     YSTDLIB_ERROR_HANDLING_TRYV(validate_child_node_type<Type>(element_type.get()));
 
-    auto list{std::make_unique<List>(List{})};
+    auto list{std::make_unique<List>(List{source_location})};
     YSTDLIB_ERROR_HANDLING_TRYV(list->add_child(std::move(element_type)));
     return list;
 }

--- a/src/spider/tdl/parser/ast/node_impl/type_impl/container_impl/List.hpp
+++ b/src/spider/tdl/parser/ast/node_impl/type_impl/container_impl/List.hpp
@@ -10,6 +10,7 @@
 #include <spider/tdl/parser/ast/Node.hpp>
 #include <spider/tdl/parser/ast/node_impl/Type.hpp>
 #include <spider/tdl/parser/ast/node_impl/type_impl/Container.hpp>
+#include <spider/tdl/parser/ast/SourceLocation.hpp>
 
 namespace spider::tdl::parser::ast::node_impl::type_impl::container_impl {
 class List : public Container {
@@ -17,11 +18,13 @@ public:
     // Factory function
     /**
      * @param element_type The type of elements in the list.
+     * @param source_location
      * @return A result containing a unique pointer to a new `List` instance with the given element
      * type on success, or an error code indicating the failure:
      * - Forwards `validate_child_node_type`'s return values.
      */
-    [[nodiscard]] static auto create(std::unique_ptr<Node> element_type)
+    [[nodiscard]] static auto
+    create(std::unique_ptr<Node> element_type, SourceLocation source_location)
             -> ystdlib::error_handling::Result<std::unique_ptr<Node>>;
 
     // Methods implementing `Node`
@@ -37,7 +40,7 @@ public:
 
 private:
     // Constructor
-    List() = default;
+    explicit List(SourceLocation source_location) : Container{source_location} {}
 };
 }  // namespace spider::tdl::parser::ast::node_impl::type_impl::container_impl
 

--- a/src/spider/tdl/parser/ast/node_impl/type_impl/container_impl/Map.cpp
+++ b/src/spider/tdl/parser/ast/node_impl/type_impl/container_impl/Map.cpp
@@ -14,6 +14,7 @@
 #include <spider/tdl/parser/ast/node_impl/Type.hpp>
 #include <spider/tdl/parser/ast/node_impl/type_impl/container_impl/List.hpp>
 #include <spider/tdl/parser/ast/node_impl/type_impl/primitive_impl/Int.hpp>
+#include <spider/tdl/parser/ast/SourceLocation.hpp>
 #include <spider/tdl/parser/ast/utils.hpp>
 
 using spider::tdl::parser::ast::node_impl::type_impl::container_impl::Map;
@@ -66,8 +67,11 @@ auto is_supported_key_type(Type const* key_type) -> bool {
 }
 }  // namespace
 
-auto Map::create(std::unique_ptr<Node> key_type, std::unique_ptr<Node> value_type)
-        -> ystdlib::error_handling::Result<std::unique_ptr<Node>> {
+auto Map::create(
+        std::unique_ptr<Node> key_type,
+        std::unique_ptr<Node> value_type,
+        SourceLocation source_location
+) -> ystdlib::error_handling::Result<std::unique_ptr<Node>> {
     YSTDLIB_ERROR_HANDLING_TRYV(validate_child_node_type<Type>(key_type.get()));
     YSTDLIB_ERROR_HANDLING_TRYV(validate_child_node_type<Type>(value_type.get()));
 
@@ -77,7 +81,7 @@ auto Map::create(std::unique_ptr<Node> key_type, std::unique_ptr<Node> value_typ
         return ErrorCode{ErrorCodeEnum::UnsupportedKeyType};
     }
 
-    auto map{std::make_unique<Map>(Map{})};
+    auto map{std::make_unique<Map>(Map{source_location})};
     YSTDLIB_ERROR_HANDLING_TRYV(map->add_child(std::move(key_type)));
     YSTDLIB_ERROR_HANDLING_TRYV(map->add_child(std::move(value_type)));
     return map;

--- a/src/spider/tdl/parser/ast/node_impl/type_impl/container_impl/Map.hpp
+++ b/src/spider/tdl/parser/ast/node_impl/type_impl/container_impl/Map.hpp
@@ -12,6 +12,7 @@
 #include <spider/tdl/parser/ast/Node.hpp>
 #include <spider/tdl/parser/ast/node_impl/Type.hpp>
 #include <spider/tdl/parser/ast/node_impl/type_impl/Container.hpp>
+#include <spider/tdl/parser/ast/SourceLocation.hpp>
 
 namespace spider::tdl::parser::ast::node_impl::type_impl::container_impl {
 class Map : public Container {
@@ -27,14 +28,17 @@ public:
     /**
      * @param key_type
      * @param value_type
+     * @param source_location
      * @return A result containing a unique pointer to a new `Map` instance with the given key and
      * value types on success, or an error code indicating the failure:
      * - Map::ErrorCodeEnum::UnsupportedKeyType if the `key_type` is not supported.
      * - Forwards `validate_child_node_type`'s return values.
      */
-    [[nodiscard]] static auto
-    create(std::unique_ptr<Node> key_type, std::unique_ptr<Node> value_type)
-            -> ystdlib::error_handling::Result<std::unique_ptr<Node>>;
+    [[nodiscard]] static auto create(
+            std::unique_ptr<Node> key_type,
+            std::unique_ptr<Node> value_type,
+            SourceLocation source_location
+    ) -> ystdlib::error_handling::Result<std::unique_ptr<Node>>;
 
     // Methods implementing `Node`
     [[nodiscard]] auto serialize_to_str(size_t indentation_level) const
@@ -55,7 +59,7 @@ public:
 
 private:
     // Constructor
-    Map() = default;
+    explicit Map(SourceLocation source_location) : Container{source_location} {}
 };
 }  // namespace spider::tdl::parser::ast::node_impl::type_impl::container_impl
 

--- a/src/spider/tdl/parser/ast/node_impl/type_impl/container_impl/Tuple.cpp
+++ b/src/spider/tdl/parser/ast/node_impl/type_impl/container_impl/Tuple.cpp
@@ -13,16 +13,17 @@
 
 #include <spider/tdl/parser/ast/Node.hpp>
 #include <spider/tdl/parser/ast/node_impl/Type.hpp>
+#include <spider/tdl/parser/ast/SourceLocation.hpp>
 #include <spider/tdl/parser/ast/utils.hpp>
 
 namespace spider::tdl::parser::ast::node_impl::type_impl::container_impl {
-auto Tuple::create(std::vector<std::unique_ptr<Node>> elements)
+auto Tuple::create(std::vector<std::unique_ptr<Node>> elements, SourceLocation source_location)
         -> ystdlib::error_handling::Result<std::unique_ptr<Node>> {
     for (auto const& type : elements) {
         YSTDLIB_ERROR_HANDLING_TRYV(validate_child_node_type<Type>(type.get()));
     }
 
-    auto tuple{std::make_unique<Tuple>(Tuple{})};
+    auto tuple{std::make_unique<Tuple>(Tuple{source_location})};
     for (auto& type : elements) {
         YSTDLIB_ERROR_HANDLING_TRYV(tuple->add_child(std::move(type)));
     }

--- a/src/spider/tdl/parser/ast/node_impl/type_impl/container_impl/Tuple.hpp
+++ b/src/spider/tdl/parser/ast/node_impl/type_impl/container_impl/Tuple.hpp
@@ -10,6 +10,7 @@
 
 #include <spider/tdl/parser/ast/Node.hpp>
 #include <spider/tdl/parser/ast/node_impl/type_impl/Container.hpp>
+#include <spider/tdl/parser/ast/SourceLocation.hpp>
 
 namespace spider::tdl::parser::ast::node_impl::type_impl::container_impl {
 class Tuple : public Container {
@@ -17,11 +18,13 @@ public:
     // Factory function
     /**
      * @param elements
+     * @param source_location
      * @return A result containing a unique pointer to a new `Tuple` instance as a collection of the
      * given element types, or an error code indicating the failure:
      * - Forwards `validate_child_node_type`'s return values.
      */
-    [[nodiscard]] static auto create(std::vector<std::unique_ptr<Node>> elements)
+    [[nodiscard]] static auto
+    create(std::vector<std::unique_ptr<Node>> elements, SourceLocation source_location)
             -> ystdlib::error_handling::Result<std::unique_ptr<Node>>;
 
     // Methods implementing `Node`
@@ -33,7 +36,7 @@ public:
 
 private:
     // Constructor
-    Tuple() = default;
+    explicit Tuple(SourceLocation source_location) : Container{source_location} {}
 };
 }  // namespace spider::tdl::parser::ast::node_impl::type_impl::container_impl
 

--- a/src/spider/tdl/parser/ast/node_impl/type_impl/primitive_impl/Bool.hpp
+++ b/src/spider/tdl/parser/ast/node_impl/type_impl/primitive_impl/Bool.hpp
@@ -9,16 +9,18 @@
 
 #include <spider/tdl/parser/ast/Node.hpp>
 #include <spider/tdl/parser/ast/node_impl/type_impl/Primitive.hpp>
+#include <spider/tdl/parser/ast/SourceLocation.hpp>
 
 namespace spider::tdl::parser::ast::node_impl::type_impl::primitive_impl {
 class Bool : public Primitive {
 public:
     // Factory function
     /**
+     * @param source_location
      * @return A unique pointer to a new `Bool` instance.
      */
-    [[nodiscard]] static auto create() -> std::unique_ptr<Node> {
-        return std::make_unique<Bool>(Bool{});
+    [[nodiscard]] static auto create(SourceLocation source_location) -> std::unique_ptr<Node> {
+        return std::make_unique<Bool>(Bool{source_location});
     }
 
     // Methods implementing `Node`
@@ -27,7 +29,7 @@ public:
 
 private:
     // Constructor
-    explicit Bool() = default;
+    explicit Bool(SourceLocation source_location) : Primitive{source_location} {}
 };
 }  // namespace spider::tdl::parser::ast::node_impl::type_impl::primitive_impl
 

--- a/src/spider/tdl/parser/ast/node_impl/type_impl/primitive_impl/Float.hpp
+++ b/src/spider/tdl/parser/ast/node_impl/type_impl/primitive_impl/Float.hpp
@@ -10,6 +10,7 @@
 #include <spider/tdl/parser/ast/FloatSpec.hpp>
 #include <spider/tdl/parser/ast/Node.hpp>
 #include <spider/tdl/parser/ast/node_impl/type_impl/Primitive.hpp>
+#include <spider/tdl/parser/ast/SourceLocation.hpp>
 
 namespace spider::tdl::parser::ast::node_impl::type_impl::primitive_impl {
 class Float : public Primitive {
@@ -17,10 +18,12 @@ public:
     // Factory function
     /**
      * @param spec
+     * @param source_location
      * @return A unique pointer to a new `Float` instance with the given type spec.
      */
-    [[nodiscard]] static auto create(FloatSpec spec) -> std::unique_ptr<Node> {
-        return std::make_unique<Float>(Float{spec});
+    [[nodiscard]] static auto create(FloatSpec spec, SourceLocation source_location)
+            -> std::unique_ptr<Node> {
+        return std::make_unique<Float>(Float{spec, source_location});
     }
 
     // Methods implementing `Node`
@@ -32,7 +35,9 @@ public:
 
 private:
     // Constructor
-    explicit Float(FloatSpec spec) : m_spec{spec} {}
+    Float(FloatSpec spec, SourceLocation source_location)
+            : Primitive{source_location},
+              m_spec{spec} {}
 
     // Variables
     FloatSpec m_spec;

--- a/src/spider/tdl/parser/ast/node_impl/type_impl/primitive_impl/Int.hpp
+++ b/src/spider/tdl/parser/ast/node_impl/type_impl/primitive_impl/Int.hpp
@@ -10,6 +10,7 @@
 #include <spider/tdl/parser/ast/IntSpec.hpp>
 #include <spider/tdl/parser/ast/Node.hpp>
 #include <spider/tdl/parser/ast/node_impl/type_impl/Primitive.hpp>
+#include <spider/tdl/parser/ast/SourceLocation.hpp>
 
 namespace spider::tdl::parser::ast::node_impl::type_impl::primitive_impl {
 class Int : public Primitive {
@@ -17,10 +18,12 @@ public:
     // Factory function
     /**
      * @param spec
+     * @param source_location
      * @return A unique pointer to a new `Int` instance with the given type spec.
      */
-    [[nodiscard]] static auto create(IntSpec spec) -> std::unique_ptr<Node> {
-        return std::make_unique<Int>(Int{spec});
+    [[nodiscard]] static auto create(IntSpec spec, SourceLocation source_location)
+            -> std::unique_ptr<Node> {
+        return std::make_unique<Int>(Int{spec, source_location});
     }
 
     // Methods implementing `Node`
@@ -32,7 +35,7 @@ public:
 
 private:
     // Constructor
-    explicit Int(IntSpec spec) : m_spec{spec} {}
+    Int(IntSpec spec, SourceLocation source_location) : Primitive{source_location}, m_spec{spec} {}
 
     // Variables
     IntSpec m_spec;

--- a/src/spider/tdl/parser/ast/utils.hpp
+++ b/src/spider/tdl/parser/ast/utils.hpp
@@ -3,6 +3,7 @@
 
 #include <cstddef>
 #include <string>
+#include <string_view>
 #include <type_traits>
 
 #include <ystdlib/error_handling/Result.hpp>


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR adds support for tracking the source location in AST nodes by storing a `SourceLocation` instance in each AST node. All node implementations are updated to accept a source location through the factory function.

This PR doesn't update the serialization methods to include the source information. We will update this in a future PR to avoid making this PR too long.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Ensure all workflows pass.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - AST nodes now carry source location (line/column) data, enabling more precise diagnostics and tooling feedback.
  - Creation APIs accept location details, expanding the public surface for location-aware workflows.

- Documentation
  - Updated API references to include and describe the new location parameter.

- Tests
  - Test suite updated to validate end-to-end propagation of source locations across nodes and containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->