### PR TITLE
feat(spider-storage): Add session management trait and MariaDB implementation.

### DIFF
--- a/components/spider-core/src/types/id.rs
+++ b/components/spider-core/src/types/id.rs
@@ -116,6 +116,8 @@ pub type ExecutionManagerId = Id<ExecutionManagerIdMarker>;
 pub enum SchedulerIdMarker {}
 pub type SchedulerId = Id<SchedulerIdMarker>;
 
+pub type SessionId = u64;
+
 pub type TaskInstanceId = u64;
 
 /// Represents a signed ID.

--- a/components/spider-storage/src/db.rs
+++ b/components/spider-storage/src/db.rs
@@ -9,4 +9,5 @@ pub use protocol::{
     ExternalJobOrchestration,
     InternalJobOrchestration,
     ResourceGroupManagement,
+    SessionManagement,
 };

--- a/components/spider-storage/src/db/mariadb.rs
+++ b/components/spider-storage/src/db/mariadb.rs
@@ -441,13 +441,13 @@ impl ResourceGroupManagement for MariaDbStorageConnector {
     }
 }
 
-impl DbStorage for MariaDbStorageConnector {}
-
 impl SessionManagement for MariaDbStorageConnector {
     fn session_id(&self) -> SessionId {
         self.session_id
     }
 }
+
+impl DbStorage for MariaDbStorageConnector {}
 
 /// `MySQL` error number for foreign key constraint violation.
 const MYSQL_ER_FK_CONSTRAINT: u16 = 1452;

--- a/components/spider-storage/src/db/mariadb.rs
+++ b/components/spider-storage/src/db/mariadb.rs
@@ -19,6 +19,7 @@ use crate::{
         ExternalJobOrchestration,
         InternalJobOrchestration,
         ResourceGroupManagement,
+        SessionManagement,
         error::ExpectedStates,
     },
 };
@@ -27,6 +28,7 @@ use crate::{
 #[derive(Clone)]
 pub struct MariaDbStorageConnector {
     pool: MySqlPool,
+    session_id: u64,
 }
 
 impl MariaDbStorageConnector {
@@ -59,19 +61,20 @@ impl MariaDbStorageConnector {
             .connect_with(mysql_options)
             .await?;
 
-        let connector = Self { pool };
-
         // MariaDB does not support transactions for DDL statements. All DDL statements are
         // automatically committed. Thus, each table creation query is executed separately, and
         // atomicity is not guaranteed.
         sqlx::query(resource_groups_creation_query())
-            .execute(&connector.pool)
+            .execute(&pool)
             .await?;
-        sqlx::query(jobs_creation_query())
-            .execute(&connector.pool)
+        sqlx::query(jobs_creation_query()).execute(&pool).await?;
+        sqlx::query(sessions_creation_query())
+            .execute(&pool)
             .await?;
 
-        Ok(connector)
+        let session_id = bump_session_id(&pool).await?;
+
+        Ok(Self { pool, session_id })
     }
 }
 
@@ -432,6 +435,12 @@ impl ResourceGroupManagement for MariaDbStorageConnector {
 
 impl DbStorage for MariaDbStorageConnector {}
 
+impl SessionManagement for MariaDbStorageConnector {
+    fn session_id(&self) -> u64 {
+        self.session_id
+    }
+}
+
 /// `MySQL` error number for foreign key constraint violation.
 const MYSQL_ER_FK_CONSTRAINT: u16 = 1452;
 
@@ -440,6 +449,7 @@ const MYSQL_ER_DUP_ENTRY: u16 = 1062;
 
 const RESOURCE_GROUPS_TABLE_NAME: &str = "resource_groups";
 const JOBS_TABLE_NAME: &str = "jobs";
+const SESSIONS_TABLE_NAME: &str = "sessions";
 
 const UPDATE_JOB_STATE: &str = formatcp!(
     "UPDATE `{table}` SET `state` = ? WHERE `id` = ?;",
@@ -484,6 +494,17 @@ CREATE TABLE IF NOT EXISTS `{JOBS_TABLE_NAME}` (
 );",
         state_enum = JobState::as_mysql_enum_decl(),
         default_state = JobState::Ready.as_quoted_str(),
+    )
+}
+
+#[must_use]
+const fn sessions_creation_query() -> &'static str {
+    formatcp!(
+        r"
+CREATE TABLE IF NOT EXISTS `{SESSIONS_TABLE_NAME}` (
+  `session_id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  PRIMARY KEY (`session_id`)
+);"
     )
 }
 
@@ -561,4 +582,26 @@ async fn transition_job_state(
     .await?;
 
     Ok(())
+}
+
+/// Bumps the session ID by inserting a new row into the [`SESSIONS_TABLE_NAME`] table.
+///
+/// The table uses `AUTO_INCREMENT` on `session_id`, so each `INSERT` generates the next
+/// monotonically increasing session ID.
+///
+/// # Returns
+///
+/// The new session ID on success.
+///
+/// # Errors
+///
+/// Forwards [`sqlx::query_scalar::QueryScalar::fetch_one`]'s return values on failure.
+async fn bump_session_id(pool: &MySqlPool) -> Result<u64, DbError> {
+    const QUERY: &str = formatcp!(
+        "INSERT INTO `{table}` () VALUES () RETURNING `session_id`;",
+        table = SESSIONS_TABLE_NAME,
+    );
+
+    let session_id = sqlx::query_scalar::<_, u64>(QUERY).fetch_one(pool).await?;
+    Ok(session_id)
 }

--- a/components/spider-storage/src/db/mariadb.rs
+++ b/components/spider-storage/src/db/mariadb.rs
@@ -48,7 +48,7 @@ impl MariaDbStorageConnector {
     ///
     /// * Forwards [`sqlx::mysql::MySqlPoolOptions::connect`]'s return values on failure.
     /// * Forwards [`sqlx::query::Query::execute`]'s return values on failure.
-    /// * Forwards [`bump_session_id`]'s return value on failure.
+    /// * Forwards [`bump_session_id`]'s return values on failure.
     pub async fn connect(config: &DatabaseConfig) -> Result<Self, DbError> {
         let mysql_options = sqlx::mysql::MySqlConnectOptions::new()
             .host(&config.host)

--- a/components/spider-storage/src/db/mariadb.rs
+++ b/components/spider-storage/src/db/mariadb.rs
@@ -596,7 +596,7 @@ async fn transition_job_state(
 ///
 /// # Errors
 ///
-/// Forwards [`sqlx::query_scalar::QueryScalar::fetch_one`]'s return values on failure.
+/// Forwards [`sqlx::query::QueryScalar::fetch_one`]'s return values on failure.
 async fn bump_session_id(pool: &MySqlPool) -> Result<u64, DbError> {
     const QUERY: &str = formatcp!(
         "INSERT INTO `{table}` () VALUES () RETURNING `session_id`;",

--- a/components/spider-storage/src/db/mariadb.rs
+++ b/components/spider-storage/src/db/mariadb.rs
@@ -5,7 +5,7 @@ use spider_core::{
     job::JobState,
     task::TaskGraph,
     types::{
-        id::{JobId, ResourceGroupId},
+        id::{JobId, ResourceGroupId, SessionId},
         io::{TaskInput, TaskOutput},
     },
 };
@@ -28,7 +28,7 @@ use crate::{
 #[derive(Clone)]
 pub struct MariaDbStorageConnector {
     pool: MySqlPool,
-    session_id: u64,
+    session_id: SessionId,
 }
 
 impl MariaDbStorageConnector {
@@ -437,7 +437,7 @@ impl ResourceGroupManagement for MariaDbStorageConnector {
 impl DbStorage for MariaDbStorageConnector {}
 
 impl SessionManagement for MariaDbStorageConnector {
-    fn session_id(&self) -> u64 {
+    fn session_id(&self) -> SessionId {
         self.session_id
     }
 }
@@ -597,12 +597,14 @@ async fn transition_job_state(
 /// # Errors
 ///
 /// Forwards [`sqlx::query::QueryScalar::fetch_one`]'s return values on failure.
-async fn bump_session_id(pool: &MySqlPool) -> Result<u64, DbError> {
+async fn bump_session_id(pool: &MySqlPool) -> Result<SessionId, DbError> {
     const QUERY: &str = formatcp!(
         "INSERT INTO `{table}` () VALUES () RETURNING `session_id`;",
         table = SESSIONS_TABLE_NAME,
     );
 
-    let session_id = sqlx::query_scalar::<_, u64>(QUERY).fetch_one(pool).await?;
+    let session_id = sqlx::query_scalar::<_, SessionId>(QUERY)
+        .fetch_one(pool)
+        .await?;
     Ok(session_id)
 }

--- a/components/spider-storage/src/db/mariadb.rs
+++ b/components/spider-storage/src/db/mariadb.rs
@@ -48,6 +48,7 @@ impl MariaDbStorageConnector {
     ///
     /// * Forwards [`sqlx::mysql::MySqlPoolOptions::connect`]'s return values on failure.
     /// * Forwards [`sqlx::query::Query::execute`]'s return values on failure.
+    /// * Forwards [`bump_session_id`]'s return value on failure.
     pub async fn connect(config: &DatabaseConfig) -> Result<Self, DbError> {
         let mysql_options = sqlx::mysql::MySqlConnectOptions::new()
             .host(&config.host)

--- a/components/spider-storage/src/db/mariadb.rs
+++ b/components/spider-storage/src/db/mariadb.rs
@@ -48,8 +48,13 @@ impl MariaDbStorageConnector {
     ///
     /// * Forwards [`sqlx::mysql::MySqlPoolOptions::connect`]'s return values on failure.
     /// * Forwards [`sqlx::query::Query::execute`]'s return values on failure.
-    /// * Forwards [`bump_session_id`]'s return values on failure.
+    /// * Forwards [`sqlx::query::QueryScalar::fetch_one`]'s return values on failure.
     pub async fn connect(config: &DatabaseConfig) -> Result<Self, DbError> {
+        const BUMP_SESSION_ID_QUERY: &str = formatcp!(
+            "INSERT INTO `{table}` () VALUES () RETURNING `session_id`;",
+            table = SESSIONS_TABLE_NAME,
+        );
+
         let mysql_options = sqlx::mysql::MySqlConnectOptions::new()
             .host(&config.host)
             .port(config.port)
@@ -73,7 +78,9 @@ impl MariaDbStorageConnector {
             .execute(&pool)
             .await?;
 
-        let session_id = bump_session_id(&pool).await?;
+        let session_id = sqlx::query_scalar::<_, SessionId>(BUMP_SESSION_ID_QUERY)
+            .fetch_one(&pool)
+            .await?;
 
         Ok(Self { pool, session_id })
     }
@@ -583,28 +590,4 @@ async fn transition_job_state(
     .await?;
 
     Ok(())
-}
-
-/// Bumps the session ID by inserting a new row into the [`SESSIONS_TABLE_NAME`] table.
-///
-/// The table uses `AUTO_INCREMENT` on `session_id`, so each `INSERT` generates the next
-/// monotonically increasing session ID.
-///
-/// # Returns
-///
-/// The new session ID on success.
-///
-/// # Errors
-///
-/// Forwards [`sqlx::query::QueryScalar::fetch_one`]'s return values on failure.
-async fn bump_session_id(pool: &MySqlPool) -> Result<SessionId, DbError> {
-    const QUERY: &str = formatcp!(
-        "INSERT INTO `{table}` () VALUES () RETURNING `session_id`;",
-        table = SESSIONS_TABLE_NAME,
-    );
-
-    let session_id = sqlx::query_scalar::<_, SessionId>(QUERY)
-        .fetch_one(pool)
-        .await?;
-    Ok(session_id)
 }

--- a/components/spider-storage/src/db/protocol.rs
+++ b/components/spider-storage/src/db/protocol.rs
@@ -17,6 +17,7 @@ use crate::db::error::DbError;
 /// * [`ResourceGroupManagement`]
 /// * [`SessionManagement`]
 #[async_trait]
+#[rustfmt::skip] // Workaround for https://github.com/rust-lang/rustfmt/issues/5321
 pub trait DbStorage:
     ExternalJobOrchestration
     + InternalJobOrchestration

--- a/components/spider-storage/src/db/protocol.rs
+++ b/components/spider-storage/src/db/protocol.rs
@@ -322,7 +322,7 @@ pub trait ResourceGroupManagement {
 /// Defines the storage interface for session management.
 ///
 /// A session ID is a monotonically increasing value that bumps each time the storage layer
-/// reconnects. Callers can use it to detect and reject requests from before a restart.
+/// reconnects. Callers can use it to detect and reject stale requests from previous sessions.
 pub trait SessionManagement {
     /// # Returns
     ///

--- a/components/spider-storage/src/db/protocol.rs
+++ b/components/spider-storage/src/db/protocol.rs
@@ -15,9 +15,14 @@ use crate::db::error::DbError;
 /// * [`ExternalJobOrchestration`]
 /// * [`InternalJobOrchestration`]
 /// * [`ResourceGroupManagement`]
+/// * [`SessionManagement`]
 #[async_trait]
 pub trait DbStorage:
-    ExternalJobOrchestration + InternalJobOrchestration + ResourceGroupManagement {
+    ExternalJobOrchestration
+    + InternalJobOrchestration
+    + ResourceGroupManagement
+    + SessionManagement
+{
 }
 
 /// Defines the user-facing storage interface for job storage in the database.
@@ -311,4 +316,15 @@ pub trait ResourceGroupManagement {
     /// * [`DbError::ResourceGroupNotFound`] if the `resource_group_id` does not exist.
     /// * Forwards [`sqlx::error::Error`] on DB operation failure.
     async fn delete(&self, resource_group_id: ResourceGroupId) -> Result<(), DbError>;
+}
+
+/// Defines the storage interface for session management.
+///
+/// A session ID is a monotonically increasing value that bumps each time the storage layer
+/// reconnects. Callers can use it to detect and reject requests from before a restart.
+pub trait SessionManagement {
+    /// # Returns
+    ///
+    /// The current session ID.
+    fn session_id(&self) -> u64;
 }

--- a/components/spider-storage/src/db/protocol.rs
+++ b/components/spider-storage/src/db/protocol.rs
@@ -3,7 +3,7 @@ use spider_core::{
     job::JobState,
     task::TaskGraph,
     types::{
-        id::{JobId, ResourceGroupId},
+        id::{JobId, ResourceGroupId, SessionId},
         io::{TaskInput, TaskOutput},
     },
 };
@@ -327,5 +327,5 @@ pub trait SessionManagement {
     /// # Returns
     ///
     /// The current session ID.
-    fn session_id(&self) -> u64;
+    fn session_id(&self) -> SessionId;
 }

--- a/components/spider-storage/tests/mariadb_test.rs
+++ b/components/spider-storage/tests/mariadb_test.rs
@@ -12,6 +12,7 @@ use spider_storage::db::{
     ExternalJobOrchestration,
     InternalJobOrchestration,
     ResourceGroupManagement,
+    SessionManagement,
 };
 
 use super::{
@@ -729,8 +730,6 @@ async fn test_delete_expired_terminated_jobs_no_match() {
 #[tokio::test]
 #[ignore = "requires MariaDB"]
 async fn test_session_id_returned_after_connect() {
-    use spider_storage::db::SessionManagement;
-
     let storage = create_mariadb_connector().await;
     let session_id = storage.session_id();
     assert!(
@@ -743,8 +742,6 @@ async fn test_session_id_returned_after_connect() {
 #[ignore = "requires MariaDB"]
 #[serial_test::serial]
 async fn test_session_id_bumps_on_reconnect() {
-    use spider_storage::db::SessionManagement;
-
     let storage1 = create_mariadb_connector().await;
     let session_id1 = storage1.session_id();
 

--- a/components/spider-storage/tests/mariadb_test.rs
+++ b/components/spider-storage/tests/mariadb_test.rs
@@ -725,3 +725,34 @@ async fn test_delete_expired_terminated_jobs_no_match() {
         .expect("get_state should succeed");
     assert_eq!(state, JobState::Failed);
 }
+
+#[tokio::test]
+#[ignore = "requires MariaDB"]
+async fn test_session_id_returned_after_connect() {
+    use spider_storage::db::SessionManagement;
+
+    let storage = create_mariadb_connector().await;
+    let session_id = storage.session_id();
+    assert!(
+        session_id > 0,
+        "session_id should be greater than 0 after connect, got {session_id}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires MariaDB"]
+#[serial_test::serial]
+async fn test_session_id_bumps_on_reconnect() {
+    use spider_storage::db::SessionManagement;
+
+    let storage1 = create_mariadb_connector().await;
+    let session_id1 = storage1.session_id();
+
+    let storage2 = create_mariadb_connector().await;
+    let session_id2 = storage2.session_id();
+
+    assert!(
+        session_id2 > session_id1,
+        "session_id should increase on reconnect, got {session_id1} -> {session_id2}"
+    );
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR adds interface and MariaDB implementation of session management storage.

The session management storage provides a session id, which bumps everytime a new database connection is created. This session id is to invalidate all previous session requests on storage restart.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
- [x] New unit tests added for the session management.
- [ ] GitHub workflows pass.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Storage connectors now expose monotonic session IDs that increment across reconnects, helping detect and reject stale requests.
  * Session management has been added to the core storage connector interface.
  * A new SessionId identifier type is available for callers.

* **Tests**
  * Added integration tests confirming session ID presence after connect and that subsequent reconnects yield higher session IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->