### PR TITLE
fix(ci): Replace `npm install -g @go-task/cli` with `go-task/setup-task` action to eliminate npm supply-chain risk.

### DIFF
--- a/.github/workflows/code-linting-checks.yaml
+++ b/.github/workflows/code-linting-checks.yaml
@@ -32,7 +32,9 @@ jobs:
           python-version: "3.10"
 
       - name: "Install task"
-        run: "npm install -g @go-task/cli@3.44.0"
+        uses: "go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44"  # v2.0.0
+        with:
+          version: "3.44.0"
 
       - name: "Install dev dependencies"
         run: "./tools/scripts/lib_install/linux/install-dev.sh"

--- a/.github/workflows/tdl-generated-code-checks.yaml
+++ b/.github/workflows/tdl-generated-code-checks.yaml
@@ -29,8 +29,9 @@ jobs:
           java-version: "11"
 
       - name: "Install task"
-        shell: "bash"
-        run: "npm install -g @go-task/cli@3.44.0"
+        uses: "go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44"  # v2.0.0
+        with:
+          version: "3.44.0"
 
       - name: "Generate parsers"
         shell: "bash"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,7 +35,9 @@ jobs:
           python-version: "3.10"
 
       - name: "Install task"
-        run: "npm install -g @go-task/cli@3.44.0"
+        uses: "go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44"  # v2.0.0
+        with:
+          version: "3.44.0"
 
       - name: "Install dev dependencies"
         run: "./tools/scripts/lib_install/linux/install-dev.sh"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
All CI workflows install the Task runner via `npm install -g @go-task/cli`. `@go-task/cli` declares
a transitive dependency on `axios: ^1.8.2`, and because global npm installs have no lock file, npm
resolves to whatever the latest semver-compatible version is at install time. During the
[axios supply-chain compromise on 2026-03-31][axios-advisory], this caused CI runners to pull in the
malicious `axios@1.14.1` package, which executed a post-install script that connected to an
attacker-controlled C2 server.

This PR replaces all occurrences of `npm install -g @go-task/cli` with the official
[`go-task/setup-task`][setup-task] GitHub Action, pinned by commit SHA. The action downloads the Task
binary directly from GitHub Releases without involving npm, eliminating the transitive dependency on
axios and the broader npm supply-chain attack surface.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
1. Verified that no `npm install -g` commands remain in any workflow file.
2. Confirmed the pinned commit SHA `3be4020d41929789a01026e0e427a4321ce0ad44` corresponds to
   `go-task/setup-task` [v2.0.0][setup-task-v2].

[axios-advisory]: https://github.com/advisories/GHSA-fw8c-xr5c-95f9
[setup-task]: https://github.com/go-task/setup-task
[setup-task-v2]: https://github.com/go-task/setup-task/releases/tag/v2.0.0
[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI/CD workflows to use an improved task installation mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->