### PR TITLE
feat(tdl): Add a super header to import all AST nodes and hide the implementation namespace.

### DIFF
--- a/src/spider/CMakeLists.txt
+++ b/src/spider/CMakeLists.txt
@@ -235,6 +235,7 @@ set(SPIDER_TDL_SHARED_HEADERS
     tdl/parser/ast/node_impl/type_impl/primitive_impl/Float.hpp
     tdl/parser/ast/node_impl/type_impl/primitive_impl/Int.hpp
     tdl/parser/ast/node_impl/type_impl/Struct.hpp
+    tdl/parser/ast/nodes.hpp
     tdl/parser/ast/SourceLocation.hpp
     tdl/parser/ast/utils.hpp
     CACHE INTERNAL

--- a/src/spider/tdl/parser/ast/nodes.hpp
+++ b/src/spider/tdl/parser/ast/nodes.hpp
@@ -1,0 +1,48 @@
+/**
+ * A super header that imports all AST nodes and hides the implementation namespaces.
+ */
+#ifndef SPIDER_TDL_PARSER_AST_NODES_HPP
+#define SPIDER_TDL_PARSER_AST_NODES_HPP
+
+#include <spider/tdl/parser/ast/node_impl/Function.hpp>
+#include <spider/tdl/parser/ast/node_impl/Identifier.hpp>
+#include <spider/tdl/parser/ast/node_impl/NamedVar.hpp>
+#include <spider/tdl/parser/ast/node_impl/Namespace.hpp>
+#include <spider/tdl/parser/ast/node_impl/StructSpec.hpp>
+#include <spider/tdl/parser/ast/node_impl/Type.hpp>
+#include <spider/tdl/parser/ast/node_impl/type_impl/Container.hpp>
+#include <spider/tdl/parser/ast/node_impl/type_impl/container_impl/List.hpp>
+#include <spider/tdl/parser/ast/node_impl/type_impl/container_impl/Map.hpp>
+#include <spider/tdl/parser/ast/node_impl/type_impl/container_impl/Tuple.hpp>
+#include <spider/tdl/parser/ast/node_impl/type_impl/Primitive.hpp>
+#include <spider/tdl/parser/ast/node_impl/type_impl/primitive_impl/Bool.hpp>
+#include <spider/tdl/parser/ast/node_impl/type_impl/primitive_impl/Float.hpp>
+#include <spider/tdl/parser/ast/node_impl/type_impl/primitive_impl/Int.hpp>
+#include <spider/tdl/parser/ast/node_impl/type_impl/Struct.hpp>
+
+// IWYU pragma: begin_exports
+#include <spider/tdl/parser/ast/FloatSpec.hpp>
+#include <spider/tdl/parser/ast/IntSpec.hpp>
+#include <spider/tdl/parser/ast/Node.hpp>
+
+// IWYU pragma: end_exports
+
+namespace spider::tdl::parser::ast {
+using Function = node_impl::Function;
+using Identifier = node_impl::Identifier;
+using NamedVar = node_impl::NamedVar;
+using Namespace = node_impl::Namespace;
+using StructSpec = node_impl::StructSpec;
+using Type = node_impl::Type;
+using Container = node_impl::type_impl::Container;
+using Primitive = node_impl::type_impl::Primitive;
+using Struct = node_impl::type_impl::Struct;
+using List = node_impl::type_impl::container_impl::List;
+using Map = node_impl::type_impl::container_impl::Map;
+using Tuple = node_impl::type_impl::container_impl::Tuple;
+using Int = node_impl::type_impl::primitive_impl::Int;
+using Float = node_impl::type_impl::primitive_impl::Float;
+using Bool = node_impl::type_impl::primitive_impl::Bool;
+}  // namespace spider::tdl::parser::ast
+
+#endif  // SPIDER_TDL_PARSER_AST_NODES_HPP


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

As planned to use Antlr's actions to embed AST generation in the generated Antlr parser, this PR adds a super header that includes all AST nodes and hides implementation namespaces. Doing this has two benefits:

* For Antlr, it only needs to include this super header to use all AST nodes.
* We can use the derived node types without knowing the namespace prefix for implementation.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Ensure all workflows pass.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a consolidated public header that aggregates all AST node types, providing a single, stable entry point for consuming the parser’s type definitions.
  - Exposes commonly used node and type aliases under a consistent namespace for simpler imports and improved discoverability.
  - No runtime behaviour changes; this is an API surface enhancement for easier integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->