### PR TITLE
fix(test): Add missing fixture imports in integration tests (fixes #206).

### DIFF
--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from .client import g_storage_url, SQLConnection
+from .client import g_storage_url, SQLConnection, storage  # noqa: F401
 from .utils import g_scheduler_port
 
 
@@ -52,7 +52,7 @@ def start_scheduler_workers(
 
 @pytest.fixture(scope="class")
 def scheduler_worker(
-    storage: SQLConnection,
+    storage: SQLConnection,  # noqa: F811
 ) -> Generator[None, None, None]:
     """
     Fixture to start a scheduler process and two worker processes.

--- a/tests/integration/test_scheduler_worker.py
+++ b/tests/integration/test_scheduler_worker.py
@@ -20,6 +20,7 @@ from .client import (
     remove_data,
     remove_job,
     SQLConnection,
+    storage,  # noqa: F401
     submit_job,
     Task,
     TaskGraph,
@@ -68,7 +69,7 @@ def start_scheduler_worker(
 
 @pytest.fixture(scope="class")
 def scheduler_worker(
-    storage: SQLConnection,
+    storage: SQLConnection,  # noqa: F811
 ) -> Generator[None, None, None]:
     """
     Fixture to start qa scheduler process and a worker processes.
@@ -90,7 +91,7 @@ def scheduler_worker(
 
 @pytest.fixture
 def success_job(
-    storage: SQLConnection,
+    storage: SQLConnection,  # noqa: F811
 ) -> Generator[tuple[TaskGraph, Task, Task, Task], None, None]:
     """
     Fixture to create a job with two parent tasks and one child task.
@@ -157,7 +158,7 @@ def success_job(
 
 @pytest.fixture
 def fail_job(
-    storage: SQLConnection,
+    storage: SQLConnection,  # noqa: F811
 ) -> Generator[Task, None, None]:
     """
     Fixture to create a job that will fail. The task will raise an error when executed.
@@ -188,7 +189,7 @@ def fail_job(
 
 @pytest.fixture
 def data_job(
-    storage: SQLConnection,
+    storage: SQLConnection,  # noqa: F811
 ) -> Generator[Task, None, None]:
     """
     Fixture to create a data and a task that uses the data.
@@ -228,7 +229,7 @@ def data_job(
 
 @pytest.fixture
 def random_fail_job(
-    storage: SQLConnection,
+    storage: SQLConnection,  # noqa: F811
 ) -> Generator[Task, None, None]:
     """
     Fixture to create a job that randomly fails. The task will succeed after a few retries.
@@ -273,7 +274,7 @@ class TestSchedulerWorker:
     @pytest.mark.usefixtures("scheduler_worker")
     def test_job_success(
         self,
-        storage: SQLConnection,
+        storage: SQLConnection,  # noqa: F811
         success_job: tuple[TaskGraph, Task, Task, Task],
     ) -> None:
         """
@@ -303,7 +304,7 @@ class TestSchedulerWorker:
     @pytest.mark.usefixtures("scheduler_worker")
     def test_job_failure(
         self,
-        storage: SQLConnection,
+        storage: SQLConnection,  # noqa: F811
         fail_job: Task,
     ) -> None:
         """
@@ -320,7 +321,7 @@ class TestSchedulerWorker:
     @pytest.mark.usefixtures("scheduler_worker")
     def test_data_job(
         self,
-        storage: SQLConnection,
+        storage: SQLConnection,  # noqa: F811
         data_job: Task,
     ) -> None:
         """
@@ -340,7 +341,7 @@ class TestSchedulerWorker:
     @pytest.mark.usefixtures("scheduler_worker")
     def test_random_fail_job(
         self,
-        storage: SQLConnection,
+        storage: SQLConnection,  # noqa: F811
         random_fail_job: Task,
     ) -> None:
         """

--- a/tests/integration/test_signal.py
+++ b/tests/integration/test_signal.py
@@ -18,6 +18,7 @@ from .client import (
     get_task_state,
     remove_job,
     SQLConnection,
+    storage,  # noqa: F401
     submit_job,
     Task,
     TaskGraph,
@@ -72,7 +73,7 @@ def start_scheduler_worker(
 
 @pytest.fixture
 def scheduler_worker_signal(
-    storage: SQLConnection,
+    storage: SQLConnection,  # noqa: F811
 ) -> Generator[tuple[subprocess.Popen[bytes], subprocess.Popen[bytes]], None, None]:
     """
     Fixture to start a scheduler and a worker process.
@@ -97,7 +98,7 @@ class TestWorkerSignal:
 
     def test_task_signal(
         self,
-        storage: SQLConnection,
+        storage: SQLConnection,  # noqa: F811
         scheduler_worker_signal: tuple[subprocess.Popen[bytes], subprocess.Popen[bytes]],
     ) -> None:
         """
@@ -174,7 +175,7 @@ class TestWorkerSignal:
 
     def test_task_exit(
         self,
-        storage: SQLConnection,
+        storage: SQLConnection,  # noqa: F811
         scheduler_worker_signal: tuple[subprocess.Popen[bytes], subprocess.Popen[bytes]],
     ) -> None:
         """


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
## Root Cause
#174 introduces a bug in integration tests that all integration tests files are missing `storage` fixture.

The `storage` fixture is defined in `tests/integration/client.py`, and was imported into each integration test files. `ruff`, introduced by #174, does not understand pytest fixtures, and treats fixture argument of a test as a redefinition of the imported fixture (F811) and the imported fixture as unused (F401). The `ruff fix` automatically remove the "unused" fixture imports.

## Fix
This PR adds back the missing storage fixture.
Because the F401 and F811 are important checks that we don't want to suppress globally, even for all integration test files, we explicitly suppress the F401 and F811 using `# noqa: F401/F811` at import and argument sites. 



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* [x] All C++ unit tests and integration tests pass in Ubuntu 24.04.
* [x] Python lint test pass in Ubuntu 24.04.
* [ ] GitHub workflows pass.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
