### PR TITLE
build: Allow configuring the CMake dependency file path via the `SPIDER_CMAKE_DEPENDENCY_FILE` CMake variable.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,9 +40,9 @@ set(CMAKE_MODULE_PATH
 )
 
 # Set the project dependency file path
-set(CMAKE_DEPENDENCY_FILE "" CACHE STRING "The cmake dependency file to include.")
-if(NOT CMAKE_DEPENDENCY_FILE STREQUAL "")
-    include("${CMAKE_DEPENDENCY_FILE}")
+set(SPIDER_CMAKE_DEPENDENCY_FILE "" CACHE STRING "The cmake dependency file to include.")
+if(NOT SPIDER_CMAKE_DEPENDENCY_FILE STREQUAL "")
+    include("${SPIDER_CMAKE_DEPENDENCY_FILE}")
 endif()
 
 # Profiling options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,16 @@ set(CMAKE_MODULE_PATH
     "${PROJECT_SOURCE_DIR}/cmake/Modules/"
 )
 
+# Set the project dependency file path
+set(CMAKE_DEPENDENCY_FILE
+    ""
+    CACHE STRING
+    "The cmake dependency file to include."
+)
+if (DEFINED CMAKE_DEPENDENCY_FILE AND NOT CMAKE_DEPENDENCY_FILE STREQUAL "")
+    include("${CMAKE_DEPENDENCY_FILE}")
+endif()
+
 # Profiling options
 add_definitions(-DPROF_ENABLED=0)
 
@@ -79,15 +89,8 @@ else()
 endif()
 message(STATUS "Building using ${SPIDER_LIBS_STRING} libraries")
 
-if(PROJECT_IS_TOP_LEVEL)
-    # Include dependency settings if the project isn't being included as a subproject.
-    include("build/deps/cmake-settings/all.cmake")
-
-    # If previously undefined, `BUILD_TESTING` will be set to ON.
+if(SPIDER_BUILD_TESTING)
     include(CTest)
-endif()
-
-if(BUILD_TESTING AND SPIDER_BUILD_TESTING)
     set(SPIDER_ENABLE_TESTS ON)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ set(CMAKE_MODULE_PATH
 
 # Set the project dependency file path
 set(CMAKE_DEPENDENCY_FILE "" CACHE STRING "The cmake dependency file to include.")
-if(DEFINED CMAKE_DEPENDENCY_FILE AND NOT CMAKE_DEPENDENCY_FILE STREQUAL "")
+if(NOT CMAKE_DEPENDENCY_FILE STREQUAL "")
     include("${CMAKE_DEPENDENCY_FILE}")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,12 +40,8 @@ set(CMAKE_MODULE_PATH
 )
 
 # Set the project dependency file path
-set(CMAKE_DEPENDENCY_FILE
-    ""
-    CACHE STRING
-    "The cmake dependency file to include."
-)
-if (DEFINED CMAKE_DEPENDENCY_FILE AND NOT CMAKE_DEPENDENCY_FILE STREQUAL "")
+set(CMAKE_DEPENDENCY_FILE "" CACHE STRING "The cmake dependency file to include.")
+if(DEFINED CMAKE_DEPENDENCY_FILE AND NOT CMAKE_DEPENDENCY_FILE STREQUAL "")
     include("${CMAKE_DEPENDENCY_FILE}")
 endif()
 

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -30,7 +30,7 @@ vars:
   G_DEPS_DIR: "{{.G_BUILD_DIR}}/deps"
   # These should be kept in-sync with its usage in CMakeLists.txt
   G_DEPS_CMAKE_SETTINGS_DIR: "{{.G_DEPS_DIR}}/cmake-settings"
-  G_DEPS_CMAKE_SETTINGS_FILE: "{{.G_DEPS_CMAKE_SETTINGS_DIR}}/settings.cmake"
+  G_DEPS_CMAKE_SETTINGS_FILE: "{{.G_DEPS_CMAKE_SETTINGS_DIR}}/all.cmake"
 
 tasks:
   clean:
@@ -49,7 +49,10 @@ tasks:
       - "{{.G_EXAMPLES_CMAKE_CACHE}}"
       - "{{.G_EXAMPLES_COMPILE_COMMANDS_DB}}"
     cmds:
-      - "cmake -S '{{.ROOT_DIR}}' -B '{{.G_BUILD_SPIDER_DIR}}'"
+      - >-
+       cmake -S '{{.ROOT_DIR}}'
+       -DCMAKE_DEPENDENCY_FILE='{{.G_DEPS_CMAKE_SETTINGS_FILE}}'
+       -B '{{.G_BUILD_SPIDER_DIR}}'
       - "cmake -S '{{.ROOT_DIR}}/examples/quick-start' -B '{{.G_BUILD_EXAMPLES_DIR}}'"
 
   init:

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -30,7 +30,7 @@ vars:
   G_DEPS_DIR: "{{.G_BUILD_DIR}}/deps"
   # These should be kept in-sync with its usage in CMakeLists.txt
   G_DEPS_CMAKE_SETTINGS_DIR: "{{.G_DEPS_DIR}}/cmake-settings"
-  G_DEPS_CMAKE_SETTINGS_FILE: "{{.G_DEPS_CMAKE_SETTINGS_DIR}}/all.cmake"
+  G_CMAKE_DEPENDENCY_FILE: "{{.G_DEPS_CMAKE_SETTINGS_DIR}}/all.cmake"
 
 tasks:
   clean:
@@ -51,7 +51,7 @@ tasks:
     cmds:
       - >-
        cmake -S '{{.ROOT_DIR}}'
-       -DCMAKE_DEPENDENCY_FILE='{{.G_DEPS_CMAKE_SETTINGS_FILE}}'
+       -DCMAKE_DEPENDENCY_FILE='{{.G_CMAKE_DEPENDENCY_FILE}}'
        -B '{{.G_BUILD_SPIDER_DIR}}'
       - "cmake -S '{{.ROOT_DIR}}/examples/quick-start' -B '{{.G_BUILD_EXAMPLES_DIR}}'"
 

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -51,7 +51,7 @@ tasks:
     cmds:
       - >-
        cmake -S '{{.ROOT_DIR}}'
-       -DCMAKE_DEPENDENCY_FILE='{{.G_CMAKE_DEPENDENCY_FILE}}'
+       -DSPIDER_CMAKE_DEPENDENCY_FILE='{{.G_CMAKE_DEPENDENCY_FILE}}'
        -B '{{.G_BUILD_SPIDER_DIR}}'
       - "cmake -S '{{.ROOT_DIR}}/examples/quick-start' -B '{{.G_BUILD_EXAMPLES_DIR}}'"
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

## Problem
Previously, the `CMake` was setup to include hard-coded dependency cmake file if the `spider` is not configured as top level project. This works when `spider` is included as a submodule. However, if `spider` is built as a package, user has no way to tell `spider`'s `cmake` to look for the dependency file at another location.

## Solution
This PR creates a `cmake` variable `CMAKE_DEPENDENCY_FILE` to store the path to the dependency file. The build task is modified to set this variable to the previously hard-coded path. User could set this variable at `cmake` configuration time.

This PR also avoids including `CTest` if the project is top level, leaving whether to setup test to the existing variable `SPIDER_BUILD_TESTING` alone.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
* [x] The project builds with new setup.
* [ ] GitHub workflows pass.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional cache setting to specify an external CMake dependency file.

* **Chores**
  * Test gating simplified: test tooling is included when project testing is enabled; test enablement still requires both global and project testing flags.
  * Updated default dependency reference to a consolidated configuration file.
  * Streamlined configuration workflow: single setup now configures core project and Quick‑Start examples together.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->