### PR TITLE
style(cmake): Apply formatting updates for `gersemi` v0.23.1.

### DIFF
--- a/cmake/Modules/FindLibraryDependencies.cmake
+++ b/cmake/Modules/FindLibraryDependencies.cmake
@@ -27,8 +27,7 @@ macro(FindStaticLibraryDependencies fld_LIBNAME fld_PREFIX fld_STATIC_LIBS)
         find_library(${fld_PREFIX}_${fld_DEP_LIB}_LIBRARY NAMES ${fld_DEP_LIB} PATH_SUFFIXES lib)
         if(${fld_PREFIX}_${fld_DEP_LIB}_LIBRARY)
             list(
-                APPEND
-                ${fld_PREFIX}_LIBRARY_DEPENDENCIES
+                APPEND ${fld_PREFIX}_LIBRARY_DEPENDENCIES
                 "${${fld_PREFIX}_${fld_DEP_LIB}_LIBRARY}"
             )
         else()
@@ -48,8 +47,7 @@ macro(FindDynamicLibraryDependencies fld_PREFIX fld_DYNAMIC_LIBS)
         find_library(${fld_PREFIX}_${fld_DEP_LIB}_LIBRARY NAMES ${fld_DEP_LIB} PATH_SUFFIXES lib)
         if(${fld_PREFIX}_${fld_DEP_LIB}_LIBRARY)
             list(
-                APPEND
-                ${fld_PREFIX}_LIBRARY_DEPENDENCIES
+                APPEND ${fld_PREFIX}_LIBRARY_DEPENDENCIES
                 "${${fld_PREFIX}_${fld_DEP_LIB}_LIBRARY}"
             )
         else()


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
In latest release of `gersemi` 0.23, "some builtin commands, like `list(APPEND)` or `string(APPEND)`, are formatted in a way that signature keyword is considered a proper keyword with usually semantic of one value keyword".

This PR updates the `CMake` files to conform the the new lint rule.



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* [x] `gersemi check` pass.
* [x] GitHub workflows pass.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor formatting adjustments to build configuration directives for improved code consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->