### PR TITLE
feat(tdl): Add `StructSpecDependencyGraph` to represent the dependencies among defined structs as a graph.

### DIFF
--- a/src/spider/CMakeLists.txt
+++ b/src/spider/CMakeLists.txt
@@ -227,6 +227,7 @@ set(SPIDER_TDL_SHARED_SOURCES
     tdl/parser/ast/node_impl/type_impl/Struct.cpp
     tdl/parser/ast/utils.cpp
     tdl/parser/parse.cpp
+    tdl/pass/analysis/StructSpecDependencyGraph.cpp
     CACHE INTERNAL
     "spider task definition language shared source files"
 )
@@ -258,6 +259,7 @@ set(SPIDER_TDL_SHARED_HEADERS
     tdl/parser/Exception.hpp
     tdl/parser/parse.hpp
     tdl/parser/SourceLocation.hpp
+    tdl/pass/analysis/StructSpecDependencyGraph.hpp
     CACHE INTERNAL
     "spider task definition language shared header files"
 )

--- a/src/spider/tdl/parser/ast/node_impl/TranslationUnit.hpp
+++ b/src/spider/tdl/parser/ast/node_impl/TranslationUnit.hpp
@@ -82,8 +82,8 @@ public:
             -> ystdlib::error_handling::Result<void>;
 
     /**
-     * Creates a dependency graph of struct specs defined in this translation unit.
-     * @return The struct spec dependency graph.
+     * @return A newly constructed dependency graph of struct specs defined in this translation
+     * unit.
      */
     [[nodiscard]] auto create_struct_spec_dependency_graph() const
             -> pass::analysis::StructSpecDependencyGraph {

--- a/src/spider/tdl/parser/ast/node_impl/TranslationUnit.hpp
+++ b/src/spider/tdl/parser/ast/node_impl/TranslationUnit.hpp
@@ -14,6 +14,7 @@
 #include <spider/tdl/parser/ast/Node.hpp>
 #include <spider/tdl/parser/ast/node_impl/StructSpec.hpp>
 #include <spider/tdl/parser/SourceLocation.hpp>
+#include <spider/tdl/pass/analysis/StructSpecDependencyGraph.hpp>
 
 namespace spider::tdl::parser::ast::node_impl {
 /**
@@ -79,6 +80,15 @@ public:
      */
     [[nodiscard]] auto add_namespace(std::unique_ptr<Node> namespace_node)
             -> ystdlib::error_handling::Result<void>;
+
+    /**
+     * Creates a dependency graph of struct specs defined in this translation unit.
+     * @return The struct spec dependency graph.
+     */
+    [[nodiscard]] auto create_struct_spec_dependency_graph() const
+            -> pass::analysis::StructSpecDependencyGraph {
+        return pass::analysis::StructSpecDependencyGraph{m_struct_spec_table};
+    }
 
 private:
     // Constructor

--- a/src/spider/tdl/pass/analysis/StructSpecDependencyGraph.cpp
+++ b/src/spider/tdl/pass/analysis/StructSpecDependencyGraph.cpp
@@ -1,0 +1,59 @@
+#include "StructSpecDependencyGraph.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <set>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include <absl/container/flat_hash_map.h>
+#include <ystdlib/error_handling/Result.hpp>
+
+#include <spider/tdl/parser/ast/nodes.hpp>
+
+namespace spider::tdl::pass::analysis {
+StructSpecDependencyGraph::StructSpecDependencyGraph(
+        absl::flat_hash_map<std::string, std::shared_ptr<StructSpec const>> const& struct_specs
+) {
+    auto const num_struct_specs{struct_specs.size()};
+
+    // Initialize the graph nodes and their ids
+    m_struct_spec_refs.reserve(num_struct_specs);
+    m_struct_spec_ids.reserve(num_struct_specs);
+    for (auto const& [_, struct_spec] : struct_specs) {
+        m_struct_spec_refs.emplace_back(struct_spec);
+        m_struct_spec_ids.emplace(struct_spec.get(), m_struct_spec_ids.size());
+    }
+
+    // Build def-use chains
+    m_def_use_chains.reserve(num_struct_specs);
+    for (auto const& [_, struct_spec] : struct_specs) {
+        std::set<size_t> use_ids;
+        auto field_visitor
+                = [&](parser::ast::NamedVar const& field) -> ystdlib::error_handling::Result<void> {
+            auto const* type_as_struct{dynamic_cast<parser::ast::Struct const*>(field.get_type())};
+            if (nullptr == type_as_struct) {
+                return ystdlib::error_handling::success();
+            }
+
+            auto const struct_name{type_as_struct->get_name()};
+            auto const it{struct_specs.find(struct_name)};
+            if (struct_specs.cend() == it) {
+                // This is a dangling reference, which will be caught in other analysis pass. In
+                // this dependency graph, we just ignore it.
+                return ystdlib::error_handling::success();
+            }
+
+            auto const use_id{m_struct_spec_ids.at(it->second.get())};
+            use_ids.emplace(use_id);
+            return ystdlib::error_handling::success();
+        };
+
+        auto const* def{struct_spec.get()};
+        std::ignore = def->visit_fields(field_visitor);
+        auto const def_id{m_struct_spec_ids.at(def)};
+        m_def_use_chains.emplace(def_id, std::vector<size_t>{use_ids.cbegin(), use_ids.cend()});
+    }
+}
+}  // namespace spider::tdl::pass::analysis

--- a/src/spider/tdl/pass/analysis/StructSpecDependencyGraph.hpp
+++ b/src/spider/tdl/pass/analysis/StructSpecDependencyGraph.hpp
@@ -45,7 +45,7 @@ private:
     // Variables
     std::vector<std::shared_ptr<StructSpec const>> m_struct_spec_refs;
     absl::flat_hash_map<StructSpec const*, size_t> m_struct_spec_ids;
-    absl::flat_hash_map<size_t, std::vector<size_t>> m_def_use_chains;
+    std::vector<std::vector<size_t>> m_def_use_chains;
 };
 }  // namespace spider::tdl::pass::analysis
 

--- a/src/spider/tdl/pass/analysis/StructSpecDependencyGraph.hpp
+++ b/src/spider/tdl/pass/analysis/StructSpecDependencyGraph.hpp
@@ -1,0 +1,52 @@
+#ifndef SPIDER_TDL_PASS_ANALYSIS_STRUCTSPECDEPENDENCYGRAPH_HPP
+#define SPIDER_TDL_PASS_ANALYSIS_STRUCTSPECDEPENDENCYGRAPH_HPP
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <absl/container/flat_hash_map.h>
+
+#include <spider/tdl/parser/ast/node_impl/StructSpec.hpp>
+
+namespace spider::tdl::pass::analysis {
+/**
+ * Represents a dependency graph of struct specifications defined in a translation unit.
+ */
+class StructSpecDependencyGraph {
+public:
+    // Types
+    using StructSpec = parser::ast::node_impl::StructSpec;
+
+    // Constructors
+    /**
+     * @param struct_specs A map from struct names to their corresponding `StructSpec` objects.
+     */
+    explicit StructSpecDependencyGraph(
+            absl::flat_hash_map<std::string, std::shared_ptr<StructSpec const>> const& struct_specs
+    );
+
+    // Delete copy constructor and assignment operator
+    StructSpecDependencyGraph(StructSpecDependencyGraph const&) = delete;
+    auto operator=(StructSpecDependencyGraph const&) -> StructSpecDependencyGraph& = delete;
+
+    // Default move constructor and assignment operator
+    StructSpecDependencyGraph(StructSpecDependencyGraph&&) = default;
+    auto operator=(StructSpecDependencyGraph&&) -> StructSpecDependencyGraph& = default;
+
+    // Destructor
+    ~StructSpecDependencyGraph() = default;
+
+    // Methods
+    [[nodiscard]] auto get_num_struct_specs() const -> size_t { return m_struct_spec_refs.size(); }
+
+private:
+    // Variables
+    std::vector<std::shared_ptr<StructSpec const>> m_struct_spec_refs;
+    absl::flat_hash_map<StructSpec const*, size_t> m_struct_spec_ids;
+    absl::flat_hash_map<size_t, std::vector<size_t>> m_def_use_chains;
+};
+}  // namespace spider::tdl::pass::analysis
+
+#endif  // SPIDER_TDL_PASS_ANALYSIS_STRUCTSPECDEPENDENCYGRAPH_HPP

--- a/tests/tdl/test-parser.cpp
+++ b/tests/tdl/test-parser.cpp
@@ -271,6 +271,11 @@ TEST_CASE("Parsing `cTestInput1`", "[tdl][parser]") {
     auto const serialize_result{translation_unit->serialize_to_str(0)};
     REQUIRE_FALSE(serialize_result.has_error());
     REQUIRE(serialize_result.value() == cExpectedSerializedAst);
+
+    auto const struct_spec_dependency_graph{
+            translation_unit->create_struct_spec_dependency_graph()
+    };
+    REQUIRE(struct_spec_dependency_graph.get_num_struct_specs() == 2);
 }
 
 TEST_CASE("Parser errors", "[tdl][parser]") {


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR adds a new class, `StructSpecDependencyGraph`, to represent the dependencies among defined structs as a graph. It is added under the namespace `tdl/pass/analysis` since this graph will be used in analysis passes. In future PRs, we will extend this class to:
- Compute the SCC within the dependency graph so that we can report circular dependencies efficiently.
- Compute the topological sort result of the graph so that the generated code can lay out code in a define-before-use manner.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Ensure all workflows passed.
* [x] Manually checked the generated graph matches the expected result. Didn't add unit tests for the graph generation. Will add unit tests when SCC computation is added.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a public dependency graph for struct specifications to analyse relationships between structures.
  - Graph can be constructed from a translation unit and exposes a method to get the total number of struct specifications.

- **Tests**
  - Added tests that build the dependency graph from parsed input and verify expected struct counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->