### PR TITLE
refactor(worker): Rewrite task executor.

### DIFF
--- a/src/spider/worker/TaskExecutor.cpp
+++ b/src/spider/worker/TaskExecutor.cpp
@@ -64,6 +64,7 @@ auto TaskExecutor::spawn_cpp_executor(
         process_args.insert(process_args.end(), libs.cbegin(), libs.cend());
     }
 
+    // Must use `new` because `make_unique` cannot access the private constructor.
     auto executor = std::unique_ptr<TaskExecutor>(new TaskExecutor(
             context,
             output_pipe_read_end,
@@ -125,6 +126,7 @@ auto TaskExecutor::spawn_python_executor(
             storage_url,
     };
 
+    // Must use `new` because `make_unique` cannot access the private constructor.
     auto executor = std::unique_ptr<TaskExecutor>(new TaskExecutor(
             context,
             output_pipe_read_end,

--- a/src/spider/worker/TaskExecutor.cpp
+++ b/src/spider/worker/TaskExecutor.cpp
@@ -15,9 +15,7 @@
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <fmt/format.h>
-#include <spdlog/spdlog.h>
 
-#include <spider/core/Task.hpp>
 #include <spider/io/BoostAsio.hpp>  // IWYU pragma: keep
 #include <spider/io/MsgPack.hpp>  // IWYU pragma: keep
 #include <spider/utils/pipe.hpp>
@@ -27,11 +25,14 @@
 #include <spider/worker/TaskExecutorMessage.hpp>
 
 namespace spider::worker {
-TaskExecutor::TaskExecutor(
+TaskExecutor::TaskExecutor(boost::asio::io_context& context)
+        : m_read_pipe{context},
+          m_write_pipe{context} {}
+
+auto TaskExecutor::spawn_cpp_executor(
         boost::asio::io_context& context,
         std::string const& func_name,
         boost::uuids::uuid const task_id,
-        core::TaskLanguage const language,
         std::string const& storage_url,
         std::vector<std::string> const& libs,
         absl::flat_hash_map<
@@ -39,11 +40,14 @@ TaskExecutor::TaskExecutor(
                 boost::process::v2::environment::value
         > const& environment,
         std::vector<msgpack::sbuffer> const& args_buffers
-)
-        : m_read_pipe(context),
-          m_write_pipe(context) {
+) -> std::unique_ptr<TaskExecutor> {
+    auto executor = std::unique_ptr<TaskExecutor>(new TaskExecutor(context));
+
     auto const [input_pipe_read_end, input_pipe_write_end] = core::create_pipe();
     auto const [output_pipe_read_end, output_pipe_write_end] = core::create_pipe();
+
+    boost::filesystem::path const exe
+            = boost::process::v2::environment::find_executable("spider_task_executor", environment);
 
     std::vector<std::string> process_args{
             "--func",
@@ -61,31 +65,10 @@ TaskExecutor::TaskExecutor(
         process_args.emplace_back("--libs");
         process_args.insert(process_args.end(), libs.cbegin(), libs.cend());
     }
-    boost::filesystem::path exe;
-    switch (language) {
-        case core::TaskLanguage::Cpp: {
-            exe = boost::process::v2::environment::find_executable(
-                    "spider_task_executor",
-                    environment
-            );
-            break;
-        }
-        case core::TaskLanguage::Python: {
-            exe = boost::process::v2::environment::find_executable(
-                    "spider-py-task-executor",
-                    environment
-            );
-            break;
-        }
-        default: {
-            spdlog::error("Unsupported task language.");
-            return;
-        }
-    }
 
-    m_write_pipe.assign(input_pipe_write_end);
-    m_read_pipe.assign(output_pipe_read_end);
-    m_process = std::make_unique<Process>(Process::spawn(
+    executor->m_write_pipe.assign(input_pipe_write_end);
+    executor->m_read_pipe.assign(output_pipe_read_end);
+    executor->m_process = std::make_unique<Process>(Process::spawn(
             exe.string(),
             process_args,
             std::nullopt,
@@ -98,11 +81,71 @@ TaskExecutor::TaskExecutor(
     close(output_pipe_write_end);
 
     // Set up handler for output file
-    boost::asio::co_spawn(context, process_output_handler(), boost::asio::detached);
+    boost::asio::co_spawn(context, executor->process_output_handler(), boost::asio::detached);
 
     // Send args
     auto const args_request = core::create_args_request(args_buffers);
-    send_message(m_write_pipe, args_request);
+    send_message(executor->m_write_pipe, args_request);
+
+    return executor;
+}
+
+auto TaskExecutor::spawn_python_executor(
+        boost::asio::io_context& context,
+        std::string const& func_name,
+        boost::uuids::uuid const task_id,
+        std::string const& storage_url,
+        absl::flat_hash_map<
+                boost::process::v2::environment::key,
+                boost::process::v2::environment::value
+        > const& environment,
+        std::vector<msgpack::sbuffer> const& args_buffers
+) -> std::unique_ptr<TaskExecutor> {
+    auto executor = std::unique_ptr<TaskExecutor>(new TaskExecutor(context));
+
+    auto const [input_pipe_read_end, input_pipe_write_end] = core::create_pipe();
+    auto const [output_pipe_read_end, output_pipe_write_end] = core::create_pipe();
+
+    boost::filesystem::path const exe
+            = boost::process::v2::environment::find_executable("python3", environment);
+
+    std::vector<std::string> const process_args{
+            "-m",
+            "spider_py.task_executor.task_executor",
+            "--func",
+            func_name,
+            "--task_id",
+            to_string(task_id),
+            "--input-pipe",
+            std::to_string(input_pipe_read_end),
+            "--output-pipe",
+            std::to_string(output_pipe_write_end),
+            "--storage_url",
+            storage_url,
+    };
+
+    executor->m_write_pipe.assign(input_pipe_write_end);
+    executor->m_read_pipe.assign(output_pipe_read_end);
+    executor->m_process = std::make_unique<Process>(Process::spawn(
+            exe.string(),
+            process_args,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            {input_pipe_read_end, output_pipe_write_end}
+    ));
+    // Close the following fds since they're no longer needed by the parent process.
+    close(input_pipe_read_end);
+    close(output_pipe_write_end);
+
+    // Set up handler for output file
+    boost::asio::co_spawn(context, executor->process_output_handler(), boost::asio::detached);
+
+    // Send args
+    auto const args_request = core::create_args_request(args_buffers);
+    send_message(executor->m_write_pipe, args_request);
+
+    return executor;
 }
 
 auto TaskExecutor::get_pid() const -> pid_t {

--- a/src/spider/worker/TaskExecutor.cpp
+++ b/src/spider/worker/TaskExecutor.cpp
@@ -41,7 +41,7 @@ auto TaskExecutor::spawn_cpp_executor(
         > const& environment,
         std::vector<msgpack::sbuffer> const& args_buffers
 ) -> std::unique_ptr<TaskExecutor> {
-    boost::filesystem::path const exe
+    auto const exe
             = boost::process::v2::environment::find_executable("spider_task_executor", environment);
     if (exe.empty()) {
         return nullptr;
@@ -104,8 +104,7 @@ auto TaskExecutor::spawn_python_executor(
         > const& environment,
         std::vector<msgpack::sbuffer> const& args_buffers
 ) -> std::unique_ptr<TaskExecutor> {
-    boost::filesystem::path const exe
-            = boost::process::v2::environment::find_executable("python3", environment);
+    auto const exe = boost::process::v2::environment::find_executable("python3", environment);
     if (exe.empty()) {
         return nullptr;
     }

--- a/src/spider/worker/TaskExecutor.cpp
+++ b/src/spider/worker/TaskExecutor.cpp
@@ -275,9 +275,9 @@ TaskExecutor::TaskExecutor(
         std::unique_ptr<Process> process,
         std::vector<msgpack::sbuffer> const& args_buffers
 )
-        : m_read_pipe(context),
-          m_write_pipe(context),
-          m_process(std::move(process)) {
+        : m_read_pipe{context},
+          m_write_pipe{context},
+          m_process{std::move(process)} {
     m_read_pipe.assign(read_pipe_fd);
     m_write_pipe.assign(write_pipe_fd);
 

--- a/src/spider/worker/TaskExecutor.cpp
+++ b/src/spider/worker/TaskExecutor.cpp
@@ -41,13 +41,16 @@ auto TaskExecutor::spawn_cpp_executor(
         > const& environment,
         std::vector<msgpack::sbuffer> const& args_buffers
 ) -> std::unique_ptr<TaskExecutor> {
+    boost::filesystem::path const exe
+            = boost::process::v2::environment::find_executable("spider_task_executor", environment);
+    if (exe.empty()) {
+        return nullptr;
+    }
+
     auto executor = std::unique_ptr<TaskExecutor>(new TaskExecutor(context));
 
     auto const [input_pipe_read_end, input_pipe_write_end] = core::create_pipe();
     auto const [output_pipe_read_end, output_pipe_write_end] = core::create_pipe();
-
-    boost::filesystem::path const exe
-            = boost::process::v2::environment::find_executable("spider_task_executor", environment);
 
     std::vector<std::string> process_args{
             "--func",
@@ -101,13 +104,16 @@ auto TaskExecutor::spawn_python_executor(
         > const& environment,
         std::vector<msgpack::sbuffer> const& args_buffers
 ) -> std::unique_ptr<TaskExecutor> {
+    boost::filesystem::path const exe
+            = boost::process::v2::environment::find_executable("python3", environment);
+    if (exe.empty()) {
+        return nullptr;
+    }
+
     auto executor = std::unique_ptr<TaskExecutor>(new TaskExecutor(context));
 
     auto const [input_pipe_read_end, input_pipe_write_end] = core::create_pipe();
     auto const [output_pipe_read_end, output_pipe_write_end] = core::create_pipe();
-
-    boost::filesystem::path const exe
-            = boost::process::v2::environment::find_executable("python3", environment);
 
     std::vector<std::string> const process_args{
             "-m",

--- a/src/spider/worker/TaskExecutor.cpp
+++ b/src/spider/worker/TaskExecutor.cpp
@@ -79,6 +79,7 @@ auto TaskExecutor::spawn_cpp_executor(
             )),
             args_buffers
     ));
+
     // Close the following fds since they're no longer needed by the parent process.
     close(input_pipe_read_end);
     close(output_pipe_write_end);

--- a/src/spider/worker/TaskExecutor.cpp
+++ b/src/spider/worker/TaskExecutor.cpp
@@ -16,6 +16,7 @@
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <fmt/format.h>
+#include <spdlog/spdlog.h>
 
 #include <spider/io/BoostAsio.hpp>  // IWYU pragma: keep
 #include <spider/io/MsgPack.hpp>  // IWYU pragma: keep
@@ -41,6 +42,7 @@ auto TaskExecutor::spawn_cpp_executor(
     auto const exe
             = boost::process::v2::environment::find_executable("spider_task_executor", environment);
     if (exe.empty()) {
+        spdlog::error("Cannot find c++ task executor");
         return nullptr;
     }
 
@@ -100,6 +102,7 @@ auto TaskExecutor::spawn_python_executor(
 ) -> std::unique_ptr<TaskExecutor> {
     auto const exe = boost::process::v2::environment::find_executable("python3", environment);
     if (exe.empty()) {
+        spdlog::error("Cannot find python3 interpreter");
         return nullptr;
     }
 

--- a/src/spider/worker/TaskExecutor.hpp
+++ b/src/spider/worker/TaskExecutor.hpp
@@ -45,7 +45,7 @@ public:
             std::vector<msgpack::sbuffer> const& args_buffers
     ) -> std::unique_ptr<TaskExecutor>;
 
-    static auto spawn_python_executor(
+    [[nodiscard]] static auto spawn_python_executor(
             boost::asio::io_context& context,
             std::string const& func_name,
             boost::uuids::uuid task_id,

--- a/src/spider/worker/TaskExecutor.hpp
+++ b/src/spider/worker/TaskExecutor.hpp
@@ -32,7 +32,7 @@ enum class TaskExecutorState : std::uint8_t {
 
 class TaskExecutor {
 public:
-    static auto spawn_cpp_executor(
+    [[nodiscard]] static auto spawn_cpp_executor(
             boost::asio::io_context& context,
             std::string const& func_name,
             boost::uuids::uuid task_id,
@@ -87,7 +87,7 @@ public:
     [[nodiscard]] auto get_error() const -> std::tuple<core::FunctionInvokeError, std::string>;
 
 private:
-    // Private constructor
+    // Constructors
     explicit TaskExecutor(boost::asio::io_context& context);
 
     auto process_output_handler() -> boost::asio::awaitable<void>;

--- a/src/spider/worker/TaskExecutor.hpp
+++ b/src/spider/worker/TaskExecutor.hpp
@@ -97,7 +97,7 @@ private:
     TaskExecutorState m_state = TaskExecutorState::Running;
 
     // Use `std::unique_ptr` to work around requirement of default constructor
-    std::unique_ptr<Process> m_process = nullptr;
+    std::unique_ptr<Process> m_process;
     boost::asio::readable_pipe m_read_pipe;
     boost::asio::writable_pipe m_write_pipe;
 

--- a/src/spider/worker/TaskExecutor.hpp
+++ b/src/spider/worker/TaskExecutor.hpp
@@ -88,7 +88,12 @@ public:
 
 private:
     // Constructors
-    explicit TaskExecutor(boost::asio::io_context& context);
+    explicit TaskExecutor(
+            boost::asio::io_context& context,
+            int read_pipe_fd,
+            int write_pipe_fd,
+            std::unique_ptr<Process> process
+    );
 
     auto process_output_handler() -> boost::asio::awaitable<void>;
 

--- a/src/spider/worker/TaskExecutor.hpp
+++ b/src/spider/worker/TaskExecutor.hpp
@@ -16,7 +16,6 @@
 #include <boost/process/v2/environment.hpp>
 #include <boost/uuid/uuid.hpp>
 
-#include <spider/core/Task.hpp>
 #include <spider/io/BoostAsio.hpp>  // IWYU pragma: keep
 #include <spider/io/MsgPack.hpp>  // IWYU pragma: keep
 #include <spider/worker/FunctionManager.hpp>
@@ -33,11 +32,10 @@ enum class TaskExecutorState : std::uint8_t {
 
 class TaskExecutor {
 public:
-    TaskExecutor(
+    static auto spawn_cpp_executor(
             boost::asio::io_context& context,
             std::string const& func_name,
             boost::uuids::uuid task_id,
-            core::TaskLanguage language,
             std::string const& storage_url,
             std::vector<std::string> const& libs,
             absl::flat_hash_map<
@@ -45,7 +43,19 @@ public:
                     boost::process::v2::environment::value
             > const& environment,
             std::vector<msgpack::sbuffer> const& args_buffers
-    );
+    ) -> std::unique_ptr<TaskExecutor>;
+
+    static auto spawn_python_executor(
+            boost::asio::io_context& context,
+            std::string const& func_name,
+            boost::uuids::uuid task_id,
+            std::string const& storage_url,
+            absl::flat_hash_map<
+                    boost::process::v2::environment::key,
+                    boost::process::v2::environment::value
+            > const& environment,
+            std::vector<msgpack::sbuffer> const& args_buffers
+    ) -> std::unique_ptr<TaskExecutor>;
 
     TaskExecutor(TaskExecutor const&) = delete;
     auto operator=(TaskExecutor const&) -> TaskExecutor& = delete;
@@ -77,6 +87,9 @@ public:
     [[nodiscard]] auto get_error() const -> std::tuple<core::FunctionInvokeError, std::string>;
 
 private:
+    // Private constructor
+    explicit TaskExecutor(boost::asio::io_context& context);
+
     auto process_output_handler() -> boost::asio::awaitable<void>;
 
     std::mutex m_state_mutex;

--- a/src/spider/worker/TaskExecutor.hpp
+++ b/src/spider/worker/TaskExecutor.hpp
@@ -92,7 +92,8 @@ private:
             boost::asio::io_context& context,
             int read_pipe_fd,
             int write_pipe_fd,
-            std::unique_ptr<Process> process
+            std::unique_ptr<Process> process,
+            std::vector<msgpack::sbuffer> const& args_buffers
     );
 
     auto process_output_handler() -> boost::asio::awaitable<void>;

--- a/src/spider/worker/worker.cpp
+++ b/src/spider/worker/worker.cpp
@@ -476,7 +476,7 @@ auto task_loop(
             fail_task_id = executor_setup_result.error();
             continue;
         }
-        auto [executor, task] = std::move(executor_setup_result.value());
+        auto& [executor, task] = executor_setup_result.value();
 
         auto const pid = executor->get_pid();
         spider::core::ChildPid::set_pid(pid);

--- a/src/spider/worker/worker.cpp
+++ b/src/spider/worker/worker.cpp
@@ -414,6 +414,11 @@ auto task_loop(
             fail_task_id = task.get_id();
             continue;
         }
+        if (nullptr == executor) {
+            spdlog::error("Failed to spawn task executor for task {}", task.get_function_name());
+            fail_task_id = task.get_id();
+            continue;
+        }
 
         pid_t const pid = executor->get_pid();
         spider::core::ChildPid::set_pid(pid);

--- a/src/spider/worker/worker.cpp
+++ b/src/spider/worker/worker.cpp
@@ -387,15 +387,6 @@ auto task_loop(
 
         // Validate task language
         auto const language = task.get_language();
-        switch (language) {
-            case spider::core::TaskLanguage::Cpp:
-            case spider::core::TaskLanguage::Python:
-                break;
-            default:
-                spdlog::error("Unsupported task language.");
-                fail_task_id = task.get_id();
-                continue;
-        }
 
         // Execute task
         std::unique_ptr<spider::worker::TaskExecutor> executor = nullptr;

--- a/src/spider/worker/worker.cpp
+++ b/src/spider/worker/worker.cpp
@@ -121,7 +121,7 @@ auto get_environment_variable() -> absl::flat_hash_map<
 
     auto const path_env_it = environment_variables.find("PATH");
     if (environment_variables.end() != path_env_it) {
-        std::string path_env = path_env_it->second.string();
+        auto path_env = path_env_it->second.string();
         path_env.append(":");
         path_env.append(executable_dir.string());
         path_env_it->second = boost::process::v2::environment::value(path_env);
@@ -380,8 +380,8 @@ auto task_loop(
                     = std::get<std::unique_ptr<spider::core::StorageConnection>>(conn_result);
 
             auto const optional_arg_buffers = setup_task(*conn, metadata_store, instance, task);
-            if (!optional_arg_buffers.has_value()) {
-                spdlog::error("Failed to setup task {}", task.get_function_name());
+            if (false == optional_arg_buffers.has_value()) {
+                spdlog::error("Failed to setup task `{}`.", task.get_function_name());
                 fail_task_id = task.get_id();
                 continue;
             }
@@ -441,7 +441,7 @@ auto task_loop(
             }
         }
 
-        pid_t const pid = executor->get_pid();
+        auto const pid = executor->get_pid();
         spider::core::ChildPid::set_pid(pid);
         // Double check if stop token is set to avoid any missing signal
         if (spider::core::StopFlag::is_stop_requested()) {

--- a/src/spider/worker/worker.cpp
+++ b/src/spider/worker/worker.cpp
@@ -480,6 +480,9 @@ auto task_loop(
                 task,
                 fail_task_id
         );
+        if (nullptr == executor) {
+            continue;
+        }
 
         auto const pid = executor->get_pid();
         spider::core::ChildPid::set_pid(pid);

--- a/src/spider/worker/worker.cpp
+++ b/src/spider/worker/worker.cpp
@@ -269,7 +269,6 @@ auto setup_executor(
     }
     auto const& arg_buffers = optional_arg_buffers.value();
 
-    // Validate task language
     auto const language = task.get_language();
 
     std::unique_ptr<spider::worker::TaskExecutor> executor;

--- a/src/spider/worker/worker.cpp
+++ b/src/spider/worker/worker.cpp
@@ -250,7 +250,7 @@ auto setup_task(
 ) -> ystdlib::error_handling::
         Result<std::tuple<std::unique_ptr<spider::worker::TaskExecutor>, spider::core::Task>,
                std::optional<boost::uuids::uuid>> {
-    auto conn_result = storage_factory->provide_storage_connection();
+    auto const conn_result = storage_factory->provide_storage_connection();
     if (std::holds_alternative<spider::core::StorageErr>(conn_result)) {
         spdlog::error(
                 "Failed to connect to storage: {}",

--- a/src/spider/worker/worker.cpp
+++ b/src/spider/worker/worker.cpp
@@ -368,8 +368,7 @@ auto task_loop(
         std::unique_ptr<spider::worker::TaskExecutor> executor;
         // Task setup scope to ensure storage connection RAII
         {
-            std::variant<std::unique_ptr<spider::core::StorageConnection>, spider::core::StorageErr>
-                    conn_result = storage_factory->provide_storage_connection();
+            auto conn_result = storage_factory->provide_storage_connection();
             if (std::holds_alternative<spider::core::StorageErr>(conn_result)) {
                 spdlog::error(
                         "Failed to connect to storage: {}",
@@ -377,17 +376,16 @@ auto task_loop(
                 );
                 continue;
             }
-            auto const& conn =
-                    std::get<std::unique_ptr<spider::core::StorageConnection>>(conn_result);
+            auto const& conn
+                    = std::get<std::unique_ptr<spider::core::StorageConnection>>(conn_result);
 
-            std::optional<std::vector<msgpack::sbuffer>> optional_arg_buffers
-                    = setup_task(*conn, metadata_store, instance, task);
+            auto const optional_arg_buffers = setup_task(*conn, metadata_store, instance, task);
             if (!optional_arg_buffers.has_value()) {
                 spdlog::error("Failed to setup task {}", task.get_function_name());
                 fail_task_id = task.get_id();
                 continue;
             }
-            std::vector<msgpack::sbuffer> const& arg_buffers = optional_arg_buffers.value();
+            auto const& arg_buffers = optional_arg_buffers.value();
 
             // Validate task language
             auto const language = task.get_language();
@@ -419,7 +417,7 @@ auto task_loop(
                         *conn,
                         instance,
                         fmt::format(
-                                "Unsupported task language for task {}",
+                                "Unsupported task language for task `{}`.",
                                 task.get_function_name()
                         )
                 );

--- a/src/spider/worker/worker.cpp
+++ b/src/spider/worker/worker.cpp
@@ -321,7 +321,7 @@ auto setup_executor(
     metadata_store->task_fail(
             *conn,
             instance,
-            fmt::format("Failed to spawn task executor for task {}", task.get_function_name())
+            fmt::format("Failed to spawn task executor for task `{}`.", task.get_function_name())
     );
     return nullptr;
 }

--- a/src/spider/worker/worker.cpp
+++ b/src/spider/worker/worker.cpp
@@ -237,7 +237,7 @@ auto setup_task(
  * @param fail_task_id Output parameter to store the ID of the task if setup failed.
  * @return A unique pointer to the created task executor, or nullptr if setup failed.
  */
-auto setup_executor(
+[[nodiscard]] auto setup_executor(
         std::shared_ptr<spider::core::StorageFactory> const& storage_factory,
         std::shared_ptr<spider::core::MetadataStorage> const& metadata_store,
         std::string const& storage_url,

--- a/src/spider/worker/worker.cpp
+++ b/src/spider/worker/worker.cpp
@@ -235,10 +235,10 @@ auto setup_task(
  * @param libs The dynamic libraries that include the spider tasks.
  * @param environment The environment variables for the task executor.
  * @param context The context for asynchronous operations.
- * @return A result containing a pair of
+ * @return A result containing a pair on success, or the ID of the failed task on failure.
+ * The pair:
  * - A unique pointer to the spawned task executor.
  * - The task fetched from metadata storage.
- * on success. The task id on failure.
  */
 [[nodiscard]] auto setup_executor(
         std::unique_ptr<spider::core::StorageConnection> conn,

--- a/tests/worker/test-TaskExecutor.cpp
+++ b/tests/worker/test-TaskExecutor.cpp
@@ -92,20 +92,19 @@ TEMPLATE_LIST_TEST_CASE(
 
     boost::uuids::random_generator gen;
 
-    spider::worker::TaskExecutor executor{
+    auto executor = spider::worker::TaskExecutor::spawn_cpp_executor(
             context,
             "sum_test",
             gen(),
-            spider::core::TaskLanguage::Cpp,
             spider::test::get_storage_url<TestType>(),
             get_libraries(),
             environment_variable,
             pack_args(2, 3)
-    };
+    );
     context.run();
-    executor.wait();
-    REQUIRE(executor.succeed());
-    std::optional<int> const result_option = executor.get_result<int>();
+    executor->wait();
+    REQUIRE(executor->succeed());
+    std::optional<int> const result_option = executor->template get_result<int>();
     REQUIRE(result_option.has_value());
     REQUIRE(5 == result_option.value_or(0));
 }
@@ -125,20 +124,19 @@ TEMPLATE_LIST_TEST_CASE(
 
     boost::uuids::random_generator gen;
 
-    spider::worker::TaskExecutor executor{
+    auto executor = spider::worker::TaskExecutor::spawn_cpp_executor(
             context,
             "sum_test",
             gen(),
-            spider::core::TaskLanguage::Cpp,
             spider::test::get_storage_url<TestType>(),
             get_libraries(),
             environment_variable,
             pack_args(2)
-    };
+    );
     context.run();
-    executor.wait();
-    REQUIRE(executor.error());
-    std::tuple<spider::core::FunctionInvokeError, std::string> error = executor.get_error();
+    executor->wait();
+    REQUIRE(executor->error());
+    std::tuple<spider::core::FunctionInvokeError, std::string> error = executor->get_error();
     REQUIRE(spider::core::FunctionInvokeError::WrongNumberOfArguments == std::get<0>(error));
 }
 
@@ -157,20 +155,19 @@ TEMPLATE_LIST_TEST_CASE(
 
     boost::uuids::random_generator gen;
 
-    spider::worker::TaskExecutor executor{
+    auto executor = spider::worker::TaskExecutor::spawn_cpp_executor(
             context,
             "error_test",
             gen(),
-            spider::core::TaskLanguage::Cpp,
             spider::test::get_storage_url<TestType>(),
             get_libraries(),
             environment_variable,
             pack_args(2)
-    };
+    );
     context.run();
-    executor.wait();
-    REQUIRE(executor.error());
-    std::tuple<spider::core::FunctionInvokeError, std::string> error = executor.get_error();
+    executor->wait();
+    REQUIRE(executor->error());
+    std::tuple<spider::core::FunctionInvokeError, std::string> error = executor->get_error();
     REQUIRE(spider::core::FunctionInvokeError::FunctionExecutionError == std::get<0>(error));
 }
 
@@ -221,20 +218,19 @@ TEMPLATE_LIST_TEST_CASE(
 
     boost::asio::io_context context;
 
-    spider::worker::TaskExecutor executor{
+    auto executor = spider::worker::TaskExecutor::spawn_cpp_executor(
             context,
             "data_test",
             task_id,
-            spider::core::TaskLanguage::Cpp,
             spider::test::get_storage_url<TestType>(),
             get_libraries(),
             environment_variable,
             pack_args(data.get_id())
-    };
+    );
     context.run();
-    executor.wait();
-    REQUIRE(executor.succeed());
-    std::optional<int> const optional_result = executor.get_result<int>();
+    executor->wait();
+    REQUIRE(executor->succeed());
+    std::optional<int> const optional_result = executor->template get_result<int>();
     REQUIRE(optional_result.has_value());
     if (optional_result.has_value()) {
         REQUIRE(3 == optional_result.value());
@@ -266,20 +262,19 @@ TEMPLATE_LIST_TEST_CASE(
     std::string const input_1(cLargeInputSize, 'a');
     std::string const input_2(cLargeInputSize, 'b');
 
-    spider::worker::TaskExecutor executor{
+    auto executor = spider::worker::TaskExecutor::spawn_cpp_executor(
             context,
             "join_string_test",
             gen(),
-            spider::core::TaskLanguage::Cpp,
             spider::test::get_storage_url<TestType>(),
             get_libraries(),
             environment_variable,
             pack_args(input_1, input_2)
-    };
+    );
     context.run();
-    executor.wait();
-    REQUIRE(executor.succeed());
-    std::optional<std::string> const result_option = executor.get_result<std::string>();
+    executor->wait();
+    REQUIRE(executor->succeed());
+    std::optional<std::string> const result_option = executor->template get_result<std::string>();
     REQUIRE(result_option.has_value());
     REQUIRE(input_1 + input_2 == result_option.value_or(""));
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR:
- Use factory functions to spawn language-specific task executors (C++ and Python).
- Use `python3 -m spider_py.task_executor.task_executor` to invoke Python executor.
- Passes all environment variables to task executor process instead of just `$PATH`.



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* [x] C++ integration tests pass.
* [x] Python integration tests pass.
* [ ] GitHub workflows pass.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Executors now created via dedicated C++ and Python factory methods that return managed nullable handles. Startup argument passing, asynchronous output delivery and PID-based stop signalling preserved. Runtime executable resolution and PATH/environment handling improved. Public API simplified to factory usage; internal constructor logic reworked. Storage connection usage streamlined with clearer failure paths and scoped lifecycle management.

* **Tests**
  * Tests updated to use the new factory APIs and pointer-style executor usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->