### PR TITLE
feat(tdl): Add `TranslationUnit` AST node.

### DIFF
--- a/src/spider/CMakeLists.txt
+++ b/src/spider/CMakeLists.txt
@@ -217,6 +217,7 @@ set(SPIDER_TDL_SHARED_SOURCES
     tdl/parser/ast/node_impl/NamedVar.cpp
     tdl/parser/ast/node_impl/Namespace.cpp
     tdl/parser/ast/node_impl/StructSpec.cpp
+    tdl/parser/ast/node_impl/TranslationUnit.cpp
     tdl/parser/ast/node_impl/type_impl/container_impl/List.cpp
     tdl/parser/ast/node_impl/type_impl/container_impl/Map.cpp
     tdl/parser/ast/node_impl/type_impl/container_impl/Tuple.cpp
@@ -240,6 +241,7 @@ set(SPIDER_TDL_SHARED_HEADERS
     tdl/parser/ast/node_impl/NamedVar.hpp
     tdl/parser/ast/node_impl/Namespace.hpp
     tdl/parser/ast/node_impl/StructSpec.hpp
+    tdl/parser/ast/node_impl/TranslationUnit.hpp
     tdl/parser/ast/node_impl/Type.hpp
     tdl/parser/ast/node_impl/type_impl/Container.hpp
     tdl/parser/ast/node_impl/type_impl/container_impl/List.hpp

--- a/src/spider/tdl/parser/ast/node_impl/TranslationUnit.cpp
+++ b/src/spider/tdl/parser/ast/node_impl/TranslationUnit.cpp
@@ -1,0 +1,5 @@
+//
+// Created by pleia on 8/22/2025.
+//
+
+#include "TranslationUnit.hpp"

--- a/src/spider/tdl/parser/ast/node_impl/TranslationUnit.cpp
+++ b/src/spider/tdl/parser/ast/node_impl/TranslationUnit.cpp
@@ -1,5 +1,103 @@
-//
-// Created by pleia on 8/22/2025.
-//
-
 #include "TranslationUnit.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+#include <utility>
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+#include <ystdlib/error_handling/ErrorCode.hpp>
+#include <ystdlib/error_handling/Result.hpp>
+
+#include <spider/tdl/parser/ast/Node.hpp>
+#include <spider/tdl/parser/ast/node_impl/Namespace.hpp>
+#include <spider/tdl/parser/ast/node_impl/StructSpec.hpp>
+#include <spider/tdl/parser/ast/utils.hpp>
+
+using spider::tdl::parser::ast::node_impl::TranslationUnit;
+using TranslationUnitErrorCodeCategory
+        = ystdlib::error_handling::ErrorCategory<TranslationUnit::ErrorCodeEnum>;
+
+template <>
+auto TranslationUnitErrorCodeCategory::name() const noexcept -> char const* {
+    return "spider::tdl::parser::ast::node_impl::TranslationUnit";
+}
+
+template <>
+auto TranslationUnitErrorCodeCategory::message(TranslationUnit::ErrorCodeEnum error_enum) const
+        -> std::string {
+    switch (error_enum) {
+        case TranslationUnit::ErrorCodeEnum::DuplicatedNamespaceName:
+            return "The translation unit contains duplicated namespace names.";
+        case TranslationUnit::ErrorCodeEnum::DuplicatedStructSpecName:
+            return "The translation unit contains duplicated struct spec names.";
+        default:
+            return "Unknown error code enum";
+    }
+}
+
+namespace spider::tdl::parser::ast::node_impl {
+auto TranslationUnit::serialize_to_str(size_t indentation_level) const
+        -> ystdlib::error_handling::Result<std::string> {
+    std::vector<std::string> serialized_struct_specs;
+    for (auto const& [name, struct_spec] : m_struct_spec_table) {
+        serialized_struct_specs.emplace_back(
+                YSTDLIB_ERROR_HANDLING_TRYX(struct_spec->serialize_to_str(indentation_level + 2))
+        );
+    }
+
+    std::vector<std::string> serialized_namespaces;
+    YSTDLIB_ERROR_HANDLING_TRYV(
+            visit_children([&](Node const& child) -> ystdlib::error_handling::Result<void> {
+                YSTDLIB_ERROR_HANDLING_TRYV(validate_child_node_type<Namespace>(&child));
+                serialized_namespaces.emplace_back(
+                        YSTDLIB_ERROR_HANDLING_TRYX(child.serialize_to_str(indentation_level + 2))
+                );
+                return ystdlib::error_handling::success();
+            })
+    );
+
+    return fmt::format(
+            "{}[TranslationUnit]:\n{}StructSpecs:\n{}\n{}Namespaces:\n{}",
+            create_indentation(indentation_level),
+            create_indentation(indentation_level + 1),
+            fmt::join(serialized_struct_specs, "\n"),
+            create_indentation(indentation_level + 1),
+            fmt::join(serialized_namespaces, "\n")
+    );
+}
+
+auto TranslationUnit::add_namespace(std::unique_ptr<Node> namespace_node)
+        -> ystdlib::error_handling::Result<void> {
+    YSTDLIB_ERROR_HANDLING_TRYV(validate_child_node_type<Namespace>(namespace_node.get()));
+    // The previous check ensures the node is of type `Namespace`.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+    auto const* ns{static_cast<Namespace const*>(namespace_node.get())};
+    YSTDLIB_ERROR_HANDLING_TRYV(
+            visit_children([&](Node const& child) -> ystdlib::error_handling::Result<void> {
+                YSTDLIB_ERROR_HANDLING_TRYV(validate_child_node_type<Namespace>(&child));
+                // The previous check ensures the node is of type `Namespace`.
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+                auto const& existing_ns{static_cast<Namespace const&>(child)};
+                if (existing_ns.get_name() == ns->get_name()) {
+                    return ErrorCode{ErrorCodeEnum::DuplicatedNamespaceName};
+                }
+                return ystdlib::error_handling::success();
+            })
+    );
+    return add_child(std::move(namespace_node));
+}
+
+auto TranslationUnit::add_struct_spec(std::shared_ptr<StructSpec const> const& struct_spec)
+        -> ystdlib::error_handling::Result<void> {
+    auto const name{struct_spec->get_name()};
+    if (m_struct_spec_table.contains(name)) {
+        return ErrorCode{ErrorCodeEnum::DuplicatedStructSpecName};
+    }
+    m_struct_spec_table.emplace(name, struct_spec);
+    return ystdlib::error_handling::success();
+}
+}  // namespace spider::tdl::parser::ast::node_impl

--- a/src/spider/tdl/parser/ast/node_impl/TranslationUnit.hpp
+++ b/src/spider/tdl/parser/ast/node_impl/TranslationUnit.hpp
@@ -6,16 +6,13 @@
 #include <memory>
 #include <string>
 #include <string_view>
-#include <type_traits>
-#include <vector>
 
 #include <absl/container/flat_hash_map.h>
 #include <ystdlib/error_handling/ErrorCode.hpp>
 #include <ystdlib/error_handling/Result.hpp>
 
 #include <spider/tdl/parser/ast/Node.hpp>
-#include <spider/tdl/parser/ast/node_impl/Identifier.hpp>
-#include <spider/tdl/parser/ast/node_impl/NamedVar.hpp>
+#include <spider/tdl/parser/ast/node_impl/StructSpec.hpp>
 #include <spider/tdl/parser/SourceLocation.hpp>
 
 namespace spider::tdl::parser::ast::node_impl {
@@ -43,7 +40,7 @@ public:
         return std::make_unique<TranslationUnit>(TranslationUnit{source_location});
     }
 
-    // Methods implementing `Node`
+    // Methods implementing `Node`.
     [[nodiscard]] auto serialize_to_str(size_t indentation_level) const
             -> ystdlib::error_handling::Result<std::string> override;
 
@@ -53,7 +50,8 @@ public:
      * @return A shared pointer to the `StructSpec` with the given name if it exists in the struct
      * spec table, nullptr otherwise.
      */
-    [[nodiscard]] auto get_struct_spec(std::string_view name) const -> std::shared<StructSpec> {
+    [[nodiscard]] auto get_struct_spec(std::string_view name) const
+            -> std::shared_ptr<StructSpec const> {
         if (m_struct_spec_table.contains(name)) {
             return m_struct_spec_table.at(name);
         }
@@ -67,7 +65,7 @@ public:
      * - TranslationUnit::ErrorCodeEnum::DuplicatedStructSpecName if another struct spec with the
      *   same name already exists.
      */
-    [[nodiscard]] auto add_struct_spec(std::shared_ptr<StructSpec> struct_spec)
+    [[nodiscard]] auto add_struct_spec(std::shared_ptr<StructSpec const> const& struct_spec)
             -> ystdlib::error_handling::Result<void>;
 
     /**
@@ -86,8 +84,12 @@ private:
     explicit TranslationUnit(SourceLocation source_location) : Node{source_location} {}
 
     // Variables
-    absl::flat_hash_map<std::string_view, std::shared_ptr<StructSpec>> m_struct_spec_table;
+    absl::flat_hash_map<std::string, std::shared_ptr<StructSpec const>> m_struct_spec_table;
 };
 }  // namespace spider::tdl::parser::ast::node_impl
+
+YSTDLIB_ERROR_HANDLING_MARK_AS_ERROR_CODE_ENUM(
+        spider::tdl::parser::ast::node_impl::TranslationUnit::ErrorCodeEnum
+);
 
 #endif  // SPIDER_TDL_PARSER_AST_NODE_IMPL_TRANSLATIONUNIT_HPP

--- a/src/spider/tdl/parser/ast/node_impl/TranslationUnit.hpp
+++ b/src/spider/tdl/parser/ast/node_impl/TranslationUnit.hpp
@@ -1,0 +1,93 @@
+#ifndef SPIDER_TDL_PARSER_AST_NODE_IMPL_TRANSLATIONUNIT_HPP
+#define SPIDER_TDL_PARSER_AST_NODE_IMPL_TRANSLATIONUNIT_HPP
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <vector>
+
+#include <absl/container/flat_hash_map.h>
+#include <ystdlib/error_handling/ErrorCode.hpp>
+#include <ystdlib/error_handling/Result.hpp>
+
+#include <spider/tdl/parser/ast/Node.hpp>
+#include <spider/tdl/parser/ast/node_impl/Identifier.hpp>
+#include <spider/tdl/parser/ast/node_impl/NamedVar.hpp>
+#include <spider/tdl/parser/SourceLocation.hpp>
+
+namespace spider::tdl::parser::ast::node_impl {
+/**
+ * Represents the root of a TDL AST, encapsulating the entire translation unit.
+ * A translation unit maintains a list of namespaces as its children, and also a symbol table for
+ * all defined structs as struct specs.
+ */
+class TranslationUnit : public Node {
+public:
+    // Factory function
+    // Types
+    enum class ErrorCodeEnum : uint8_t {
+        DuplicatedNamespaceName = 1,
+        DuplicatedStructSpecName,
+    };
+
+    using ErrorCode = ystdlib::error_handling::ErrorCode<ErrorCodeEnum>;
+
+    /**
+     * @param source_location
+     * @return A unique pointer to a new `TranslationUnit` instance.
+     */
+    [[nodiscard]] static auto create(SourceLocation source_location) -> std::unique_ptr<Node> {
+        return std::make_unique<TranslationUnit>(TranslationUnit{source_location});
+    }
+
+    // Methods implementing `Node`
+    [[nodiscard]] auto serialize_to_str(size_t indentation_level) const
+            -> ystdlib::error_handling::Result<std::string> override;
+
+    // Methods
+    /**
+     * @param name
+     * @return A shared pointer to the `StructSpec` with the given name if it exists in the struct
+     * spec table, nullptr otherwise.
+     */
+    [[nodiscard]] auto get_struct_spec(std::string_view name) const -> std::shared<StructSpec> {
+        if (m_struct_spec_table.contains(name)) {
+            return m_struct_spec_table.at(name);
+        }
+        return nullptr;
+    }
+
+    /**
+     * Adds a `StructSpec` to the struct spec table.
+     * @param struct_spec
+     * @return A void result on success, or an error code indicating the failure:
+     * - TranslationUnit::ErrorCodeEnum::DuplicatedStructSpecName if another struct spec with the
+     *   same name already exists.
+     */
+    [[nodiscard]] auto add_struct_spec(std::shared_ptr<StructSpec> struct_spec)
+            -> ystdlib::error_handling::Result<void>;
+
+    /**
+     * Adds a `Namespace` node as a child.
+     * @param namespace_node
+     * @return A void result on success, or an error code indicating the failure:
+     * - TranslationUnit::ErrorCodeEnum::DuplicatedNamespaceName if another namespace with the same
+     *   name already exists.
+     * - Forwards `Node::add_child`'s return values.
+     */
+    [[nodiscard]] auto add_namespace(std::unique_ptr<Node> namespace_node)
+            -> ystdlib::error_handling::Result<void>;
+
+private:
+    // Constructor
+    explicit TranslationUnit(SourceLocation source_location) : Node{source_location} {}
+
+    // Variables
+    absl::flat_hash_map<std::string_view, std::shared_ptr<StructSpec>> m_struct_spec_table;
+};
+}  // namespace spider::tdl::parser::ast::node_impl
+
+#endif  // SPIDER_TDL_PARSER_AST_NODE_IMPL_TRANSLATIONUNIT_HPP

--- a/src/spider/tdl/parser/ast/nodes.hpp
+++ b/src/spider/tdl/parser/ast/nodes.hpp
@@ -34,6 +34,7 @@ using Identifier = node_impl::Identifier;
 using NamedVar = node_impl::NamedVar;
 using Namespace = node_impl::Namespace;
 using StructSpec = node_impl::StructSpec;
+using TranslationUnit = node_impl::TranslationUnit;
 using Type = node_impl::Type;
 using Container = node_impl::type_impl::Container;
 using Primitive = node_impl::type_impl::Primitive;
@@ -44,7 +45,6 @@ using Tuple = node_impl::type_impl::container_impl::Tuple;
 using Int = node_impl::type_impl::primitive_impl::Int;
 using Float = node_impl::type_impl::primitive_impl::Float;
 using Bool = node_impl::type_impl::primitive_impl::Bool;
-using TranslationUnit = node_impl::TranslationUnit;
 }  // namespace spider::tdl::parser::ast
 
 #endif  // SPIDER_TDL_PARSER_AST_NODES_HPP

--- a/src/spider/tdl/parser/ast/nodes.hpp
+++ b/src/spider/tdl/parser/ast/nodes.hpp
@@ -9,6 +9,7 @@
 #include <spider/tdl/parser/ast/node_impl/NamedVar.hpp>
 #include <spider/tdl/parser/ast/node_impl/Namespace.hpp>
 #include <spider/tdl/parser/ast/node_impl/StructSpec.hpp>
+#include <spider/tdl/parser/ast/node_impl/TranslationUnit.hpp>
 #include <spider/tdl/parser/ast/node_impl/Type.hpp>
 #include <spider/tdl/parser/ast/node_impl/type_impl/Container.hpp>
 #include <spider/tdl/parser/ast/node_impl/type_impl/container_impl/List.hpp>
@@ -43,6 +44,7 @@ using Tuple = node_impl::type_impl::container_impl::Tuple;
 using Int = node_impl::type_impl::primitive_impl::Int;
 using Float = node_impl::type_impl::primitive_impl::Float;
 using Bool = node_impl::type_impl::primitive_impl::Bool;
+using TranslationUnit = node_impl::TranslationUnit;
 }  // namespace spider::tdl::parser::ast
 
 #endif  // SPIDER_TDL_PARSER_AST_NODES_HPP


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR adds the `TranslationUnit` AST node.

A `TranslationUnit` AST node is considered the root of a parsed tree. It contains a list of namespaces as children, and a symbol table for all the defined structs. This node is not designed to use with RAII for two reasons:

* As the root of the tree, both namespaces and struct specs will be inserted into this root node. Allowing adding nodes after the node is created makes the ANTLR actions easier to write.
* The node is supposed to be created at parsing time; however, if we want to add multi-file TDL support, we may need to add already-parsed struct specs from other translation units, which may not be at parsing time.

Due to the sharing nature of struct spec, they are not made as child nodes of a translation unit node.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [ ] Ensure all workflows pass.
* [x] Add unit tests to cover basic behaviors of `TranslationUnit` node.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
