### PR TITLE
feat(spider-tdl): Add `#[task]` proc macro for task declaration:

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1358,7 +1358,17 @@ dependencies = [
  "rmp-serde",
  "serde",
  "spider-core",
+ "spider-tdl-derive",
  "thiserror",
+]
+
+[[package]]
+name = "spider-tdl-derive"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,5 @@ members = [
   "components/spider-derive",
   "components/spider-storage",
   "components/spider-tdl",
+  "components/spider-tdl-derive",
 ]

--- a/components/spider-tdl-derive/Cargo.toml
+++ b/components/spider-tdl-derive/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "spider-tdl-derive"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+name = "spider_tdl_derive"
+path = "src/lib.rs"
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.106"
+quote = "1.0.45"
+syn = { version = "2.0.117", features = ["full"] }

--- a/components/spider-tdl-derive/src/lib.rs
+++ b/components/spider-tdl-derive/src/lib.rs
@@ -18,9 +18,8 @@ use task_macro::TaskAttr;
 /// * Accept `spider_tdl::TaskContext` as its first parameter. Type aliases and fully qualified
 ///   paths are allowed. This requirement is enforced at compile time via a generated assertion, so
 ///   any type that does not resolve to `spider_tdl::TaskContext` will produce a type error.
-/// * Return `Result<(T1, T2, ...), spider_tdl::TdlError>`. A return type of
-///   `Result<T, spider_tdl::TdlError>` is automatically promoted to
-///   `Result<(T,), spider_tdl::TdlError>`.
+/// * Return `Result<(T1, T2, ...), spider_tdl::TdlError>`. A return type of `Result<T,
+///   spider_tdl::TdlError>` is automatically promoted to `Result<(T,), spider_tdl::TdlError>`.
 ///
 /// # Arguments
 ///

--- a/components/spider-tdl-derive/src/lib.rs
+++ b/components/spider-tdl-derive/src/lib.rs
@@ -1,0 +1,51 @@
+//! Procedural macros that support the [`spider_tdl`](../spider_tdl/index.html) crate.
+//!
+//! Currently, the only macro provided is the [`macro@task`] attribute macro, which transforms a
+//! user-authored function into the marker struct, params struct, and `Task` trait implementation
+//! consumed by the runtime.
+
+mod task_macro;
+
+use proc_macro::TokenStream;
+use syn::{ItemFn, parse_macro_input};
+use task_macro::TaskAttr;
+
+/// Attribute macro that transforms a function into a Spider TDL–compatible task.
+///
+/// The annotated function must:
+///
+/// * Be a free-standing function (i.e., no `self` parameter).
+/// * Accept `spider_tdl::TaskContext` as its first parameter. Type aliases and fully qualified
+///   paths are allowed. This requirement is enforced at compile time via a generated assertion, so
+///   any type that does not resolve to `TaskContext` will produce a type error.
+/// * Return `Result<(T1, T2, ...), TdlError>`. A return type of `Result<T, TdlError>` is
+///   automatically promoted to `Result<(T,), TdlError>`.
+///
+/// # Arguments
+///
+/// * `name = "..."` (optional): Overrides the registered task name. If omitted, the function name
+///   is used as-is (no module or namespace prefix is added).
+///
+/// # Example
+///
+/// ```ignore
+/// use spider_tdl::{r#std::int32, task, TaskContext, TdlError};
+///
+/// #[task]
+/// fn add(_ctx: TaskContext, a: int32, b: int32) -> Result<(int32,), TdlError> {
+///     Ok((a + b,))
+/// }
+///
+/// #[task(name = "math::sub")]
+/// fn sub(_ctx: TaskContext, a: int32, b: int32) -> Result<int32, TdlError> {
+///     Ok(a - b)
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn task(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let attr = parse_macro_input!(attr as TaskAttr);
+    let item = parse_macro_input!(item as ItemFn);
+    task_macro::expand(&attr, &item)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}

--- a/components/spider-tdl-derive/src/lib.rs
+++ b/components/spider-tdl-derive/src/lib.rs
@@ -17,9 +17,10 @@ use task_macro::TaskAttr;
 /// * Be a free-standing function (i.e., no `self` parameter).
 /// * Accept `spider_tdl::TaskContext` as its first parameter. Type aliases and fully qualified
 ///   paths are allowed. This requirement is enforced at compile time via a generated assertion, so
-///   any type that does not resolve to `TaskContext` will produce a type error.
-/// * Return `Result<(T1, T2, ...), TdlError>`. A return type of `Result<T, TdlError>` is
-///   automatically promoted to `Result<(T,), TdlError>`.
+///   any type that does not resolve to `spider_tdl::TaskContext` will produce a type error.
+/// * Return `Result<(T1, T2, ...), spider_tdl::TdlError>`. A return type of
+///   `Result<T, spider_tdl::TdlError>` is automatically promoted to
+///   `Result<(T,), spider_tdl::TdlError>`.
 ///
 /// # Arguments
 ///

--- a/components/spider-tdl-derive/src/task_macro.rs
+++ b/components/spider-tdl-derive/src/task_macro.rs
@@ -1,0 +1,602 @@
+//! Implementation of the `#[task]` attribute macro.
+//!
+//! The macro replaces the annotated function with three items:
+//!
+//! 1. A unit marker struct that shares the function's identifier and visibility.
+//! 2. A private params struct holding the non-context parameters, with
+//!    `#[derive(serde::Deserialize)]` so the runtime can rebuild it from wire bytes.
+//! 3. An `impl spider_tdl::Task` for the marker struct that wires the params back into the
+//!    user-authored function body.
+//!
+//! See the crate-level docs of [`spider_tdl_derive`] for usage examples.
+
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{
+    FnArg,
+    GenericArgument,
+    ItemFn,
+    LitStr,
+    Pat,
+    PathArguments,
+    ReturnType,
+    Token,
+    Type,
+    parse::{Parse, ParseStream},
+};
+
+/// Parsed representation of the `#[task(...)]` attribute arguments.
+pub struct TaskAttr {
+    /// The name alias of the task.
+    name: Option<LitStr>,
+}
+
+impl Parse for TaskAttr {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        if input.is_empty() {
+            return Ok(Self { name: None });
+        }
+
+        let ident: syn::Ident = input.parse()?;
+        if ident != "name" {
+            return Err(syn::Error::new_spanned(&ident, "expected `name = \"...\"`"));
+        }
+        input.parse::<Token![=]>()?;
+        let name: LitStr = input.parse()?;
+        Ok(Self { name: Some(name) })
+    }
+}
+
+/// Expands a `#[task]`-annotated function into a marker struct, params struct, and
+/// [`spider_tdl::Task`] trait implementation.
+///
+/// # NOTE
+///
+/// * The first parameter's type is *not* validated syntactically here; the generated code includes
+///   a private assertion method whose signature requires the type to resolve to
+///   [`spider_tdl::TaskContext`], so any mismatch (including aliases that point at an unrelated
+///   type) surfaces as a type-checker error at compile time.
+/// * The error return type is *not* validated syntactically here; the generated code assumes the
+///   function body to return [`spider_tdl::TdlError`] on Err path, so any mismatch implementations
+///   will trigger a type error at compile time.
+///
+/// # Returns
+///
+/// The generated token stream on success.
+///
+/// # Errors
+///
+/// Returns an error if:
+///
+/// * Forwards [`validate_no_self`]'s return values on failure.
+/// * Forwards [`validate_has_parameters`]'s return values on failure.
+/// * Forwards [`extract_return_type`]'s return values on failure.
+///
+/// # Panics
+///
+/// Panics if:
+///
+/// * The first parameter's type is required but the function has no parameter, which is unreachable
+///   at runtime.
+pub fn expand(attr: &TaskAttr, func: &ItemFn) -> syn::Result<TokenStream> {
+    validate_no_self(func)?;
+    validate_has_parameters(func)?;
+
+    let func_name = &func.sig.ident;
+    let private_task_body_wrapper_name = format_ident!("__{func_name}");
+    let params_struct_name = format_ident!("__{func_name}_params");
+
+    let first_param = func
+        .sig
+        .inputs
+        .first()
+        .expect("validated that function has at least one parameter");
+    let FnArg::Typed(first_pat_type) = first_param else {
+        unreachable!("`self` parameters are rejected by `validate_no_self`");
+    };
+    let first_param_type = &first_pat_type.ty;
+
+    let task_params: Vec<_> = func.sig.inputs.iter().skip(1).collect();
+    let param_fields: Vec<TokenStream> = task_params
+        .iter()
+        .map(|arg| {
+            let FnArg::Typed(pat_type) = arg else {
+                unreachable!("`self` parameters are rejected by validation");
+            };
+            let pat = &pat_type.pat;
+            let ty = &pat_type.ty;
+            quote! { #pat: #ty }
+        })
+        .collect();
+    let param_field_names: Vec<&Box<Pat>> = task_params
+        .iter()
+        .map(|arg| {
+            let FnArg::Typed(pat_type) = arg else {
+                unreachable!("`self` parameters are rejected by validation");
+            };
+            &pat_type.pat
+        })
+        .collect();
+    let execute_call = if param_field_names.is_empty() {
+        quote! { Self::#private_task_body_wrapper_name(ctx) }
+    } else {
+        let positional_field_accesses =
+            param_field_names.iter().map(|name| quote! { params.#name });
+        quote! { Self::#private_task_body_wrapper_name(ctx, #(#positional_field_accesses),*) }
+    };
+
+    let params_arg = if param_field_names.is_empty() {
+        quote! { _params }
+    } else {
+        quote! { params }
+    };
+
+    let (return_type_tokens, needs_return_wrapping) = extract_return_type(&func.sig.output)?;
+    let private_task_body_wrapper = build_task_body_wrapper(
+        &private_task_body_wrapper_name,
+        func,
+        &return_type_tokens,
+        needs_return_wrapping,
+    );
+
+    let task_name_str = attr
+        .name
+        .as_ref()
+        .map_or_else(|| func_name.to_string(), LitStr::value);
+
+    let vis = &func.vis;
+
+    let expanded = quote! {
+        #[allow(non_camel_case_types)]
+        #vis struct #func_name;
+
+        impl #func_name {
+            // A compile-time assertion that the parameter type resolves to
+            // `::spider_tdl::TaskContext`. Returning `ctx` forces the compiler to require type
+            // equality (a transparent alias counts; an unrelated newtype does not). The function is
+            // never invoked at runtime.
+            #[allow(dead_code, non_snake_case, clippy::needless_pass_by_value)]
+            fn __assert_first_param_is_task_context(
+                ctx: #first_param_type,
+            ) -> ::spider_tdl::TaskContext {
+                ctx
+            }
+
+            #private_task_body_wrapper
+        }
+
+        #[allow(non_camel_case_types)]
+        #[derive(::serde::Deserialize)]
+        struct #params_struct_name {
+            #(#param_fields,)*
+        }
+
+        impl ::spider_tdl::Task for #func_name {
+            type Params = #params_struct_name;
+            type Return = #return_type_tokens;
+
+            const NAME: &'static str = #task_name_str;
+
+            fn execute(
+                ctx: ::spider_tdl::TaskContext,
+                #params_arg: Self::Params,
+            ) -> ::std::result::Result<Self::Return, ::spider_tdl::TdlError> {
+                #execute_call
+            }
+        }
+    };
+
+    Ok(expanded)
+}
+
+/// Builds the private wrapper that holds the original user task body.
+///
+/// # Returns
+///
+/// The token stream of the built private method.
+fn build_task_body_wrapper(
+    task_body_wrapper_name: &syn::Ident,
+    orig: &ItemFn,
+    return_type_tokens: &TokenStream,
+    needs_return_wrapping: bool,
+) -> TokenStream {
+    let original_params = &orig.sig.inputs;
+    let original_body = &orig.block;
+
+    if needs_return_wrapping {
+        let original_output = &orig.sig.output;
+        let ReturnType::Type(_, original_return_type) = original_output else {
+            unreachable!("validated that function has a return type");
+        };
+        let wrapped_return = quote! {
+            ::std::result::Result<#return_type_tokens, ::spider_tdl::TdlError>
+        };
+        quote! {
+            #[allow(clippy::redundant_closure_call, clippy::unnecessary_wraps)]
+            fn #task_body_wrapper_name(#original_params) -> #wrapped_return {
+                (|| -> #original_return_type #original_body)().map(|__v| (__v,))
+            }
+        }
+    } else {
+        let standardized_return = quote! {
+            ::std::result::Result<#return_type_tokens, ::spider_tdl::TdlError>
+        };
+        quote! {
+            #[allow(clippy::unnecessary_wraps)]
+            fn #task_body_wrapper_name(#original_params) -> #standardized_return
+                #original_body
+        }
+    }
+}
+
+/// Validates that no parameter is a `self` receiver.
+///
+/// # Errors
+///
+/// Returns an error if:
+///
+/// * [`syn::Error`] if any parameter is a `self` receiver.
+fn validate_no_self(func: &ItemFn) -> syn::Result<()> {
+    for arg in &func.sig.inputs {
+        if let FnArg::Receiver(receiver) = arg {
+            return Err(syn::Error::new_spanned(
+                receiver,
+                "task functions must not have a `self` parameter",
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Validates that the function declares at least one parameter (the `TaskContext`).
+///
+/// # Errors
+///
+/// Returns an error if:
+///
+/// * [`syn::Error`] if the function doesn't have parameters.
+fn validate_has_parameters(func: &ItemFn) -> syn::Result<()> {
+    if func.sig.inputs.is_empty() {
+        return Err(syn::Error::new_spanned(
+            &func.sig,
+            "task functions must have at least one parameter (`TaskContext`)",
+        ));
+    }
+    Ok(())
+}
+
+/// Extracts the `Ok` type of a `Result<...>` return type as a tuple.
+///
+/// If the user wrote a tuple type (e.g., `Result<(int32, int32), TdlError>`), it is returned
+/// as-is. If the user wrote a bare type (e.g., `Result<int32, TdlError>`), it is wrapped into a
+/// single-element tuple (`(int32,)`).
+///
+/// # Returns
+///
+/// A tuple on success, contaings:
+///
+/// * The Ok type in the original result.
+/// * A boolean indicating whether the Ok type is a bare type.
+///
+/// # Errors
+///
+/// Returns an error if:
+///
+/// * [`syn::Error`] if:
+///   * The function has no return type.
+///   * The return type is not a path expression (e.g., a tuple or reference).
+///   * The return type's last path segment is not `Result`.
+///   * `Result` is missing its generic argument list, or its first generic argument is not a type.
+fn extract_return_type(output: &ReturnType) -> syn::Result<(TokenStream, bool)> {
+    const INVALID_RETURN_TYPE_ERROR_MSG: &str =
+        "task functions must return `Result<(T, ...), TdlError>`";
+
+    let ReturnType::Type(_, return_type) = output else {
+        return Err(syn::Error::new_spanned(
+            output,
+            INVALID_RETURN_TYPE_ERROR_MSG,
+        ));
+    };
+
+    let Type::Path(type_path) = return_type.as_ref() else {
+        return Err(syn::Error::new_spanned(
+            return_type,
+            INVALID_RETURN_TYPE_ERROR_MSG,
+        ));
+    };
+
+    let last_segment = type_path
+        .path
+        .segments
+        .last()
+        .expect("return type path should have at least one segment");
+
+    if last_segment.ident != "Result" {
+        return Err(syn::Error::new_spanned(
+            return_type,
+            INVALID_RETURN_TYPE_ERROR_MSG,
+        ));
+    }
+
+    let PathArguments::AngleBracketed(angle_args) = &last_segment.arguments else {
+        return Err(syn::Error::new_spanned(
+            &last_segment.arguments,
+            "expected generic arguments on `Result`",
+        ));
+    };
+
+    if angle_args.args.len() != 2 {
+        return Err(syn::Error::new_spanned(
+            angle_args,
+            "expected exactly two generic arguments on `Result`",
+        ));
+    }
+
+    let ok_type = angle_args
+        .args
+        .first()
+        .expect("arg size has been checked above");
+    let GenericArgument::Type(ok_type) = ok_type else {
+        return Err(syn::Error::new_spanned(
+            ok_type,
+            "expected a type as the first generic argument of `Result`",
+        ));
+    };
+
+    if let Type::Tuple(tuple_type) = ok_type {
+        Ok((quote! { #tuple_type }, false))
+    } else {
+        Ok((quote! { (#ok_type,) }, true))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Parses `attr_str` as task attributes, `func_str` as a function, expands them, and returns
+    /// the normalized token-stream string.
+    ///
+    /// # Returns
+    ///
+    /// The normalized token-stream of the expanded function.
+    fn expand_to_string(attr_str: &str, func_str: &str) -> String {
+        let attr: TaskAttr = syn::parse_str(attr_str).expect("failed to parse task attribute");
+        let func: ItemFn = syn::parse_str(func_str).expect("failed to parse function");
+        let expanded = expand(&attr, &func).expect("macro expansion failed");
+        expanded.to_string()
+    }
+
+    /// # Returns
+    ///
+    /// The normalized token-stream as a string.
+    fn normalize(tokens: &TokenStream) -> String {
+        tokens.to_string()
+    }
+
+    #[test]
+    fn expand_task_with_tuple_return() {
+        let actual = expand_to_string(
+            "",
+            r"
+            pub(crate) fn add(
+                ctx: TaskContext,
+                a: int32,
+                b: int32,
+            ) -> Result<(int32, int32), TdlError> {
+                Ok((a + b, a - b))
+            }
+            ",
+        );
+
+        let expected = normalize(&quote! {
+            #[allow(non_camel_case_types)]
+            pub(crate) struct add;
+
+            impl add {
+                #[allow(dead_code, non_snake_case, clippy::needless_pass_by_value)]
+                fn __assert_first_param_is_task_context(
+                    ctx: TaskContext,
+                ) -> ::spider_tdl::TaskContext {
+                    ctx
+                }
+
+                #[allow(clippy::unnecessary_wraps)]
+                fn __add(
+                    ctx: TaskContext,
+                    a: int32,
+                    b: int32
+                ) ->::std::result::Result<(int32, int32), ::spider_tdl::TdlError> {
+                    Ok((a + b, a - b))
+                }
+            }
+
+            #[allow(non_camel_case_types)]
+            #[derive(::serde::Deserialize)]
+            struct __add_params {
+                a: int32,
+                b: int32,
+            }
+
+            impl ::spider_tdl::Task for add {
+                type Params = __add_params;
+                type Return = (int32, int32);
+
+                const NAME: &'static str = "add";
+
+                fn execute(
+                    ctx: ::spider_tdl::TaskContext,
+                    params: Self::Params,
+                ) -> ::std::result::Result<Self::Return, ::spider_tdl::TdlError> {
+                    Self::__add(ctx, params.a, params.b)
+                }
+            }
+        });
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn expand_task_empty_params() {
+        let actual = expand_to_string(
+            r#"name = "my_ns::my_task""#,
+            r"
+            fn noop(ctx: TaskContext) -> Result<(int32,), TdlError> {
+                Ok((42,))
+            }
+            ",
+        );
+
+        let expected = normalize(&quote! {
+            #[allow(non_camel_case_types)]
+            struct noop;
+
+            impl noop {
+                #[allow(dead_code, non_snake_case, clippy::needless_pass_by_value)]
+                fn __assert_first_param_is_task_context(
+                    ctx: TaskContext,
+                ) -> ::spider_tdl::TaskContext {
+                    ctx
+                }
+
+                #[allow(clippy::unnecessary_wraps)]
+                fn __noop(
+                    ctx: TaskContext
+                ) -> ::std::result::Result<(int32,), ::spider_tdl::TdlError> {
+                    Ok((42,))
+                }
+            }
+
+            #[allow(non_camel_case_types)]
+            #[derive(::serde::Deserialize)]
+            struct __noop_params {}
+
+            impl ::spider_tdl::Task for noop {
+                type Params = __noop_params;
+                type Return = (int32,);
+
+                const NAME: &'static str = "my_ns::my_task";
+
+                fn execute(
+                    ctx: ::spider_tdl::TaskContext,
+                    _params: Self::Params,
+                ) -> ::std::result::Result<Self::Return, ::spider_tdl::TdlError> {
+                    Self::__noop(ctx)
+                }
+            }
+        });
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn auto_wrap_single_value_return() {
+        let actual = expand_to_string(
+            "",
+            r"
+            fn single(ctx: TaskContext, x: int32) -> Result<int32, TdlError> {
+                let x = x * x;
+                Ok(x)
+            }
+            ",
+        );
+
+        let expected = normalize(&quote! {
+            #[allow(non_camel_case_types)]
+            struct single;
+
+            impl single {
+                #[allow(dead_code, non_snake_case, clippy::needless_pass_by_value)]
+                fn __assert_first_param_is_task_context(
+                    ctx: TaskContext,
+                ) -> ::spider_tdl::TaskContext {
+                    ctx
+                }
+
+                #[allow(clippy::redundant_closure_call, clippy::unnecessary_wraps)]
+                fn __single(ctx: TaskContext, x: int32)
+                    -> ::std::result::Result<(int32,), ::spider_tdl::TdlError>
+                {
+                    (|| -> Result<int32, TdlError> {
+                        let x = x * x;
+                        Ok(x)
+                    })().map(|__v| (__v,))
+                }
+            }
+
+            #[allow(non_camel_case_types)]
+            #[derive(::serde::Deserialize)]
+            struct __single_params {
+                x: int32,
+            }
+
+            impl ::spider_tdl::Task for single {
+                type Params = __single_params;
+                type Return = (int32,);
+
+                const NAME: &'static str = "single";
+
+                fn execute(
+                    ctx: ::spider_tdl::TaskContext,
+                    params: Self::Params,
+                ) -> ::std::result::Result<Self::Return, ::spider_tdl::TdlError> {
+                    Self::__single(ctx, params.x)
+                }
+            }
+        });
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn reject_self_parameter() {
+        let attr: TaskAttr = syn::parse_str("").expect("failed to parse attribute");
+        let func: ItemFn = syn::parse_str(
+            "fn bad(&self, ctx: TaskContext) -> Result<(int32,), TdlError> { Ok((0,)) }",
+        )
+        .expect("failed to parse function");
+
+        let err = expand(&attr, &func).expect_err("expected error for `self` parameter");
+        assert!(err.to_string().contains("self"));
+    }
+
+    #[test]
+    fn reject_no_parameters() {
+        let attr: TaskAttr = syn::parse_str("").expect("failed to parse attribute");
+        let func: ItemFn = syn::parse_str("fn bad() -> Result<(int32,), TdlError> { Ok((42,)) }")
+            .expect("failed to parse function");
+
+        let err = expand(&attr, &func).expect_err("expected error for no parameters");
+        assert!(err.to_string().contains("at least one parameter"));
+    }
+
+    #[test]
+    fn reject_non_result_return() {
+        let attr: TaskAttr = syn::parse_str("").expect("failed to parse attribute");
+        let func: ItemFn = syn::parse_str("fn bad(ctx: TaskContext) -> int32 { 42 }")
+            .expect("failed to parse function");
+
+        let err = expand(&attr, &func).expect_err("expected error for non-`Result` return");
+        assert!(err.to_string().contains("Result"));
+    }
+
+    #[test]
+    fn reject_unknown_attribute_argument() {
+        let result: syn::Result<TaskAttr> = syn::parse_str("foo = \"bar\"");
+        let Err(err) = result else {
+            panic!("expected error for unknown attribute argument");
+        };
+        assert!(err.to_string().contains("name"));
+    }
+
+    #[test]
+    fn reject_result_with_single_argument() {
+        let attr: TaskAttr = syn::parse_str("").expect("failed to parse attribute");
+        let func: ItemFn = syn::parse_str("fn bad(ctx: TaskContext) -> Result<int32> { Ok(0) }")
+            .expect("failed to parse function");
+
+        let err = expand(&attr, &func)
+            .expect_err("expected error for single-argument `Result` return type");
+        assert!(err.to_string().contains("two generic arguments"));
+    }
+}

--- a/components/spider-tdl-derive/src/task_macro.rs
+++ b/components/spider-tdl-derive/src/task_macro.rs
@@ -56,9 +56,10 @@ impl Parse for TaskAttr {
 ///   a private assertion method whose signature requires the type to resolve to
 ///   [`spider_tdl::TaskContext`], so any mismatch (including aliases that point at an unrelated
 ///   type) surfaces as a type-checker error at compile time.
-/// * The error return type is *not* validated syntactically here; the generated code assumes the
-///   function body to return [`spider_tdl::TdlError`] on Err path, so any mismatch implementations
-///   will trigger a type error at compile time.
+/// * The error return type is *not* validated syntactically here; [`build_task_body_wrapper`]
+///   syntheses the wrapper with `Result<_, ::spider_tdl::TdlError>` as its return type, so any
+///   user-declared `Err` type that does not resolve to `TdlError` produces a type-checker error at
+///   compile time.
 ///
 /// # Returns
 ///
@@ -76,8 +77,8 @@ impl Parse for TaskAttr {
 ///
 /// Panics if:
 ///
-/// * The first parameter's type is required but the function has no parameter, which is unreachable
-///   at runtime.
+/// * The first parameter's type is required but the function has no parameter. This is not
+///   reachable at runtime.
 pub fn expand(attr: &TaskAttr, func: &ItemFn) -> syn::Result<TokenStream> {
     validate_no_self(func)?;
     validate_has_parameters(func)?;
@@ -108,13 +109,13 @@ pub fn expand(attr: &TaskAttr, func: &ItemFn) -> syn::Result<TokenStream> {
             quote! { #pat: #ty }
         })
         .collect();
-    let param_field_names: Vec<&Box<Pat>> = task_params
+    let param_field_names: Vec<&Pat> = task_params
         .iter()
         .map(|arg| {
             let FnArg::Typed(pat_type) = arg else {
                 unreachable!("`self` parameters are rejected by validation");
             };
-            &pat_type.pat
+            pat_type.pat.as_ref()
         })
         .collect();
     let execute_call = if param_field_names.is_empty() {
@@ -196,15 +197,15 @@ pub fn expand(attr: &TaskAttr, func: &ItemFn) -> syn::Result<TokenStream> {
 /// The token stream of the built private method.
 fn build_task_body_wrapper(
     task_body_wrapper_name: &syn::Ident,
-    orig: &ItemFn,
+    func: &ItemFn,
     return_type_tokens: &TokenStream,
     needs_return_wrapping: bool,
 ) -> TokenStream {
-    let original_params = &orig.sig.inputs;
-    let original_body = &orig.block;
+    let original_params = &func.sig.inputs;
+    let original_body = &func.block;
 
     if needs_return_wrapping {
-        let original_output = &orig.sig.output;
+        let original_output = &func.sig.output;
         let ReturnType::Type(_, original_return_type) = original_output else {
             unreachable!("validated that function has a return type");
         };
@@ -273,7 +274,7 @@ fn validate_has_parameters(func: &ItemFn) -> syn::Result<()> {
 ///
 /// # Returns
 ///
-/// A tuple on success, contaings:
+/// A tuple on success, containing:
 ///
 /// * The Ok type in the original result.
 /// * A boolean indicating whether the Ok type is a bare type.
@@ -286,7 +287,9 @@ fn validate_has_parameters(func: &ItemFn) -> syn::Result<()> {
 ///   * The function has no return type.
 ///   * The return type is not a path expression (e.g., a tuple or reference).
 ///   * The return type's last path segment is not `Result`.
-///   * `Result` is missing its generic argument list, or its first generic argument is not a type.
+///   * `Result` is missing its generic argument list.
+///   * `Result`'s generic argument list size is not 2 (Ok and Err).
+///   * `Result`'s first generic argument is not a type.
 fn extract_return_type(output: &ReturnType) -> syn::Result<(TokenStream, bool)> {
     const INVALID_RETURN_TYPE_ERROR_MSG: &str =
         "task functions must return `Result<(T, ...), TdlError>`";
@@ -405,7 +408,7 @@ mod tests {
                 fn __add(
                     ctx: TaskContext,
                     a: int32,
-                    b: int32
+                    b: int32,
                 ) ->::std::result::Result<(int32, int32), ::spider_tdl::TdlError> {
                     Ok((a + b, a - b))
                 }
@@ -437,7 +440,7 @@ mod tests {
     }
 
     #[test]
-    fn expand_task_empty_params() {
+    fn expand_task_empty_params_and_name_alias() {
         let actual = expand_to_string(
             r#"name = "my_ns::my_task""#,
             r"

--- a/components/spider-tdl-derive/src/task_macro.rs
+++ b/components/spider-tdl-derive/src/task_macro.rs
@@ -72,13 +72,6 @@ impl Parse for TaskAttr {
 /// * Forwards [`validate_no_self`]'s return values on failure.
 /// * Forwards [`validate_has_parameters`]'s return values on failure.
 /// * Forwards [`extract_return_type`]'s return values on failure.
-///
-/// # Panics
-///
-/// Panics if:
-///
-/// * The first parameter's type is required but the function has no parameter. This is not
-///   reachable at runtime.
 pub fn expand(attr: &TaskAttr, func: &ItemFn) -> syn::Result<TokenStream> {
     validate_no_self(func)?;
     validate_has_parameters(func)?;
@@ -87,12 +80,7 @@ pub fn expand(attr: &TaskAttr, func: &ItemFn) -> syn::Result<TokenStream> {
     let private_task_body_wrapper_name = format_ident!("__{func_name}");
     let params_struct_name = format_ident!("__{func_name}_params");
 
-    let first_param = func
-        .sig
-        .inputs
-        .first()
-        .expect("validated that function has at least one parameter");
-    let FnArg::Typed(first_pat_type) = first_param else {
+    let Some(FnArg::Typed(first_pat_type)) = func.sig.inputs.first() else {
         unreachable!("`self` parameters are rejected by `validate_no_self`");
     };
     let first_param_type = &first_pat_type.ty;
@@ -335,13 +323,9 @@ fn extract_return_type(output: &ReturnType) -> syn::Result<(TokenStream, bool)> 
         ));
     }
 
-    let ok_type = angle_args
-        .args
-        .first()
-        .expect("arg size has been checked above");
-    let GenericArgument::Type(ok_type) = ok_type else {
+    let Some(GenericArgument::Type(ok_type)) = angle_args.args.first() else {
         return Err(syn::Error::new_spanned(
-            ok_type,
+            angle_args,
             "expected a type as the first generic argument of `Result`",
         ));
     };

--- a/components/spider-tdl/Cargo.toml
+++ b/components/spider-tdl/Cargo.toml
@@ -7,9 +7,10 @@ edition = "2024"
 name = "spider_tdl"
 path = "src/lib.rs"
 
-[features]
-default = []
-derive = ["dep:spider-tdl-derive"]
+[[test]]
+name = "test_task_macro"
+path = "tests/test_task_macro.rs"
+required-features = ["derive"]
 
 [dependencies]
 rmp-serde = "1.3.1"
@@ -24,7 +25,6 @@ rmp-serde = "1.3.1"
 serde = { version = "1.0.228", features = ["derive"] }
 spider-core = { path = "../spider-core" }
 
-[[test]]
-name = "test_task_macro"
-path = "tests/test_task_macro.rs"
-required-features = ["derive"]
+[features]
+default = []
+derive = ["dep:spider-tdl-derive"]

--- a/components/spider-tdl/Cargo.toml
+++ b/components/spider-tdl/Cargo.toml
@@ -7,11 +7,24 @@ edition = "2024"
 name = "spider_tdl"
 path = "src/lib.rs"
 
+[features]
+default = []
+derive = ["dep:spider-tdl-derive"]
+
 [dependencies]
 rmp-serde = "1.3.1"
 serde = { version = "1.0.228", features = ["derive"] }
 spider-core = { path = "../spider-core" }
+spider-tdl-derive = { path = "../spider-tdl-derive", optional = true }
 thiserror = "2.0.18"
 
 [dev-dependencies]
 anyhow = "1.0.98"
+rmp-serde = "1.3.1"
+serde = { version = "1.0.228", features = ["derive"] }
+spider-core = { path = "../spider-core" }
+
+[[test]]
+name = "test_task_macro"
+path = "tests/test_task_macro.rs"
+required-features = ["derive"]

--- a/components/spider-tdl/src/lib.rs
+++ b/components/spider-tdl/src/lib.rs
@@ -6,8 +6,7 @@ pub mod task_context;
 pub mod wire;
 
 pub use error::TdlError;
-pub use task::{ExecutionResult, Task, TaskHandler, TaskHandlerImpl};
-pub use task_context::TaskContext;
-
 #[cfg(feature = "derive")]
 pub use spider_tdl_derive::task;
+pub use task::{ExecutionResult, Task, TaskHandler, TaskHandlerImpl};
+pub use task_context::TaskContext;

--- a/components/spider-tdl/src/lib.rs
+++ b/components/spider-tdl/src/lib.rs
@@ -8,3 +8,6 @@ pub mod wire;
 pub use error::TdlError;
 pub use task::{ExecutionResult, Task, TaskHandler, TaskHandlerImpl};
 pub use task_context::TaskContext;
+
+#[cfg(feature = "derive")]
+pub use spider_tdl_derive::task;

--- a/components/spider-tdl/tests/test_task_macro.rs
+++ b/components/spider-tdl/tests/test_task_macro.rs
@@ -21,7 +21,7 @@ use spider_tdl::{
 };
 
 type AliasedContext = TaskContext;
-type AliasedTdlError = TdlError;
+type _AliasedTdlError = TdlError;
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
 struct Point {
@@ -63,7 +63,7 @@ fn aliased_ctx(_ctx: AliasedContext, x: int32) -> Result<(int32,), TdlError> {
 }
 
 #[task]
-fn aliased_error(_ctx: TaskContext, x: int32) -> Result<(int32,), AliasedTdlError> {
+fn aliased_error(_ctx: TaskContext, x: int32) -> Result<(int32,), _AliasedTdlError> {
     Ok((x,))
 }
 
@@ -100,7 +100,10 @@ fn make_encoded_ctx() -> Vec<u8> {
 ///
 /// * Forwards [`rmp_serde::to_vec`]'s return values on failure.
 /// * Forwards [`TaskInputsSerializer::append`]'s return values on failure.
-fn append_value<Val: Serialize>(inputs: &mut TaskInputsSerializer, value: &Val) -> anyhow::Result<()> {
+fn append_value<Val: Serialize>(
+    inputs: &mut TaskInputsSerializer,
+    value: &Val,
+) -> anyhow::Result<()> {
     inputs.append(TaskInput::ValuePayload(rmp_serde::to_vec(value)?))?;
     Ok(())
 }
@@ -125,9 +128,14 @@ fn append_value<Val: Serialize>(inputs: &mut TaskInputsSerializer, value: &Val) 
 /// # Panics
 ///
 /// Panics if `index` is out of bounds for the decoded output payloads.
-fn decode_outputs<Val: for<'de> Deserialize<'de>>(bytes: &[u8], index: usize) -> anyhow::Result<Val> {
+fn decode_outputs<Val: for<'de> Deserialize<'de>>(
+    bytes: &[u8],
+    index: usize,
+) -> anyhow::Result<Val> {
     let outputs = TaskOutputsSerializer::deserialize(bytes)?;
-    Ok(rmp_serde::from_slice(&outputs.get(index).expect("index out of bound"))?)
+    Ok(rmp_serde::from_slice(
+        outputs.get(index).expect("index out of bound"),
+    )?)
 }
 
 #[test]

--- a/components/spider-tdl/tests/test_task_macro.rs
+++ b/components/spider-tdl/tests/test_task_macro.rs
@@ -1,0 +1,314 @@
+//! End-to-end tests for the `#[task]` proc macro.
+//!
+//! These tests live in the integration-test crate so that the macro is consumed exactly the way a
+//! downstream TDL package would consume it: through the `spider_tdl::task` re-export, with the
+//! generated code resolving `::spider_tdl` and `::serde` as external crates.
+
+use serde::{Deserialize, Serialize};
+use spider_core::types::{
+    id::{JobId, ResourceGroupId, TaskId},
+    io::TaskInput,
+};
+use spider_tdl::{
+    Task,
+    TaskContext,
+    TaskHandler,
+    TaskHandlerImpl,
+    TdlError,
+    r#std::int32,
+    task,
+    wire::{TaskInputsSerializer, TaskOutputsSerializer},
+};
+
+// Verify that a type alias for [`TaskContext`] is accepted as the first parameter. The macro
+// validates this via a generated type-checked assertion method rather than a syntactic identifier
+// match, so this would fail to compile if the alias isn't honoured.
+type AliasedContext = TaskContext;
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
+struct Point {
+    x: int32,
+    y: int32,
+}
+
+#[task]
+fn add(_ctx: TaskContext, a: int32, b: int32) -> Result<(int32,), TdlError> {
+    Ok((a + b,))
+}
+
+#[task]
+fn divmod(_ctx: TaskContext, a: int32, b: int32) -> Result<(int32, int32), TdlError> {
+    if b == 0 {
+        return Err(TdlError::ExecutionError("division by zero".to_owned()));
+    }
+    Ok((a / b, a % b))
+}
+
+#[task]
+fn double_it(_ctx: TaskContext, x: int32) -> Result<int32, TdlError> {
+    Ok(x * 2)
+}
+
+#[task]
+fn answer(_ctx: TaskContext) -> Result<(int32,), TdlError> {
+    Ok((42,))
+}
+
+#[task(name = "math::custom_name")]
+fn renamed(_ctx: TaskContext, x: int32) -> Result<(int32,), TdlError> {
+    Ok((x,))
+}
+
+#[task]
+fn aliased_ctx(_ctx: AliasedContext, x: int32) -> Result<(int32,), TdlError> {
+    Ok((x,))
+}
+
+#[task]
+fn aliased_error(_ctx: TaskContext, x: int32) -> Result<(int32,), TdlError> {
+    Ok((x,))
+}
+
+#[task]
+fn translate(_ctx: TaskContext, p: Point, dx: int32, dy: int32) -> Result<(Point,), TdlError> {
+    Ok((Point {
+        x: p.x + dx,
+        y: p.y + dy,
+    },))
+}
+
+/// # Returns
+///
+/// A mocked encoded task context for testing.
+fn make_encoded_ctx() -> Vec<u8> {
+    let ctx = TaskContext {
+        job_id: JobId::new(),
+        task_id: TaskId::new(),
+        task_instance_id: 1,
+        resource_group_id: ResourceGroupId::new(),
+    };
+    rmp_serde::to_vec(&ctx).expect("failed to serialize `TaskContext`")
+}
+
+/// Appends the given value to the input serializer.
+///
+/// # Type Parameters
+///
+/// * `T` - The type of the value to append.
+///
+/// # Errors
+///
+/// Returns an error if:
+///
+/// * Forwards [`rmp_serde::to_vec`]'s return values on failure.
+/// * Forwards [`TaskInputsSerializer::append`]'s return values on failure.
+fn append_value<T: Serialize>(inputs: &mut TaskInputsSerializer, value: &T) -> anyhow::Result<()> {
+    inputs.append(TaskInput::ValuePayload(rmp_serde::to_vec(value)?))?;
+    Ok(())
+}
+
+/// Decodes the wire-format output buffer and deserializes the payload at the given index.
+///
+/// # Type Parameters
+///
+/// * `T` - The type to deserialize the indexed payload into.
+///
+/// # Returns
+///
+/// The deserialized value at `index` on success.
+///
+/// # Errors
+///
+/// Returns an error if:
+///
+/// * Forwards [`TaskOutputsSerializer::deserialize`]'s return values on failure.
+/// * Forwards [`rmp_serde::from_slice`]'s return values on failure.
+///
+/// # Panics
+///
+/// Panics if `index` is out of bounds for the decoded output payloads.
+fn decode_outputs<T: for<'de> Deserialize<'de>>(bytes: &[u8], index: usize) -> anyhow::Result<T> {
+    let outputs = TaskOutputsSerializer::deserialize(bytes)?;
+    Ok(rmp_serde::from_slice(&outputs.get(index).expect("invalid index"))?)
+}
+
+#[test]
+fn task_name_defaults_to_function_name() {
+    assert_eq!(<add as Task>::NAME, "add");
+    assert_eq!(<divmod as Task>::NAME, "divmod");
+    assert_eq!(<answer as Task>::NAME, "answer");
+}
+
+#[test]
+fn task_name_can_be_overridden() {
+    assert_eq!(<renamed as Task>::NAME, "math::custom_name");
+}
+
+#[test]
+fn aliased_task_context_compiles_and_runs() -> anyhow::Result<()> {
+    const INPUT: int32 = 7;
+
+    let handler = TaskHandlerImpl::<aliased_ctx>::new();
+
+    let mut inputs = TaskInputsSerializer::new();
+    append_value(&mut inputs, &INPUT)?;
+    let raw_args = inputs.release();
+
+    let result = handler.execute_raw(&make_encoded_ctx(), &raw_args);
+    let bytes = result.map_err(|e| anyhow::anyhow!("expected outputs, got error bytes: {e:?}"))?;
+
+    let value: int32 = decode_outputs(&bytes, 0)?;
+    assert_eq!(value, INPUT);
+    Ok(())
+}
+
+#[test]
+fn aliased_tdl_error_compiles_and_runs() -> anyhow::Result<()> {
+    const INPUT: int32 = 11;
+
+    let handler = TaskHandlerImpl::<aliased_error>::new();
+
+    let mut inputs = TaskInputsSerializer::new();
+    append_value(&mut inputs, &INPUT)?;
+    let raw_args = inputs.release();
+
+    let result = handler.execute_raw(&make_encoded_ctx(), &raw_args);
+    let bytes = result.map_err(|e| anyhow::anyhow!("expected outputs, got error bytes: {e:?}"))?;
+
+    let value: int32 = decode_outputs(&bytes, 0)?;
+    assert_eq!(value, INPUT);
+    Ok(())
+}
+
+#[test]
+fn handler_runs_tuple_return_task() -> anyhow::Result<()> {
+    const DIVIDEND: int32 = 17;
+    const DIVISOR: int32 = 5;
+    const EXPECTED_QUOTIENT: int32 = DIVIDEND / DIVISOR;
+    const EXPECTED_REMAINDER: int32 = DIVIDEND % DIVISOR;
+
+    let handler = TaskHandlerImpl::<divmod>::new();
+    assert_eq!(handler.name(), "divmod");
+
+    let mut inputs = TaskInputsSerializer::new();
+    append_value(&mut inputs, &DIVIDEND)?;
+    append_value(&mut inputs, &DIVISOR)?;
+    let raw_args = inputs.release();
+
+    let result = handler.execute_raw(&make_encoded_ctx(), &raw_args);
+    let bytes = result.map_err(|e| anyhow::anyhow!("expected outputs, got error bytes: {e:?}"))?;
+
+    let outputs = TaskOutputsSerializer::deserialize(&bytes)?;
+    assert_eq!(outputs.len(), 2);
+    let quotient: int32 = rmp_serde::from_slice(&outputs[0])?;
+    let remainder: int32 = rmp_serde::from_slice(&outputs[1])?;
+    assert_eq!(quotient, EXPECTED_QUOTIENT);
+    assert_eq!(remainder, EXPECTED_REMAINDER);
+    Ok(())
+}
+
+#[test]
+fn handler_runs_single_value_return_task() -> anyhow::Result<()> {
+    const INPUT: int32 = 21;
+    const EXPECTED_OUTPUT: int32 = INPUT * 2;
+
+    let handler = TaskHandlerImpl::<double_it>::new();
+
+    let mut inputs = TaskInputsSerializer::new();
+    append_value(&mut inputs, &INPUT)?;
+    let raw_args = inputs.release();
+
+    let result = handler.execute_raw(&make_encoded_ctx(), &raw_args);
+    let bytes = result.map_err(|e| anyhow::anyhow!("expected outputs, got error bytes: {e:?}"))?;
+
+    let value: int32 = decode_outputs(&bytes, 0)?;
+    assert_eq!(value, EXPECTED_OUTPUT);
+    Ok(())
+}
+
+#[test]
+fn handler_runs_no_params_task() -> anyhow::Result<()> {
+    const EXPECTED_VALUE: int32 = 42;
+
+    let handler = TaskHandlerImpl::<answer>::new();
+
+    let raw_args = TaskInputsSerializer::new().release();
+    let result = handler.execute_raw(&make_encoded_ctx(), &raw_args);
+    let bytes = result.map_err(|e| anyhow::anyhow!("expected outputs, got error bytes: {e:?}"))?;
+
+    let value: int32 = decode_outputs(&bytes, 0)?;
+    assert_eq!(value, EXPECTED_VALUE);
+    Ok(())
+}
+
+#[test]
+fn handler_runs_struct_param_task() -> anyhow::Result<()> {
+    const INITIAL_POINT: Point = Point { x: 1, y: 2 };
+    const DX: int32 = 10;
+    const DY: int32 = 20;
+    const EXPECTED_POINT: Point = Point {
+        x: INITIAL_POINT.x + DX,
+        y: INITIAL_POINT.y + DY,
+    };
+
+    let handler = TaskHandlerImpl::<translate>::new();
+
+    let mut inputs = TaskInputsSerializer::new();
+    append_value(&mut inputs, &INITIAL_POINT)?;
+    append_value(&mut inputs, &DX)?;
+    append_value(&mut inputs, &DY)?;
+    let raw_args = inputs.release();
+
+    let result = handler.execute_raw(&make_encoded_ctx(), &raw_args);
+    let bytes = result.map_err(|e| anyhow::anyhow!("expected outputs, got error bytes: {e:?}"))?;
+
+    let translated: Point = decode_outputs(&bytes, 0)?;
+    assert_eq!(translated, EXPECTED_POINT);
+    Ok(())
+}
+
+#[test]
+fn handler_propagates_task_error() -> anyhow::Result<()> {
+    const DIVIDEND: int32 = 10;
+    const DIVISOR: int32 = 0;
+
+    let handler = TaskHandlerImpl::<divmod>::new();
+
+    let mut inputs = TaskInputsSerializer::new();
+    append_value(&mut inputs, &DIVIDEND)?;
+    append_value(&mut inputs, &DIVISOR)?;
+    let raw_args = inputs.release();
+
+    let result = handler.execute_raw(&make_encoded_ctx(), &raw_args);
+    let Err(bytes) = result else {
+        panic!("expected error bytes, got outputs");
+    };
+
+    let err: TdlError = rmp_serde::from_slice(&bytes)?;
+    assert!(matches!(err, TdlError::ExecutionError(ref msg) if msg == "division by zero"));
+    Ok(())
+}
+
+#[test]
+fn direct_execute_call_round_trips() -> anyhow::Result<()> {
+    const OPERAND_A: int32 = 7;
+    const OPERAND_B: int32 = 35;
+    const EXPECTED_SUM: int32 = OPERAND_A + OPERAND_B;
+
+    let ctx = TaskContext {
+        job_id: JobId::new(),
+        task_id: TaskId::new(),
+        task_instance_id: 1,
+        resource_group_id: ResourceGroupId::new(),
+    };
+
+    let mut inputs = TaskInputsSerializer::new();
+    append_value(&mut inputs, &OPERAND_A)?;
+    append_value(&mut inputs, &OPERAND_B)?;
+    let raw_args = inputs.release();
+
+    let params = TaskInputsSerializer::deserialize::<<add as Task>::Params>(&raw_args)?;
+    let (sum,) = <add as Task>::execute(ctx, params)?;
+    assert_eq!(sum, EXPECTED_SUM);
+    Ok(())
+}

--- a/components/spider-tdl/tests/test_task_macro.rs
+++ b/components/spider-tdl/tests/test_task_macro.rs
@@ -20,10 +20,8 @@ use spider_tdl::{
     wire::{TaskInputsSerializer, TaskOutputsSerializer},
 };
 
-// Verify that a type alias for [`TaskContext`] is accepted as the first parameter. The macro
-// validates this via a generated type-checked assertion method rather than a syntactic identifier
-// match, so this would fail to compile if the alias isn't honoured.
 type AliasedContext = TaskContext;
+type AliasedTdlError = TdlError;
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
 struct Point {
@@ -65,7 +63,7 @@ fn aliased_ctx(_ctx: AliasedContext, x: int32) -> Result<(int32,), TdlError> {
 }
 
 #[task]
-fn aliased_error(_ctx: TaskContext, x: int32) -> Result<(int32,), TdlError> {
+fn aliased_error(_ctx: TaskContext, x: int32) -> Result<(int32,), AliasedTdlError> {
     Ok((x,))
 }
 
@@ -94,7 +92,7 @@ fn make_encoded_ctx() -> Vec<u8> {
 ///
 /// # Type Parameters
 ///
-/// * `T` - The type of the value to append.
+/// * `Val` - The type of the value to append.
 ///
 /// # Errors
 ///
@@ -102,7 +100,7 @@ fn make_encoded_ctx() -> Vec<u8> {
 ///
 /// * Forwards [`rmp_serde::to_vec`]'s return values on failure.
 /// * Forwards [`TaskInputsSerializer::append`]'s return values on failure.
-fn append_value<T: Serialize>(inputs: &mut TaskInputsSerializer, value: &T) -> anyhow::Result<()> {
+fn append_value<Val: Serialize>(inputs: &mut TaskInputsSerializer, value: &Val) -> anyhow::Result<()> {
     inputs.append(TaskInput::ValuePayload(rmp_serde::to_vec(value)?))?;
     Ok(())
 }
@@ -111,7 +109,7 @@ fn append_value<T: Serialize>(inputs: &mut TaskInputsSerializer, value: &T) -> a
 ///
 /// # Type Parameters
 ///
-/// * `T` - The type to deserialize the indexed payload into.
+/// * `Val` - The type to deserialize the indexed payload into.
 ///
 /// # Returns
 ///
@@ -127,9 +125,9 @@ fn append_value<T: Serialize>(inputs: &mut TaskInputsSerializer, value: &T) -> a
 /// # Panics
 ///
 /// Panics if `index` is out of bounds for the decoded output payloads.
-fn decode_outputs<T: for<'de> Deserialize<'de>>(bytes: &[u8], index: usize) -> anyhow::Result<T> {
+fn decode_outputs<Val: for<'de> Deserialize<'de>>(bytes: &[u8], index: usize) -> anyhow::Result<Val> {
     let outputs = TaskOutputsSerializer::deserialize(bytes)?;
-    Ok(rmp_serde::from_slice(&outputs.get(index).expect("invalid index"))?)
+    Ok(rmp_serde::from_slice(&outputs.get(index).expect("index out of bound"))?)
 }
 
 #[test]


### PR DESCRIPTION
* Add `spider-tdl-derive` crate housing the `#[task]` macro.
* Re-export `#[task]` from `spider-tdl` behind the optional `derive` feature.

<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

As the title suggests. This PR is one of the PR series #302 that implements the task proc-macro.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Add unit tests to assert the generated tasks match the expected.
* [x] Add integration tests to assert the macro-converted tasks are usable by the TDL task framework.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a #[task] procedural macro attribute for concise task definitions, automatic parameter (de)serialization, standardized return shaping and error handling.
  * Introduced an optional "derive" feature and a new derive crate to enable compile-time validation and feature-gated task re-exporting.
  * Tasks support overridable names via attribute metadata.

* **Tests**
  * Added end-to-end integration tests covering macro-generated tasks, serialization roundtrips, execution and error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->