### PR TITLE
feat(spider-storage): Add MariaDB implementation for execution manager liveness tracking.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,6 +341,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1224,6 +1234,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
 dependencies = [
+ "fslock",
  "futures-executor",
  "futures-util",
  "log",
@@ -2002,6 +2013,28 @@ dependencies = [
  "libredox",
  "wasite",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1342,6 +1342,7 @@ dependencies = [
  "serde",
  "serial_test",
  "spider-core",
+ "spider-derive",
  "sqlx",
  "subtle",
  "tabled",

--- a/components/spider-core/src/types/id.rs
+++ b/components/spider-core/src/types/id.rs
@@ -113,10 +113,6 @@ pub enum ExecutionManagerIdMarker {}
 pub type ExecutionManagerId = Id<ExecutionManagerIdMarker>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum ExecutionManagerIdMarker {}
-pub type ExecutionManagerId = Id<ExecutionManagerIdMarker>;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SchedulerIdMarker {}
 pub type SchedulerId = Id<SchedulerIdMarker>;
 

--- a/components/spider-core/src/types/id.rs
+++ b/components/spider-core/src/types/id.rs
@@ -113,6 +113,10 @@ pub enum WorkerIdMarker {}
 pub type WorkerId = Id<WorkerIdMarker>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ExecutionManagerIdMarker {}
+pub type ExecutionManagerId = Id<ExecutionManagerIdMarker>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SchedulerIdMarker {}
 pub type SchedulerId = Id<SchedulerIdMarker>;
 

--- a/components/spider-storage/Cargo.toml
+++ b/components/spider-storage/Cargo.toml
@@ -31,7 +31,7 @@ uuid = { version = "1.19.0", features = ["serde"] }
 anyhow = "1.0.98"
 dashmap = "6.1.0"
 rand = "0.9.1"
-serial_test = { version = "3.2.0", features= ["file_locks"] }
+serial_test = { version = "3.2.0", features = ["file_locks"] }
 tabled = "0.20.0"
 tokio = { version = "1.50.0", features = ["macros", "rt-multi-thread", "sync"] }
 uuid = { version = "1.19.0", features = ["v4"] }

--- a/components/spider-storage/Cargo.toml
+++ b/components/spider-storage/Cargo.toml
@@ -20,6 +20,7 @@ rmp-serde = "1.3.1"
 secrecy = { version = "0.10.3", features = ["serde"] }
 serde = { version = "1.0.228", features = ["derive"] }
 spider-core = { path = "../spider-core" }
+spider-derive = { path = "../spider-derive" }
 sqlx = { version = "0.8.6", features = ["mysql", "runtime-tokio"] }
 subtle = "2.6.1"
 thiserror = "2.0.18"

--- a/components/spider-storage/Cargo.toml
+++ b/components/spider-storage/Cargo.toml
@@ -31,7 +31,7 @@ uuid = { version = "1.19.0", features = ["serde"] }
 anyhow = "1.0.98"
 dashmap = "6.1.0"
 rand = "0.9.1"
-serial_test = "3.2.0"
+serial_test = { version = "3.2.0", features= ["file_locks"] }
 tabled = "0.20.0"
 tokio = { version = "1.50.0", features = ["macros", "rt-multi-thread", "sync"] }
 uuid = { version = "1.19.0", features = ["v4"] }

--- a/components/spider-storage/src/db.rs
+++ b/components/spider-storage/src/db.rs
@@ -6,6 +6,7 @@ pub use error::DbError;
 pub use mariadb::MariaDbStorageConnector;
 pub use protocol::{
     DbStorage,
+    ExecutionManagerLivenessManagement,
     ExternalJobOrchestration,
     InternalJobOrchestration,
     ResourceGroupManagement,

--- a/components/spider-storage/src/db/error.rs
+++ b/components/spider-storage/src/db/error.rs
@@ -22,9 +22,6 @@ pub enum DbError {
     #[error("execution manager `{0:?}` is illegal")]
     IllegalExecutionManagerId(ExecutionManagerId),
 
-    #[error("execution manager `{0:?}` already exists")]
-    ExecutionManagerAlreadyExists(ExecutionManagerId),
-
     #[error("execution manager `{0:?}` is already dead")]
     ExecutionManagerAlreadyDead(ExecutionManagerId),
 

--- a/components/spider-storage/src/db/error.rs
+++ b/components/spider-storage/src/db/error.rs
@@ -19,8 +19,8 @@ pub enum DbError {
     #[error("job `{0:?}` does not exist")]
     JobNotFound(JobId),
 
-    #[error("execution manager `{0:?}` does not exist")]
-    ExecutionManagerNotFound(ExecutionManagerId),
+    #[error("execution manager `{0:?}` is illegal")]
+    IllegalExecutionManagerId(ExecutionManagerId),
 
     #[error("execution manager `{0:?}` already exists")]
     ExecutionManagerAlreadyExists(ExecutionManagerId),

--- a/components/spider-storage/src/db/error.rs
+++ b/components/spider-storage/src/db/error.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use spider_core::{
     job::JobState,
-    types::id::{JobId, ResourceGroupId},
+    types::id::{ExecutionManagerId, JobId, ResourceGroupId},
 };
 
 #[derive(thiserror::Error, Debug)]
@@ -18,6 +18,15 @@ pub enum DbError {
 
     #[error("job `{0:?}` does not exist")]
     JobNotFound(JobId),
+
+    #[error("execution manager `{0:?}` does not exist")]
+    ExecutionManagerNotFound(ExecutionManagerId),
+
+    #[error("execution manager `{0:?}` already exists")]
+    ExecutionManagerAlreadyExists(ExecutionManagerId),
+
+    #[error("execution manager `{0:?}` is already dead")]
+    ExecutionManagerAlreadyDead(ExecutionManagerId),
 
     #[error("job in state {from} cannot transit into state {to}")]
     InvalidJobStateTransition { from: JobState, to: JobState },

--- a/components/spider-storage/src/db/mariadb.rs
+++ b/components/spider-storage/src/db/mariadb.rs
@@ -447,29 +447,18 @@ enum ExecutionManagerState {
 impl ExecutionManagerLivenessManagement for MariaDbStorageConnector {
     async fn register_execution_manager(
         &self,
-        execution_manager_id: ExecutionManagerId,
         ip_address: IpAddr,
-    ) -> Result<(), DbError> {
+    ) -> Result<ExecutionManagerId, DbError> {
         const INSERT_QUERY: &str = formatcp!(
-            "INSERT INTO `{table}` (`id`, `ip_address`) VALUES (?, ?);",
+            "INSERT INTO `{table}` (`ip_address`) VALUES (?) RETURNING CAST(`id` AS BINARY(16));",
             table = EXECUTION_MANAGERS_TABLE_NAME,
         );
 
-        sqlx::query(INSERT_QUERY)
-            .bind(execution_manager_id)
+        sqlx::query_scalar(INSERT_QUERY)
             .bind(ip_address.to_string())
-            .execute(&self.pool)
+            .fetch_one(&self.pool)
             .await
-            .map(|_| ())
-            .map_err(|e| match e {
-                sqlx::Error::Database(e)
-                    if e.try_downcast_ref::<MySqlDatabaseError>()
-                        .is_some_and(|mysql_err| mysql_err.number() == MYSQL_ER_DUP_ENTRY) =>
-                {
-                    DbError::ExecutionManagerAlreadyExists(execution_manager_id)
-                }
-                e => e.into(),
-            })
+            .map_err(Into::into)
     }
 
     async fn update_execution_manager_heartbeat(
@@ -555,9 +544,8 @@ impl ExecutionManagerLivenessManagement for MariaDbStorageConnector {
                 .collect::<Vec<_>>()
                 .join(",");
             let update_query = format!(
-                "UPDATE `{EXECUTION_MANAGERS_TABLE_NAME}` SET \
-                 `state` = '{dead_state}', `death_confirmed_at` = CURRENT_TIMESTAMP WHERE `id` IN \
-                 ({placeholders})",
+                "UPDATE `{EXECUTION_MANAGERS_TABLE_NAME}` SET `state` = '{dead_state}', \
+                 `death_confirmed_at` = CURRENT_TIMESTAMP WHERE `id` IN ({placeholders})",
                 dead_state = ExecutionManagerState::Dead.as_str(),
             );
             let mut query = sqlx::query(&update_query);
@@ -635,7 +623,7 @@ const fn execution_managers_creation_query() -> &'static str {
     formatcp!(
         r"
 CREATE TABLE IF NOT EXISTS `{EXECUTION_MANAGERS_TABLE_NAME}` (
-  `id` UUID NOT NULL,
+  `id` UUID NOT NULL DEFAULT UUID_v7(),
   `ip_address` VARCHAR(45) NOT NULL,
   `state` {state_enum} NOT NULL DEFAULT {default_state},
   `last_heartbeat_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/components/spider-storage/src/db/mariadb.rs
+++ b/components/spider-storage/src/db/mariadb.rs
@@ -476,38 +476,36 @@ impl ExecutionManagerLivenessManagement for MariaDbStorageConnector {
         &self,
         execution_manager_id: ExecutionManagerId,
     ) -> Result<(), DbError> {
+        const SELECT_STATE_FOR_UPDATE_QUERY: &str = formatcp!(
+            "SELECT `state` FROM `{table}` WHERE `id` = ? FOR UPDATE;",
+            table = EXECUTION_MANAGERS_TABLE_NAME,
+        );
         const UPDATE_QUERY: &str = formatcp!(
             "UPDATE `{table}` SET `last_heartbeat_at` = CURRENT_TIMESTAMP WHERE `id` = ? AND \
              `state` = '{alive_state}';",
             table = EXECUTION_MANAGERS_TABLE_NAME,
             alive_state = ExecutionManagerState::Alive.as_str(),
         );
-        const SELECT_STATE_QUERY: &str = formatcp!(
-            "SELECT `state` FROM `{table}` WHERE `id` = ?;",
-            table = EXECUTION_MANAGERS_TABLE_NAME,
-        );
 
-        let rows_affected = sqlx::query(UPDATE_QUERY)
-            .bind(execution_manager_id)
-            .execute(&self.pool)
-            .await?
-            .rows_affected();
-        if rows_affected != 0 {
-            return Ok(());
-        }
+        let mut tx = self.pool.begin().await?;
 
-        let state = sqlx::query_scalar::<_, ExecutionManagerState>(SELECT_STATE_QUERY)
+        let state = sqlx::query_scalar::<_, ExecutionManagerState>(SELECT_STATE_FOR_UPDATE_QUERY)
             .bind(execution_manager_id)
-            .fetch_optional(&self.pool)
+            .fetch_optional(&mut *tx)
             .await?
             .ok_or(DbError::ExecutionManagerNotFound(execution_manager_id))?;
 
-        match state {
-            ExecutionManagerState::Alive => Ok(()),
-            ExecutionManagerState::Dead => {
-                Err(DbError::ExecutionManagerAlreadyDead(execution_manager_id))
-            }
+        if state == ExecutionManagerState::Dead {
+            return Err(DbError::ExecutionManagerAlreadyDead(execution_manager_id));
         }
+
+        sqlx::query(UPDATE_QUERY)
+            .bind(execution_manager_id)
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+        Ok(())
     }
 
     async fn is_execution_manager_alive(

--- a/components/spider-storage/src/db/mariadb.rs
+++ b/components/spider-storage/src/db/mariadb.rs
@@ -1,3 +1,5 @@
+use std::{net::IpAddr, time::Duration};
+
 use async_trait::async_trait;
 use const_format::formatcp;
 use secrecy::ExposeSecret;
@@ -5,10 +7,11 @@ use spider_core::{
     job::JobState,
     task::TaskGraph,
     types::{
-        id::{JobId, ResourceGroupId},
+        id::{ExecutionManagerId, JobId, ResourceGroupId},
         io::{TaskInput, TaskOutput},
     },
 };
+use spider_derive::MySqlEnum;
 use sqlx::{MySqlPool, mysql::MySqlDatabaseError};
 
 use crate::{
@@ -16,6 +19,7 @@ use crate::{
     db::{
         DbError,
         DbStorage,
+        ExecutionManagerLivenessManagement,
         ExternalJobOrchestration,
         InternalJobOrchestration,
         ResourceGroupManagement,
@@ -27,6 +31,12 @@ use crate::{
 #[derive(Clone)]
 pub struct MariaDbStorageConnector {
     pool: MySqlPool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, MySqlEnum)]
+enum ExecutionManagerState {
+    Alive,
+    Dead,
 }
 
 impl MariaDbStorageConnector {
@@ -68,6 +78,9 @@ impl MariaDbStorageConnector {
             .execute(&connector.pool)
             .await?;
         sqlx::query(jobs_creation_query())
+            .execute(&connector.pool)
+            .await?;
+        sqlx::query(execution_managers_creation_query())
             .execute(&connector.pool)
             .await?;
 
@@ -430,6 +443,132 @@ impl ResourceGroupManagement for MariaDbStorageConnector {
     }
 }
 
+#[async_trait]
+impl ExecutionManagerLivenessManagement for MariaDbStorageConnector {
+    async fn register_execution_manager(
+        &self,
+        execution_manager_id: ExecutionManagerId,
+        ip_address: IpAddr,
+    ) -> Result<(), DbError> {
+        const INSERT_QUERY: &str = formatcp!(
+            "INSERT INTO `{table}` (`id`, `ip_address`) VALUES (?, ?);",
+            table = EXECUTION_MANAGERS_TABLE_NAME,
+        );
+
+        sqlx::query(INSERT_QUERY)
+            .bind(execution_manager_id)
+            .bind(ip_address.to_string())
+            .execute(&self.pool)
+            .await
+            .map(|_| ())
+            .map_err(|e| match e {
+                sqlx::Error::Database(e)
+                    if e.try_downcast_ref::<MySqlDatabaseError>()
+                        .is_some_and(|mysql_err| mysql_err.number() == MYSQL_ER_DUP_ENTRY) =>
+                {
+                    DbError::ExecutionManagerAlreadyExists(execution_manager_id)
+                }
+                e => e.into(),
+            })
+    }
+
+    async fn update_execution_manager_heartbeat(
+        &self,
+        execution_manager_id: ExecutionManagerId,
+    ) -> Result<(), DbError> {
+        const UPDATE_QUERY: &str = formatcp!(
+            "UPDATE `{table}` SET `last_heartbeat_at` = CURRENT_TIMESTAMP WHERE `id` = ? AND \
+             `state` = '{alive_state}';",
+            table = EXECUTION_MANAGERS_TABLE_NAME,
+            alive_state = ExecutionManagerState::Alive.as_str(),
+        );
+        const SELECT_STATE_QUERY: &str = formatcp!(
+            "SELECT `state` FROM `{table}` WHERE `id` = ?;",
+            table = EXECUTION_MANAGERS_TABLE_NAME,
+        );
+
+        let rows_affected = sqlx::query(UPDATE_QUERY)
+            .bind(execution_manager_id)
+            .execute(&self.pool)
+            .await?
+            .rows_affected();
+        if rows_affected != 0 {
+            return Ok(());
+        }
+
+        let state = sqlx::query_scalar::<_, ExecutionManagerState>(SELECT_STATE_QUERY)
+            .bind(execution_manager_id)
+            .fetch_optional(&self.pool)
+            .await?
+            .ok_or(DbError::ExecutionManagerNotFound(execution_manager_id))?;
+
+        match state {
+            ExecutionManagerState::Alive => Ok(()),
+            ExecutionManagerState::Dead => {
+                Err(DbError::ExecutionManagerAlreadyDead(execution_manager_id))
+            }
+        }
+    }
+
+    async fn is_execution_manager_alive(&self, id: ExecutionManagerId) -> Result<bool, DbError> {
+        const QUERY: &str = formatcp!(
+            "SELECT `state` FROM `{table}` WHERE `id` = ?;",
+            table = EXECUTION_MANAGERS_TABLE_NAME,
+        );
+
+        let Some(state) = sqlx::query_scalar::<_, ExecutionManagerState>(QUERY)
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await?
+        else {
+            return Ok(false);
+        };
+
+        match state {
+            ExecutionManagerState::Alive => Ok(true),
+            ExecutionManagerState::Dead => Ok(false),
+        }
+    }
+
+    async fn get_dead_execution_managers(
+        &self,
+        stale_after: Duration,
+    ) -> Result<Vec<ExecutionManagerId>, DbError> {
+        const UPDATE_BATCH_SIZE: usize = 1000;
+
+        const SELECT_QUERY: &str = formatcp!(
+            "SELECT CAST(`id` AS BINARY(16)) FROM `{table}` WHERE `state` = '{alive_state}' AND \
+             `last_heartbeat_at` < CURRENT_TIMESTAMP - INTERVAL ? SECOND FOR UPDATE;",
+            table = EXECUTION_MANAGERS_TABLE_NAME,
+            alive_state = ExecutionManagerState::Alive.as_str(),
+        );
+
+        let mut tx = self.pool.begin().await?;
+        let execution_manager_ids: Vec<ExecutionManagerId> = sqlx::query_scalar(SELECT_QUERY)
+            .bind(stale_after.as_secs())
+            .fetch_all(&mut *tx)
+            .await?;
+
+        for execution_manager_id_batch in execution_manager_ids.chunks(UPDATE_BATCH_SIZE) {
+            let placeholders = std::iter::repeat_n("?", execution_manager_id_batch.len())
+                .collect::<Vec<_>>()
+                .join(",");
+            let update_query = format!(
+                "UPDATE `{EXECUTION_MANAGERS_TABLE_NAME}` SET `state` = ? WHERE `id` IN \
+                 ({placeholders})"
+            );
+            let mut query = sqlx::query(&update_query).bind(ExecutionManagerState::Dead);
+            for execution_manager_id in execution_manager_id_batch {
+                query = query.bind(execution_manager_id);
+            }
+            query.execute(&mut *tx).await?;
+        }
+
+        tx.commit().await?;
+        Ok(execution_manager_ids)
+    }
+}
+
 impl DbStorage for MariaDbStorageConnector {}
 
 /// `MySQL` error number for foreign key constraint violation.
@@ -440,6 +579,7 @@ const MYSQL_ER_DUP_ENTRY: u16 = 1062;
 
 const RESOURCE_GROUPS_TABLE_NAME: &str = "resource_groups";
 const JOBS_TABLE_NAME: &str = "jobs";
+const EXECUTION_MANAGERS_TABLE_NAME: &str = "execution_managers";
 
 const UPDATE_JOB_STATE: &str = formatcp!(
     "UPDATE `{table}` SET `state` = ? WHERE `id` = ?;",
@@ -484,6 +624,25 @@ CREATE TABLE IF NOT EXISTS `{JOBS_TABLE_NAME}` (
 );",
         state_enum = JobState::as_mysql_enum_decl(),
         default_state = JobState::Ready.as_quoted_str(),
+    )
+}
+
+#[must_use]
+const fn execution_managers_creation_query() -> &'static str {
+    formatcp!(
+        r"
+CREATE TABLE IF NOT EXISTS `{EXECUTION_MANAGERS_TABLE_NAME}` (
+  `id` UUID NOT NULL,
+  `ip_address` VARCHAR(45) NOT NULL,
+  `state` {state_enum} NOT NULL DEFAULT {default_state},
+  `last_heartbeat_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  INDEX `execution_manager_liveness` (`state`, `last_heartbeat_at`)
+);",
+        state_enum = ExecutionManagerState::as_mysql_enum_decl(),
+        default_state = ExecutionManagerState::Alive.as_quoted_str(),
     )
 }
 

--- a/components/spider-storage/src/db/mariadb.rs
+++ b/components/spider-storage/src/db/mariadb.rs
@@ -1,4 +1,4 @@
-use std::{net::IpAddr, time::Duration};
+use std::net::IpAddr;
 
 use async_trait::async_trait;
 use const_format::formatcp;
@@ -535,7 +535,7 @@ impl ExecutionManagerLivenessManagement for MariaDbStorageConnector {
 
     async fn get_dead_execution_managers(
         &self,
-        stale_after: Duration,
+        stale_after_sec: u64,
     ) -> Result<Vec<ExecutionManagerId>, DbError> {
         const UPDATE_BATCH_SIZE: usize = 1000;
 
@@ -548,7 +548,7 @@ impl ExecutionManagerLivenessManagement for MariaDbStorageConnector {
 
         let mut tx = self.pool.begin().await?;
         let execution_manager_ids: Vec<ExecutionManagerId> = sqlx::query_scalar(SELECT_QUERY)
-            .bind(stale_after.as_secs())
+            .bind(stale_after_sec)
             .fetch_all(&mut *tx)
             .await?;
 

--- a/components/spider-storage/src/db/mariadb.rs
+++ b/components/spider-storage/src/db/mariadb.rs
@@ -33,12 +33,6 @@ pub struct MariaDbStorageConnector {
     pool: MySqlPool,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, MySqlEnum)]
-enum ExecutionManagerState {
-    Alive,
-    Dead,
-}
-
 impl MariaDbStorageConnector {
     /// Connects to database and initializes tables.
     ///
@@ -443,6 +437,12 @@ impl ResourceGroupManagement for MariaDbStorageConnector {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, MySqlEnum)]
+enum ExecutionManagerState {
+    Alive,
+    Dead,
+}
+
 #[async_trait]
 impl ExecutionManagerLivenessManagement for MariaDbStorageConnector {
     async fn register_execution_manager(
@@ -510,14 +510,17 @@ impl ExecutionManagerLivenessManagement for MariaDbStorageConnector {
         }
     }
 
-    async fn is_execution_manager_alive(&self, id: ExecutionManagerId) -> Result<bool, DbError> {
+    async fn is_execution_manager_alive(
+        &self,
+        execution_manager_id: ExecutionManagerId,
+    ) -> Result<bool, DbError> {
         const QUERY: &str = formatcp!(
             "SELECT `state` FROM `{table}` WHERE `id` = ?;",
             table = EXECUTION_MANAGERS_TABLE_NAME,
         );
 
         let Some(state) = sqlx::query_scalar::<_, ExecutionManagerState>(QUERY)
-            .bind(id)
+            .bind(execution_manager_id)
             .fetch_optional(&self.pool)
             .await?
         else {

--- a/components/spider-storage/src/db/mariadb.rs
+++ b/components/spider-storage/src/db/mariadb.rs
@@ -555,10 +555,12 @@ impl ExecutionManagerLivenessManagement for MariaDbStorageConnector {
                 .collect::<Vec<_>>()
                 .join(",");
             let update_query = format!(
-                "UPDATE `{EXECUTION_MANAGERS_TABLE_NAME}` SET `state` = ? WHERE `id` IN \
-                 ({placeholders})"
+                "UPDATE `{EXECUTION_MANAGERS_TABLE_NAME}` SET \
+                 `state` = '{dead_state}', `death_confirmed_at` = CURRENT_TIMESTAMP WHERE `id` IN \
+                 ({placeholders})",
+                dead_state = ExecutionManagerState::Dead.as_str(),
             );
-            let mut query = sqlx::query(&update_query).bind(ExecutionManagerState::Dead);
+            let mut query = sqlx::query(&update_query);
             for execution_manager_id in execution_manager_id_batch {
                 query = query.bind(execution_manager_id);
             }
@@ -638,7 +640,7 @@ CREATE TABLE IF NOT EXISTS `{EXECUTION_MANAGERS_TABLE_NAME}` (
   `state` {state_enum} NOT NULL DEFAULT {default_state},
   `last_heartbeat_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `death_confirmed_at` TIMESTAMP NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   INDEX `execution_manager_liveness` (`state`, `last_heartbeat_at`)
 );",

--- a/components/spider-storage/src/db/mariadb.rs
+++ b/components/spider-storage/src/db/mariadb.rs
@@ -493,7 +493,7 @@ impl ExecutionManagerLivenessManagement for MariaDbStorageConnector {
             .bind(execution_manager_id)
             .fetch_optional(&mut *tx)
             .await?
-            .ok_or(DbError::ExecutionManagerNotFound(execution_manager_id))?;
+            .ok_or(DbError::IllegalExecutionManagerId(execution_manager_id))?;
 
         if state == ExecutionManagerState::Dead {
             return Err(DbError::ExecutionManagerAlreadyDead(execution_manager_id));
@@ -522,7 +522,7 @@ impl ExecutionManagerLivenessManagement for MariaDbStorageConnector {
             .fetch_optional(&self.pool)
             .await?
         else {
-            return Ok(false);
+            return Err(DbError::IllegalExecutionManagerId(execution_manager_id));
         };
 
         match state {

--- a/components/spider-storage/src/db/mariadb.rs
+++ b/components/spider-storage/src/db/mariadb.rs
@@ -587,7 +587,6 @@ const MYSQL_ER_DUP_ENTRY: u16 = 1062;
 
 const RESOURCE_GROUPS_TABLE_NAME: &str = "resource_groups";
 const JOBS_TABLE_NAME: &str = "jobs";
-
 const EXECUTION_MANAGERS_TABLE_NAME: &str = "execution_managers";
 const SESSIONS_TABLE_NAME: &str = "sessions";
 

--- a/components/spider-storage/src/db/protocol.rs
+++ b/components/spider-storage/src/db/protocol.rs
@@ -326,20 +326,21 @@ pub trait ExecutionManagerLivenessManagement: Clone + Send + Sync {
     ///
     /// # Parameters
     ///
-    /// * `execution_manager_id` - The ID of the execution manager to register.
     /// * `ip_address` - The execution manager IP address.
+    ///
+    /// # Returns
+    ///
+    /// The ID of the registered execution manager on success.
     ///
     /// # Errors
     ///
     /// Returns an error if:
     ///
-    /// * [`DbError::ExecutionManagerAlreadyExists`] if the execution manager ID already exists.
     /// * Forwards [`sqlx::error::Error`] on DB operation failure.
     async fn register_execution_manager(
         &self,
-        execution_manager_id: ExecutionManagerId,
         ip_address: IpAddr,
-    ) -> Result<(), DbError>;
+    ) -> Result<ExecutionManagerId, DbError>;
 
     /// Updates the heartbeat of an alive execution manager.
     ///

--- a/components/spider-storage/src/db/protocol.rs
+++ b/components/spider-storage/src/db/protocol.rs
@@ -1,9 +1,11 @@
+use std::{net::IpAddr, time::Duration};
+
 use async_trait::async_trait;
 use spider_core::{
     job::JobState,
     task::TaskGraph,
     types::{
-        id::{JobId, ResourceGroupId},
+        id::{ExecutionManagerId, JobId, ResourceGroupId},
         io::{TaskInput, TaskOutput},
     },
 };
@@ -15,9 +17,13 @@ use crate::db::error::DbError;
 /// * [`ExternalJobOrchestration`]
 /// * [`InternalJobOrchestration`]
 /// * [`ResourceGroupManagement`]
+/// * [`ExecutionManagerLivenessManagement`]
 #[async_trait]
 pub trait DbStorage:
-    ExternalJobOrchestration + InternalJobOrchestration + ResourceGroupManagement {
+    ExternalJobOrchestration
+    + InternalJobOrchestration
+    + ResourceGroupManagement
+    + ExecutionManagerLivenessManagement {
 }
 
 /// Defines the user-facing storage interface for job storage in the database.
@@ -311,4 +317,89 @@ pub trait ResourceGroupManagement {
     /// * [`DbError::ResourceGroupNotFound`] if the `resource_group_id` does not exist.
     /// * Forwards [`sqlx::error::Error`] on DB operation failure.
     async fn delete(&self, resource_group_id: ResourceGroupId) -> Result<(), DbError>;
+}
+
+/// Defines the storage interface for execution manager liveness management in the database.
+#[async_trait]
+pub trait ExecutionManagerLivenessManagement: Clone + Send + Sync {
+    /// Registers an execution manager in the database.
+    ///
+    /// # Parameters
+    ///
+    /// * `execution_manager_id` - The ID of the execution manager to register.
+    /// * `ip_address` - The execution manager IP address.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * [`DbError::ExecutionManagerAlreadyExists`] if the execution manager ID already exists.
+    /// * Forwards [`sqlx::error::Error`] on DB operation failure.
+    async fn register_execution_manager(
+        &self,
+        execution_manager_id: ExecutionManagerId,
+        ip_address: IpAddr,
+    ) -> Result<(), DbError>;
+
+    /// Updates the heartbeat timestamp of an alive execution manager.
+    ///
+    /// # Parameters
+    ///
+    /// * `execution_manager_id` - The ID of the execution manager to update.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * [`DbError::ExecutionManagerNotFound`] if the execution manager does not exist.
+    /// * [`DbError::ExecutionManagerAlreadyDead`] if the execution manager is dead.
+    /// * Forwards [`sqlx::error::Error`] on DB operation failure.
+    async fn update_execution_manager_heartbeat(
+        &self,
+        execution_manager_id: ExecutionManagerId,
+    ) -> Result<(), DbError>;
+
+    /// Checks whether the execution manager with the given ID is alive.
+    ///
+    /// # Parameters
+    ///
+    /// * `execution_manager_id` - The execution manager ID to check.
+    ///
+    /// # Returns
+    ///
+    /// Whether the execution manager is alive on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * Forwards [`sqlx::error::Error`] on DB operation failure.
+    async fn is_execution_manager_alive(
+        &self,
+        execution_manager_id: ExecutionManagerId,
+    ) -> Result<bool, DbError>;
+
+    /// Marks stale execution managers dead and returns their IDs.
+    ///
+    /// This operation is atomic: once an execution manager is returned by this method, it will not
+    /// be returned again in subsequent calls.
+    ///
+    /// # Parameters
+    ///
+    /// * `stale_after` - The duration after the last heartbeat which makes an execution manager
+    ///   stale.
+    ///
+    /// # Returns
+    ///
+    /// A vector of dead execution manager IDs on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * Forwards [`sqlx::error::Error`] on DB operation failure.
+    async fn get_dead_execution_managers(
+        &self,
+        stale_after: Duration,
+    ) -> Result<Vec<ExecutionManagerId>, DbError>;
 }

--- a/components/spider-storage/src/db/protocol.rs
+++ b/components/spider-storage/src/db/protocol.rs
@@ -341,7 +341,7 @@ pub trait ExecutionManagerLivenessManagement: Clone + Send + Sync {
         ip_address: IpAddr,
     ) -> Result<(), DbError>;
 
-    /// Updates the heartbeat timestamp of an alive execution manager.
+    /// Updates the heartbeat of an alive execution manager.
     ///
     /// # Parameters
     ///
@@ -381,8 +381,8 @@ pub trait ExecutionManagerLivenessManagement: Clone + Send + Sync {
 
     /// Marks stale execution managers dead and returns their IDs.
     ///
-    /// This operation is atomic: once an execution manager is returned by this method, it will not
-    /// be returned again in subsequent calls.
+    /// This operation is atomic: once an execution manager is marked dead and returned by a call of
+    /// this method, it will not be returned again in subsequent calls.
     ///
     /// # Parameters
     ///

--- a/components/spider-storage/src/db/protocol.rs
+++ b/components/spider-storage/src/db/protocol.rs
@@ -1,4 +1,4 @@
-use std::{net::IpAddr, time::Duration};
+use std::net::IpAddr;
 
 use async_trait::async_trait;
 use spider_core::{
@@ -386,7 +386,7 @@ pub trait ExecutionManagerLivenessManagement: Clone + Send + Sync {
     ///
     /// # Parameters
     ///
-    /// * `stale_after` - The duration after the last heartbeat which makes an execution manager
+    /// * `stale_after_sec` - The seconds after the last heartbeat which makes an execution manager
     ///   stale.
     ///
     /// # Returns
@@ -400,6 +400,6 @@ pub trait ExecutionManagerLivenessManagement: Clone + Send + Sync {
     /// * Forwards [`sqlx::error::Error`] on DB operation failure.
     async fn get_dead_execution_managers(
         &self,
-        stale_after: Duration,
+        stale_after_sec: u64,
     ) -> Result<Vec<ExecutionManagerId>, DbError>;
 }

--- a/components/spider-storage/src/db/protocol.rs
+++ b/components/spider-storage/src/db/protocol.rs
@@ -351,7 +351,7 @@ pub trait ExecutionManagerLivenessManagement: Clone + Send + Sync {
     ///
     /// Returns an error if:
     ///
-    /// * [`DbError::ExecutionManagerNotFound`] if the execution manager does not exist.
+    /// * [`DbError::IllegalExecutionManagerId`] if the execution manager ID is illegal.
     /// * [`DbError::ExecutionManagerAlreadyDead`] if the execution manager is dead.
     /// * Forwards [`sqlx::error::Error`] on DB operation failure.
     async fn update_execution_manager_heartbeat(
@@ -373,6 +373,7 @@ pub trait ExecutionManagerLivenessManagement: Clone + Send + Sync {
     ///
     /// Returns an error if:
     ///
+    /// * [`DbError::IllegalExecutionManagerId`] if the execution manager ID is illegal.
     /// * Forwards [`sqlx::error::Error`] on DB operation failure.
     async fn is_execution_manager_alive(
         &self,

--- a/components/spider-storage/tests/mariadb_test.rs
+++ b/components/spider-storage/tests/mariadb_test.rs
@@ -880,7 +880,7 @@ async fn test_get_dead_execution_managers_none_stale() {
 
     // Large window — the just-registered EM should not be stale yet.
     let dead = storage
-        .get_dead_execution_managers(Duration::from_mins(1))
+        .get_dead_execution_managers(Duration::from_secs(60))
         .await
         .expect("get_dead_execution_managers should succeed");
     assert!(

--- a/components/spider-storage/tests/mariadb_test.rs
+++ b/components/spider-storage/tests/mariadb_test.rs
@@ -11,8 +11,13 @@ use spider_core::{
     },
 };
 use spider_storage::db::{
-    DbError, ExecutionManagerLivenessManagement, ExternalJobOrchestration,
-    InternalJobOrchestration, MariaDbStorageConnector, ResourceGroupManagement, SessionManagement,
+    DbError,
+    ExecutionManagerLivenessManagement,
+    ExternalJobOrchestration,
+    InternalJobOrchestration,
+    MariaDbStorageConnector,
+    ResourceGroupManagement,
+    SessionManagement,
 };
 
 use super::{

--- a/components/spider-storage/tests/mariadb_test.rs
+++ b/components/spider-storage/tests/mariadb_test.rs
@@ -790,8 +790,8 @@ async fn test_update_execution_manager_heartbeat_not_found() {
 
     let result = storage.update_execution_manager_heartbeat(fake_em_id).await;
     assert!(
-        matches!(result, Err(DbError::ExecutionManagerNotFound(_))),
-        "expected ExecutionManagerNotFound, got {result:?}"
+        matches!(result, Err(DbError::IllegalExecutionManagerId(_))),
+        "expected IllegalExecutionManagerId, got {result:?}"
     );
 }
 
@@ -839,11 +839,11 @@ async fn test_is_execution_manager_alive_false_not_found() {
     let storage = create_mariadb_connector().await;
     let fake_em_id = ExecutionManagerId::new();
 
-    let alive = storage
-        .is_execution_manager_alive(fake_em_id)
-        .await
-        .expect("is_execution_manager_alive should succeed");
-    assert!(!alive, "nonexistent EM should not be alive");
+    let result = storage.is_execution_manager_alive(fake_em_id).await;
+    assert!(
+        matches!(result, Err(DbError::IllegalExecutionManagerId(id)) if id == fake_em_id),
+        "nonexistent EM should return IllegalExecutionManagerId, got {result:?}"
+    );
 }
 
 #[tokio::test]

--- a/components/spider-storage/tests/mariadb_test.rs
+++ b/components/spider-storage/tests/mariadb_test.rs
@@ -880,7 +880,7 @@ async fn test_get_dead_execution_managers_none_stale() {
 
     // Large window — the just-registered EM should not be stale yet.
     let dead = storage
-        .get_dead_execution_managers(Duration::from_secs(60))
+        .get_dead_execution_managers(Duration::from_mins(1))
         .await
         .expect("get_dead_execution_managers should succeed");
     assert!(

--- a/components/spider-storage/tests/mariadb_test.rs
+++ b/components/spider-storage/tests/mariadb_test.rs
@@ -731,10 +731,6 @@ async fn test_delete_expired_terminated_jobs_no_match() {
     assert_eq!(state, JobState::Failed);
 }
 
-// ---------------------------------------------------------------------------
-// Execution manager liveness tests
-// ---------------------------------------------------------------------------
-
 /// Registers a new execution manager with a random ID and `127.0.0.1` as the
 /// IP address, then returns the assigned ID.
 async fn register_test_em(storage: &MariaDbStorageConnector) -> ExecutionManagerId {

--- a/components/spider-storage/tests/mariadb_test.rs
+++ b/components/spider-storage/tests/mariadb_test.rs
@@ -11,13 +11,8 @@ use spider_core::{
     },
 };
 use spider_storage::db::{
-    DbError,
-    ExecutionManagerLivenessManagement,
-    ExternalJobOrchestration,
-    InternalJobOrchestration,
-    MariaDbStorageConnector,
-    ResourceGroupManagement,
-    SessionManagement,
+    DbError, ExecutionManagerLivenessManagement, ExternalJobOrchestration,
+    InternalJobOrchestration, MariaDbStorageConnector, ResourceGroupManagement, SessionManagement,
 };
 
 use super::{
@@ -963,6 +958,7 @@ async fn test_get_dead_execution_managers_multiple() {
 }
 
 #[tokio::test]
+#[ignore = "requires MariaDB"]
 async fn test_session_id_returned_after_connect() {
     let storage = create_mariadb_connector().await;
     let session_id = storage.session_id();
@@ -973,6 +969,7 @@ async fn test_session_id_returned_after_connect() {
 }
 
 #[tokio::test]
+#[ignore = "requires MariaDB"]
 async fn test_session_id_bumps_on_reconnect() {
     let storage1 = create_mariadb_connector().await;
     let session_id1 = storage1.session_id();

--- a/components/spider-storage/tests/mariadb_test.rs
+++ b/components/spider-storage/tests/mariadb_test.rs
@@ -36,6 +36,18 @@ fn single_task_graph() -> (SubmittedTaskGraph, Vec<TaskInput>) {
     build_flat_task_graph(1, TEST_INPUT_PAYLOAD_SIZE, false, false)
 }
 
+/// Registers a new execution manager with `127.0.0.1` as the IP address.
+///
+/// # Returns
+///
+/// The ID of the registered execution manager.
+async fn register_test_em(storage: &MariaDbStorageConnector) -> ExecutionManagerId {
+    storage
+        .register_execution_manager(IpAddr::V4(Ipv4Addr::LOCALHOST))
+        .await
+        .expect("register_execution_manager should succeed")
+}
+
 #[tokio::test]
 #[ignore = "requires MariaDB"]
 async fn test_register_job() {
@@ -729,15 +741,6 @@ async fn test_delete_expired_terminated_jobs_no_match() {
         .await
         .expect("get_state should succeed");
     assert_eq!(state, JobState::Failed);
-}
-
-/// Registers a new execution manager with `127.0.0.1` as the IP address,
-/// then returns the assigned ID.
-async fn register_test_em(storage: &MariaDbStorageConnector) -> ExecutionManagerId {
-    storage
-        .register_execution_manager(IpAddr::V4(Ipv4Addr::LOCALHOST))
-        .await
-        .expect("register_execution_manager should succeed")
 }
 
 #[tokio::test]

--- a/components/spider-storage/tests/mariadb_test.rs
+++ b/components/spider-storage/tests/mariadb_test.rs
@@ -731,43 +731,29 @@ async fn test_delete_expired_terminated_jobs_no_match() {
     assert_eq!(state, JobState::Failed);
 }
 
-/// Registers a new execution manager with a random ID and `127.0.0.1` as the
-/// IP address, then returns the assigned ID.
+/// Registers a new execution manager with `127.0.0.1` as the IP address,
+/// then returns the assigned ID.
 async fn register_test_em(storage: &MariaDbStorageConnector) -> ExecutionManagerId {
-    let em_id = ExecutionManagerId::new();
     storage
-        .register_execution_manager(em_id, IpAddr::V4(Ipv4Addr::LOCALHOST))
+        .register_execution_manager(IpAddr::V4(Ipv4Addr::LOCALHOST))
         .await
-        .expect("register_execution_manager should succeed");
-    em_id
+        .expect("register_execution_manager should succeed")
 }
 
 #[tokio::test]
 #[ignore = "requires MariaDB"]
 async fn test_register_execution_manager() {
     let storage = create_mariadb_connector().await;
-    let em_id = register_test_em(&storage).await;
+    let em_id = storage
+        .register_execution_manager(IpAddr::V4(Ipv4Addr::LOCALHOST))
+        .await
+        .expect("register_execution_manager should succeed");
 
     let alive = storage
         .is_execution_manager_alive(em_id)
         .await
         .expect("is_execution_manager_alive should succeed");
     assert!(alive, "newly registered EM should be alive");
-}
-
-#[tokio::test]
-#[ignore = "requires MariaDB"]
-async fn test_register_execution_manager_duplicate() {
-    let storage = create_mariadb_connector().await;
-    let em_id = register_test_em(&storage).await;
-
-    let result = storage
-        .register_execution_manager(em_id, IpAddr::V4(Ipv4Addr::LOCALHOST))
-        .await;
-    assert!(
-        matches!(result, Err(DbError::ExecutionManagerAlreadyExists(_))),
-        "expected ExecutionManagerAlreadyExists, got {result:?}"
-    );
 }
 
 #[tokio::test]

--- a/components/spider-storage/tests/mariadb_test.rs
+++ b/components/spider-storage/tests/mariadb_test.rs
@@ -460,7 +460,7 @@ async fn test_fail_terminal_state() {
 
 #[tokio::test]
 #[ignore = "requires MariaDB"]
-#[serial_test::serial]
+#[serial_test::file_serial]
 async fn test_delete_expired_terminated_jobs() {
     let storage = create_mariadb_connector().await;
     let rg_id = create_test_resource_group(&storage).await;

--- a/components/spider-storage/tests/mariadb_test.rs
+++ b/components/spider-storage/tests/mariadb_test.rs
@@ -27,6 +27,9 @@ use super::{
 /// Input payload size in bytes for the single-task graph used by DB-layer tests.
 const TEST_INPUT_PAYLOAD_SIZE: usize = 128;
 
+/// Number of execution managers to register in multi-EM tests.
+const TEST_NUM_EMS: usize = 3;
+
 /// Builds a task graph with a single task for DB-layer tests.
 ///
 /// # Returns
@@ -811,7 +814,7 @@ async fn test_update_execution_manager_heartbeat_already_dead() {
 
 #[tokio::test]
 #[ignore = "requires MariaDB"]
-async fn test_is_execution_manager_alive_true() {
+async fn test_is_execution_manager_alive_em_alive() {
     let storage = create_mariadb_connector().await;
     let em_id = register_test_em(&storage).await;
 
@@ -824,7 +827,7 @@ async fn test_is_execution_manager_alive_true() {
 
 #[tokio::test]
 #[ignore = "requires MariaDB"]
-async fn test_is_execution_manager_alive_false_not_found() {
+async fn test_is_execution_manager_alive_em_not_found() {
     let storage = create_mariadb_connector().await;
     let fake_em_id = ExecutionManagerId::new();
 
@@ -838,7 +841,7 @@ async fn test_is_execution_manager_alive_false_not_found() {
 #[tokio::test]
 #[ignore = "requires MariaDB"]
 #[serial_test::file_serial]
-async fn test_is_execution_manager_alive_false_dead() {
+async fn test_is_execution_manager_alive_em_dead() {
     let storage = create_mariadb_connector().await;
     let em_id = register_test_em(&storage).await;
 
@@ -934,7 +937,7 @@ async fn test_get_dead_execution_managers_atomic() {
 async fn test_get_dead_execution_managers_multiple() {
     let storage = create_mariadb_connector().await;
     let mut em_ids = Vec::with_capacity(3);
-    for _ in 0..3 {
+    for _ in 0..TEST_NUM_EMS {
         em_ids.push(register_test_em(&storage).await);
     }
 
@@ -946,18 +949,14 @@ async fn test_get_dead_execution_managers_multiple() {
         .expect("get_dead_execution_managers should succeed");
 
     for em_id in &em_ids {
-        assert!(
-            dead.contains(em_id),
-            "expected em_id {em_id:?} in dead list, got {dead:?}"
-        );
-    }
-
-    // Verify all are now dead.
-    for em_id in &em_ids {
         let alive = storage
             .is_execution_manager_alive(*em_id)
             .await
             .expect("is_execution_manager_alive should succeed");
         assert!(!alive, "EM {em_id:?} should be dead");
+        assert!(
+            dead.contains(em_id),
+            "expected em_id {em_id:?} in dead list, got {dead:?}"
+        );
     }
 }

--- a/components/spider-storage/tests/mariadb_test.rs
+++ b/components/spider-storage/tests/mariadb_test.rs
@@ -809,7 +809,7 @@ async fn test_update_execution_manager_heartbeat_already_dead() {
     // Wait for the heartbeat to become stale, then mark the EM dead.
     tokio::time::sleep(Duration::from_secs(2)).await;
     let dead = storage
-        .get_dead_execution_managers(Duration::from_secs(1))
+        .get_dead_execution_managers(1)
         .await
         .expect("get_dead_execution_managers should succeed");
     assert!(
@@ -860,7 +860,7 @@ async fn test_is_execution_manager_alive_false_dead() {
     // Mark the EM dead.
     tokio::time::sleep(Duration::from_secs(2)).await;
     storage
-        .get_dead_execution_managers(Duration::from_secs(1))
+        .get_dead_execution_managers(1)
         .await
         .expect("get_dead_execution_managers should succeed");
 
@@ -880,7 +880,7 @@ async fn test_get_dead_execution_managers_none_stale() {
 
     // Large window — the just-registered EM should not be stale yet.
     let dead = storage
-        .get_dead_execution_managers(Duration::from_mins(1))
+        .get_dead_execution_managers(1)
         .await
         .expect("get_dead_execution_managers should succeed");
     assert!(
@@ -899,7 +899,7 @@ async fn test_get_dead_execution_managers_marks_dead() {
     tokio::time::sleep(Duration::from_secs(2)).await;
 
     let dead = storage
-        .get_dead_execution_managers(Duration::from_secs(1))
+        .get_dead_execution_managers(1)
         .await
         .expect("get_dead_execution_managers should succeed");
     assert!(
@@ -924,7 +924,7 @@ async fn test_get_dead_execution_managers_atomic() {
     tokio::time::sleep(Duration::from_secs(2)).await;
 
     let dead_first = storage
-        .get_dead_execution_managers(Duration::from_secs(1))
+        .get_dead_execution_managers(1)
         .await
         .expect("first get_dead_execution_managers should succeed");
     assert!(
@@ -934,7 +934,7 @@ async fn test_get_dead_execution_managers_atomic() {
 
     // Second call should not return the same EM again.
     let dead_second = storage
-        .get_dead_execution_managers(Duration::from_secs(1))
+        .get_dead_execution_managers(1)
         .await
         .expect("second get_dead_execution_managers should succeed");
     assert!(
@@ -956,7 +956,7 @@ async fn test_get_dead_execution_managers_multiple() {
     tokio::time::sleep(Duration::from_secs(2)).await;
 
     let dead = storage
-        .get_dead_execution_managers(Duration::from_secs(1))
+        .get_dead_execution_managers(1)
         .await
         .expect("get_dead_execution_managers should succeed");
 

--- a/components/spider-storage/tests/mariadb_test.rs
+++ b/components/spider-storage/tests/mariadb_test.rs
@@ -1,16 +1,21 @@
-use std::time::Duration;
+use std::{
+    net::{IpAddr, Ipv4Addr},
+    time::Duration,
+};
 
 use spider_core::{
     job::JobState,
     types::{
-        id::{JobId, ResourceGroupId},
+        id::{ExecutionManagerId, JobId, ResourceGroupId},
         io::TaskInput,
     },
 };
 use spider_storage::db::{
     DbError,
+    ExecutionManagerLivenessManagement,
     ExternalJobOrchestration,
     InternalJobOrchestration,
+    MariaDbStorageConnector,
     ResourceGroupManagement,
 };
 
@@ -692,7 +697,7 @@ async fn test_cancel_from_ready_state() {
 
 #[tokio::test]
 #[ignore = "requires MariaDB"]
-#[serial_test::serial]
+#[serial_test::file_serial]
 async fn test_delete_expired_terminated_jobs_no_match() {
     let storage = create_mariadb_connector().await;
     let rg_id = create_test_resource_group(&storage).await;
@@ -724,4 +729,250 @@ async fn test_delete_expired_terminated_jobs_no_match() {
         .await
         .expect("get_state should succeed");
     assert_eq!(state, JobState::Failed);
+}
+
+// ---------------------------------------------------------------------------
+// Execution manager liveness tests
+// ---------------------------------------------------------------------------
+
+/// Registers a new execution manager with a random ID and `127.0.0.1` as the
+/// IP address, then returns the assigned ID.
+async fn register_test_em(storage: &MariaDbStorageConnector) -> ExecutionManagerId {
+    let em_id = ExecutionManagerId::new();
+    storage
+        .register_execution_manager(em_id, IpAddr::V4(Ipv4Addr::LOCALHOST))
+        .await
+        .expect("register_execution_manager should succeed");
+    em_id
+}
+
+#[tokio::test]
+#[ignore = "requires MariaDB"]
+async fn test_register_execution_manager() {
+    let storage = create_mariadb_connector().await;
+    let em_id = register_test_em(&storage).await;
+
+    let alive = storage
+        .is_execution_manager_alive(em_id)
+        .await
+        .expect("is_execution_manager_alive should succeed");
+    assert!(alive, "newly registered EM should be alive");
+}
+
+#[tokio::test]
+#[ignore = "requires MariaDB"]
+async fn test_register_execution_manager_duplicate() {
+    let storage = create_mariadb_connector().await;
+    let em_id = register_test_em(&storage).await;
+
+    let result = storage
+        .register_execution_manager(em_id, IpAddr::V4(Ipv4Addr::LOCALHOST))
+        .await;
+    assert!(
+        matches!(result, Err(DbError::ExecutionManagerAlreadyExists(_))),
+        "expected ExecutionManagerAlreadyExists, got {result:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires MariaDB"]
+async fn test_update_execution_manager_heartbeat() {
+    let storage = create_mariadb_connector().await;
+    let em_id = register_test_em(&storage).await;
+
+    storage
+        .update_execution_manager_heartbeat(em_id)
+        .await
+        .expect("update_execution_manager_heartbeat should succeed");
+}
+
+#[tokio::test]
+#[ignore = "requires MariaDB"]
+async fn test_update_execution_manager_heartbeat_not_found() {
+    let storage = create_mariadb_connector().await;
+    let fake_em_id = ExecutionManagerId::new();
+
+    let result = storage.update_execution_manager_heartbeat(fake_em_id).await;
+    assert!(
+        matches!(result, Err(DbError::ExecutionManagerNotFound(_))),
+        "expected ExecutionManagerNotFound, got {result:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires MariaDB"]
+#[serial_test::file_serial]
+async fn test_update_execution_manager_heartbeat_already_dead() {
+    let storage = create_mariadb_connector().await;
+    let em_id = register_test_em(&storage).await;
+
+    // Wait for the heartbeat to become stale, then mark the EM dead.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    let dead = storage
+        .get_dead_execution_managers(Duration::from_secs(1))
+        .await
+        .expect("get_dead_execution_managers should succeed");
+    assert!(
+        dead.contains(&em_id),
+        "expected em_id in dead list, got {dead:?}"
+    );
+
+    let result = storage.update_execution_manager_heartbeat(em_id).await;
+    assert!(
+        matches!(result, Err(DbError::ExecutionManagerAlreadyDead(_))),
+        "expected ExecutionManagerAlreadyDead, got {result:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires MariaDB"]
+async fn test_is_execution_manager_alive_true() {
+    let storage = create_mariadb_connector().await;
+    let em_id = register_test_em(&storage).await;
+
+    let alive = storage
+        .is_execution_manager_alive(em_id)
+        .await
+        .expect("is_execution_manager_alive should succeed");
+    assert!(alive, "registered EM should be alive");
+}
+
+#[tokio::test]
+#[ignore = "requires MariaDB"]
+async fn test_is_execution_manager_alive_false_not_found() {
+    let storage = create_mariadb_connector().await;
+    let fake_em_id = ExecutionManagerId::new();
+
+    let alive = storage
+        .is_execution_manager_alive(fake_em_id)
+        .await
+        .expect("is_execution_manager_alive should succeed");
+    assert!(!alive, "nonexistent EM should not be alive");
+}
+
+#[tokio::test]
+#[ignore = "requires MariaDB"]
+#[serial_test::file_serial]
+async fn test_is_execution_manager_alive_false_dead() {
+    let storage = create_mariadb_connector().await;
+    let em_id = register_test_em(&storage).await;
+
+    // Mark the EM dead.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    storage
+        .get_dead_execution_managers(Duration::from_secs(1))
+        .await
+        .expect("get_dead_execution_managers should succeed");
+
+    let alive = storage
+        .is_execution_manager_alive(em_id)
+        .await
+        .expect("is_execution_manager_alive should succeed");
+    assert!(!alive, "dead EM should not be alive");
+}
+
+#[tokio::test]
+#[ignore = "requires MariaDB"]
+#[serial_test::file_serial]
+async fn test_get_dead_execution_managers_none_stale() {
+    let storage = create_mariadb_connector().await;
+    register_test_em(&storage).await;
+
+    // Large window — the just-registered EM should not be stale yet.
+    let dead = storage
+        .get_dead_execution_managers(Duration::from_mins(1))
+        .await
+        .expect("get_dead_execution_managers should succeed");
+    assert!(
+        dead.is_empty(),
+        "freshly registered EM should not be stale, got {dead:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires MariaDB"]
+#[serial_test::file_serial]
+async fn test_get_dead_execution_managers_marks_dead() {
+    let storage = create_mariadb_connector().await;
+    let em_id = register_test_em(&storage).await;
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let dead = storage
+        .get_dead_execution_managers(Duration::from_secs(1))
+        .await
+        .expect("get_dead_execution_managers should succeed");
+    assert!(
+        dead.contains(&em_id),
+        "expected em_id in dead list, got {dead:?}"
+    );
+
+    let alive = storage
+        .is_execution_manager_alive(em_id)
+        .await
+        .expect("is_execution_manager_alive should succeed");
+    assert!(!alive, "stale EM should be marked dead");
+}
+
+#[tokio::test]
+#[ignore = "requires MariaDB"]
+#[serial_test::file_serial]
+async fn test_get_dead_execution_managers_atomic() {
+    let storage = create_mariadb_connector().await;
+    let em_id = register_test_em(&storage).await;
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let dead_first = storage
+        .get_dead_execution_managers(Duration::from_secs(1))
+        .await
+        .expect("first get_dead_execution_managers should succeed");
+    assert!(
+        dead_first.contains(&em_id),
+        "expected em_id in first dead list, got {dead_first:?}"
+    );
+
+    // Second call should not return the same EM again.
+    let dead_second = storage
+        .get_dead_execution_managers(Duration::from_secs(1))
+        .await
+        .expect("second get_dead_execution_managers should succeed");
+    assert!(
+        !dead_second.contains(&em_id),
+        "already-dead EM should not appear again, got {dead_second:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires MariaDB"]
+#[serial_test::file_serial]
+async fn test_get_dead_execution_managers_multiple() {
+    let storage = create_mariadb_connector().await;
+    let mut em_ids = Vec::with_capacity(3);
+    for _ in 0..3 {
+        em_ids.push(register_test_em(&storage).await);
+    }
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let dead = storage
+        .get_dead_execution_managers(Duration::from_secs(1))
+        .await
+        .expect("get_dead_execution_managers should succeed");
+
+    for em_id in &em_ids {
+        assert!(
+            dead.contains(em_id),
+            "expected em_id {em_id:?} in dead list, got {dead:?}"
+        );
+    }
+
+    // Verify all are now dead.
+    for em_id in &em_ids {
+        let alive = storage
+            .is_execution_manager_alive(*em_id)
+            .await
+            .expect("is_execution_manager_alive should succeed");
+        assert!(!alive, "EM {em_id:?} should be dead");
+    }
 }

--- a/components/spider-storage/tests/mariadb_test.rs
+++ b/components/spider-storage/tests/mariadb_test.rs
@@ -872,7 +872,7 @@ async fn test_is_execution_manager_alive_false_dead() {
 #[serial_test::file_serial]
 async fn test_get_dead_execution_managers_none_stale() {
     let storage = create_mariadb_connector().await;
-    register_test_em(&storage).await;
+    let em_id = register_test_em(&storage).await;
 
     // Large window — the just-registered EM should not be stale yet.
     let dead = storage
@@ -880,7 +880,7 @@ async fn test_get_dead_execution_managers_none_stale() {
         .await
         .expect("get_dead_execution_managers should succeed");
     assert!(
-        dead.is_empty(),
+        !dead.contains(&em_id),
         "freshly registered EM should not be stale, got {dead:?}"
     );
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR adds execution manager liveness in the database storage. The liveness storage supports:
- Registers a new execution manager.
- Updates an existing execution manager heartbeat.
- Checking liveness of an execution manager.
- Getting all execution managers that just died.

This PR also replaces `serial_test::serial` with `serial_test::file_serial`. `nextest` uses different 
processes to run different tests. `serial_test::serial`'s in-memory lock mechanism does not provide
serialization for `nextest`, while `serial_test::file_serial` serializes tests across processes.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
- [x] Add new unit tests.
- [x] GitHub workflows pass.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Execution manager liveness management: register managers, heartbeat updates, alive/dead queries, and automatic detection/marking of stale managers (MariaDB-backed).

* **Chores**
  * Local dependency and test configuration adjustments for file-lock based test runs.
  * Added clearer execution-manager state error variants.

* **Tests**
  * Expanded DB-layer tests for registration, heartbeats, alive checks, stale detection and atomic mark-and-skip behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->