### PR TITLE
feat(spider-py): Add support for deserializing output type names from `bytes`.

### DIFF
--- a/python/spider-py/src/spider_py/client/job.py
+++ b/python/spider-py/src/spider_py/client/job.py
@@ -53,10 +53,10 @@ def _deserialize_outputs(outputs: list[core.TaskOutput]) -> tuple[object, ...] |
     results = []
     for output in outputs:
         if isinstance(output.value, core.TaskOutputValue):
-            output_type = output.type
-            if isinstance(output_type, bytes):
-                output_type = output_type.decode("utf-8")
-            cls = parse_tdl_type(output_type).native_type()
+            type_name = output.type
+            if isinstance(type_name, bytes):
+                type_name = type_name.decode("utf-8")
+            cls = parse_tdl_type(type_name).native_type()
             unpacked = msgpack.unpackb(output.value, raw=False, strict_map_key=False)
             results.append(from_serializable(cls, unpacked))
         elif isinstance(output.value, core.Data):


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
## Background
`TaskOutput.type` sometime could contains `bytes` instead of `str`, if user's metadata storage uses `VARBINARY` or `BLOB` instead of `VARCHAR` for the type column. This value will be feed into lark parsing, which only accepts `str` input, and thus crash.

## Solution
This PR adds support for `bytes` by checking the type of the `TaskOutput.type` and decodes `bytes` using `utf-8`.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* [x] Python integration tests pass.
* [x] Using `BLOB` for type column in MariaDB works.
* [x] GitHub workflows pass.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deserialization to correctly handle type information provided as raw bytes by decoding it to UTF-8 before parsing, preventing type-related errors and ensuring consistent processing of outputs regardless of format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->