### PR TITLE
style: Update `yscope-dev-utils` to use the clang-format v21 config; Format C++ files using clang-format v21.

### DIFF
--- a/src/spider/client/task.hpp
+++ b/src/spider/client/task.hpp
@@ -61,14 +61,16 @@ struct ConcatTaskGraphType<TaskGraph<GraphReturnType, GraphParams...>, InputType
 template <TaskIo GraphReturnType, TaskIo... GraphParams, TaskIo ReturnType, TaskIo... TaskParams>
 struct ConcatTaskGraphType<
         TaskGraph<GraphReturnType, GraphParams...>,
-        TaskFunction<ReturnType, TaskParams...>> {
+        TaskFunction<ReturnType, TaskParams...>
+> {
     using Type = TaskGraph<GraphReturnType, GraphParams..., TaskParams...>;
 };
 
 template <TaskIo GraphReturnType, TaskIo... GraphParams, TaskIo ReturnType, TaskIo... TaskParams>
 struct ConcatTaskGraphType<
         TaskGraph<GraphReturnType, GraphParams...>,
-        TaskGraph<ReturnType, TaskParams...>> {
+        TaskGraph<ReturnType, TaskParams...>
+> {
     using Type = TaskGraph<GraphReturnType, GraphParams..., TaskParams...>;
 };
 
@@ -85,8 +87,10 @@ struct MergeTaskGraphTypes<TaskGraph<ReturnType, GraphParams...>, InputType, Inp
     using Type = typename MergeTaskGraphTypes<
             typename ConcatTaskGraphType<
                     TaskGraph<ReturnType, GraphParams...>,
-                    std::remove_cvref_t<InputType>>::Type,
-            Inputs...>::Type;
+                    std::remove_cvref_t<InputType>
+            >::Type,
+            Inputs...
+    >::Type;
 };
 
 template <TaskIo ReturnType, RunnableOrTaskIo... Inputs>

--- a/src/spider/core/TaskGraphImpl.hpp
+++ b/src/spider/core/TaskGraphImpl.hpp
@@ -147,8 +147,8 @@ public:
         Task task{function_name.value()};
         // Add task inputs
         for_n<sizeof...(TaskParams)>([&](auto i) {
-            using T = std::remove_cvref_t<
-                    std::tuple_element_t<i.cValue, std::tuple<TaskParams...>>>;
+            using T = std::
+                    remove_cvref_t<std::tuple_element_t<i.cValue, std::tuple<TaskParams...>>>;
             if constexpr (cIsSpecializationV<T, spider::Data>) {
                 task.add_input(TaskInput{typeid(spider::core::Data).name()});
             } else {

--- a/src/spider/io/Serializer.hpp
+++ b/src/spider/io/Serializer.hpp
@@ -43,9 +43,7 @@ struct msgpack::adaptor::pack<boost::uuids::uuid> {
 
 template <class Buffer, class T>
 concept Packable = requires(Buffer buffer, T t) {
-    {
-        msgpack::pack(buffer, t)
-    };
+    { msgpack::pack(buffer, t) };
 };
 
 template <class T>
@@ -53,9 +51,7 @@ concept SerializableImpl = Packable<msgpack::sbuffer, T>;
 
 template <class T>
 concept DeSerializableImpl = requires(T t) {
-    {
-        msgpack::object{}.convert(t)
-    };
+    { msgpack::object{}.convert(t) };
 };
 
 template <class T>

--- a/src/spider/storage/mysql/MySqlStorage.cpp
+++ b/src/spider/storage/mysql/MySqlStorage.cpp
@@ -433,9 +433,10 @@ auto MySqlMetadataStorage::add_job(
             add_task(static_cast<MySqlConnection&>(conn), job_id_bytes, *task, TaskState::Ready);
             for (boost::uuids::uuid const id : task_graph.get_child_tasks(task_id)) {
                 std::vector<boost::uuids::uuid> const parents = task_graph.get_parent_tasks(id);
-                if (std::ranges::all_of(parents, [&](boost::uuids::uuid const& parent) {
-                        return heads.contains(parent);
-                    }))
+                if (std::ranges::all_of(
+                            parents,
+                            [&](boost::uuids::uuid const& parent) { return heads.contains(parent); }
+                    ))
                 {
                     queue.push_back(id);
                 }
@@ -456,9 +457,12 @@ auto MySqlMetadataStorage::add_job(
                 add_task(static_cast<MySqlConnection&>(conn), job_id_bytes, *task, std::nullopt);
                 for (boost::uuids::uuid const id : task_graph.get_child_tasks(task_id)) {
                     std::vector<boost::uuids::uuid> const parents = task_graph.get_parent_tasks(id);
-                    if (std::ranges::all_of(parents, [&](boost::uuids::uuid const& parent) {
-                            return heads.contains(parent);
-                        }))
+                    if (std::ranges::all_of(
+                                parents,
+                                [&](boost::uuids::uuid const& parent) {
+                                    return heads.contains(parent);
+                                }
+                        ))
                     {
                         queue.push_back(id);
                     }
@@ -561,9 +565,10 @@ auto MySqlMetadataStorage::add_job_batch(
             );
             for (boost::uuids::uuid const id : task_graph.get_child_tasks(task_id)) {
                 std::vector<boost::uuids::uuid> const parents = task_graph.get_parent_tasks(id);
-                if (std::ranges::all_of(parents, [&](boost::uuids::uuid const& parent) {
-                        return heads.contains(parent);
-                    }))
+                if (std::ranges::all_of(
+                            parents,
+                            [&](boost::uuids::uuid const& parent) { return heads.contains(parent); }
+                    ))
                 {
                     queue.push_back(id);
                 }
@@ -589,9 +594,12 @@ auto MySqlMetadataStorage::add_job_batch(
                 );
                 for (boost::uuids::uuid const id : task_graph.get_child_tasks(task_id)) {
                     std::vector<boost::uuids::uuid> const parents = task_graph.get_parent_tasks(id);
-                    if (std::ranges::all_of(parents, [&](boost::uuids::uuid const& parent) {
-                            return heads.contains(parent);
-                        }))
+                    if (std::ranges::all_of(
+                                parents,
+                                [&](boost::uuids::uuid const& parent) {
+                                    return heads.contains(parent);
+                                }
+                        ))
                     {
                         queue.push_back(id);
                     }

--- a/src/spider/tdl/parser/ast/node_impl/Function.hpp
+++ b/src/spider/tdl/parser/ast/node_impl/Function.hpp
@@ -86,7 +86,8 @@ public:
     requires(std::is_invocable_r_v<
              ystdlib::error_handling::Result<void>,
              ParamVisitor,
-             NamedVar const&>)
+             NamedVar const&
+    >)
     [[nodiscard]] auto visit_params(ParamVisitor visitor) const
             -> ystdlib::error_handling::Result<void> {
         for (size_t child_idx{get_num_non_param_children()}; child_idx < get_num_children();

--- a/src/spider/tdl/parser/ast/node_impl/Namespace.hpp
+++ b/src/spider/tdl/parser/ast/node_impl/Namespace.hpp
@@ -73,7 +73,8 @@ public:
     requires(std::is_invocable_r_v<
              ystdlib::error_handling::Result<void>,
              FuncVisitor,
-             Function const&>)
+             Function const&
+    >)
     [[nodiscard]] auto visit_functions(FuncVisitor visitor) const
             -> ystdlib::error_handling::Result<void> {
         for (size_t child_idx{1}; child_idx < get_num_children(); ++child_idx) {

--- a/src/spider/tdl/parser/ast/node_impl/StructSpec.hpp
+++ b/src/spider/tdl/parser/ast/node_impl/StructSpec.hpp
@@ -73,7 +73,8 @@ public:
     requires(std::is_invocable_r_v<
              ystdlib::error_handling::Result<void>,
              FieldVisitor,
-             NamedVar const&>)
+             NamedVar const&
+    >)
     [[nodiscard]] auto visit_fields(FieldVisitor visitor) const
             -> ystdlib::error_handling::Result<void> {
         for (size_t child_idx{1}; child_idx < get_num_children(); ++child_idx) {

--- a/src/spider/worker/FunctionManager.hpp
+++ b/src/spider/worker/FunctionManager.hpp
@@ -44,8 +44,8 @@ using ArgsBuffer = msgpack::sbuffer;
 
 using ResultBuffer = msgpack::sbuffer;
 
-using Function = std::function<
-        ResultBuffer(TaskContext& context, boost::uuids::uuid task_id, ArgsBuffer const&)>;
+using Function = std::
+        function<ResultBuffer(TaskContext& context, boost::uuids::uuid task_id, ArgsBuffer const&)>;
 
 using FunctionMap = std::vector<std::pair<std::string, Function>>;
 

--- a/src/spider/worker/TaskExecutor.hpp
+++ b/src/spider/worker/TaskExecutor.hpp
@@ -46,7 +46,8 @@ public:
             std::vector<std::string> const& libs,
             absl::flat_hash_map<
                     boost::process::v2::environment::key,
-                    boost::process::v2::environment::value> const& environment,
+                    boost::process::v2::environment::value
+            > const& environment,
             Args&&... args
     )
             : m_read_pipe(context),
@@ -104,7 +105,8 @@ public:
             std::vector<std::string> const& libs,
             absl::flat_hash_map<
                     boost::process::v2::environment::key,
-                    boost::process::v2::environment::value> const& environment,
+                    boost::process::v2::environment::value
+            > const& environment,
             std::vector<msgpack::sbuffer> const& args_buffers
     )
             : m_read_pipe(context),

--- a/src/spider/worker/worker.cpp
+++ b/src/spider/worker/worker.cpp
@@ -104,7 +104,8 @@ auto parse_args(int const argc, char** argv) -> boost::program_options::variable
 
 auto get_environment_variable() -> absl::flat_hash_map<
         boost::process::v2::environment::key,
-        boost::process::v2::environment::value> {
+        boost::process::v2::environment::value
+> {
     boost::filesystem::path const executable_dir = boost::dll::program_location().parent_path();
 
     // NOLINTNEXTLINE(concurrency-mt-unsafe)
@@ -115,7 +116,8 @@ auto get_environment_variable() -> absl::flat_hash_map<
 
     absl::flat_hash_map<
             boost::process::v2::environment::key,
-            boost::process::v2::environment::value>
+            boost::process::v2::environment::value
+    >
             environment_variables;
 
     environment_variables.emplace("PATH", path_env);
@@ -350,7 +352,8 @@ auto task_loop(
         std::vector<std::string> const& libs,
         absl::flat_hash_map<
                 boost::process::v2::environment::key,
-                boost::process::v2::environment::value> const& environment
+                boost::process::v2::environment::value
+        > const& environment
 ) -> void {
     std::optional<boost::uuids::uuid> fail_task_id = std::nullopt;
     while (!spider::core::StopFlag::is_stop_requested()) {
@@ -499,7 +502,8 @@ auto main(int argc, char** argv) -> int {
 
     absl::flat_hash_map<
             boost::process::v2::environment::key,
-            boost::process::v2::environment::value> const environment_variables
+            boost::process::v2::environment::value
+    > const environment_variables
             = get_environment_variable();
 
     // Start a thread that periodically updates the scheduler's heartbeat

--- a/tests/utils/CoreTaskUtils.cpp
+++ b/tests/utils/CoreTaskUtils.cpp
@@ -99,12 +99,15 @@ auto hash_map_equal(
         return false;
     }
 
-    if (std::ranges::any_of(map_1, [&map_2, &value_equal](auto const& pair_1) -> bool {
-            if (auto const& iter_2 = map_2.find(pair_1.first); iter_2 != map_2.cend()) {
-                return !value_equal(pair_1.second, iter_2->second);
-            }
-            return true;
-        }))
+    if (std::ranges::any_of(
+                map_1,
+                [&map_2, &value_equal](auto const& pair_1) -> bool {
+                    if (auto const& iter_2 = map_2.find(pair_1.first); iter_2 != map_2.cend()) {
+                        return !value_equal(pair_1.second, iter_2->second);
+                    }
+                    return true;
+                }
+        ))
     {
         return false;
     }

--- a/tests/worker/test-TaskExecutor.cpp
+++ b/tests/worker/test-TaskExecutor.cpp
@@ -36,7 +36,8 @@
 namespace {
 auto get_environment_variable() -> absl::flat_hash_map<
         boost::process::v2::environment::key,
-        boost::process::v2::environment::value> {
+        boost::process::v2::environment::value
+> {
     boost::filesystem::path const executable_dir = boost::dll::program_location().parent_path();
     boost::filesystem::path const src_dir = executable_dir.parent_path() / "src" / "spider";
 
@@ -48,7 +49,8 @@ auto get_environment_variable() -> absl::flat_hash_map<
 
     absl::flat_hash_map<
             boost::process::v2::environment::key,
-            boost::process::v2::environment::value>
+            boost::process::v2::environment::value
+    >
             environment_variables;
 
     environment_variables.emplace("PATH", path_env);
@@ -69,7 +71,8 @@ TEMPLATE_LIST_TEST_CASE(
 ) {
     absl::flat_hash_map<
             boost::process::v2::environment::key,
-            boost::process::v2::environment::value> const environment_variable
+            boost::process::v2::environment::value
+    > const environment_variable
             = get_environment_variable();
 
     boost::asio::io_context context;
@@ -101,7 +104,8 @@ TEMPLATE_LIST_TEST_CASE(
 ) {
     absl::flat_hash_map<
             boost::process::v2::environment::key,
-            boost::process::v2::environment::value> const environment_variable
+            boost::process::v2::environment::value
+    > const environment_variable
             = get_environment_variable();
 
     boost::asio::io_context context;
@@ -131,7 +135,8 @@ TEMPLATE_LIST_TEST_CASE(
 ) {
     absl::flat_hash_map<
             boost::process::v2::environment::key,
-            boost::process::v2::environment::value> const environment_variable
+            boost::process::v2::environment::value
+    > const environment_variable
             = get_environment_variable();
 
     boost::asio::io_context context;
@@ -195,7 +200,8 @@ TEMPLATE_LIST_TEST_CASE(
 
     absl::flat_hash_map<
             boost::process::v2::environment::key,
-            boost::process::v2::environment::value> const environment_variable
+            boost::process::v2::environment::value
+    > const environment_variable
             = get_environment_variable();
 
     boost::asio::io_context context;
@@ -233,7 +239,8 @@ TEMPLATE_LIST_TEST_CASE(
 ) {
     absl::flat_hash_map<
             boost::process::v2::environment::key,
-            boost::process::v2::environment::value> const environment_variable
+            boost::process::v2::environment::value
+    > const environment_variable
             = get_environment_variable();
 
     boost::asio::io_context context;


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
Clang-format 21 introduces new options and some breaking changes with existing ones. `yscope-dev-utils` has been updated (https://github.com/y-scope/yscope-dev-utils/pull/82) to add new options and tune existing ones.

This PR updates `yscope-dev-utils` to latest version (3ff7d055) and reformats the C++ codes accordingly.



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* [x] C++ code reformatted as expected.
* [x] GitHub workflows pass.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Applied consistent formatting to templates, concepts, and lambdas across the codebase with no behavioural changes.
- Tests
  - Reformatted test utilities and TaskExecutor-related tests; no changes to test logic or coverage.
- Chores
  - Updated developer utilities submodule to a newer revision.
- Refactor
  - Minor code reflow in internal type aliases and constructors to improve readability; no API or runtime impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->