### PR TITLE
feat(tdl): Add support for sorting struct specs in Topological ordering in `StructSpecDependencyGraph`.

### DIFF
--- a/src/spider/tdl/pass/analysis/StructSpecDependencyGraph.hpp
+++ b/src/spider/tdl/pass/analysis/StructSpecDependencyGraph.hpp
@@ -52,6 +52,15 @@ public:
         return m_strongly_connected_components.value();
     }
 
+    /**
+     * @return A topological ordering of the struct specifications if the dependency graph is a DAG.
+     * The returned ordering also maintains lexicographical precedence among all valid topological
+     * orderings.
+     * @return std::nullopt if the dependency graph is not a DAG.
+     */
+    [[nodiscard]] auto get_struct_specs_in_topological_ordering()
+            -> std::optional<std::vector<size_t>>;
+
     [[nodiscard]] auto get_def_use_chains() const -> std::vector<std::vector<size_t>> const& {
         return m_def_use_chains;
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR adds support for sorting struct specs in Topological ordering in `StructSpecDependencyGraph`. In such a sorting procedure, we also preserve the lexicographical precedence so that the sorted result will be deterministic when serializing to the struct spec names.

Notice that Topological ordering only exists if the dependency graph is a DAG. We use the SCC detection mechanism introduced in #222 to check non-trivial SCCs before sorting.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Ensure all workflows pass.
* [x] Add a new unit test case to check the Topological ordering matches the expected one.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added the ability to obtain a deterministic topological order of struct specifications when dependencies are acyclic, with clear signalling when cycles prevent ordering. Enhances predictability for downstream processing.

* Documentation
  * Expanded API documentation to explain the new ordering capability and its behaviour in cyclic graphs.

* Tests
  * Added acyclic and cyclic scenarios validating ordering availability and correctness; refined test naming for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->