### PR TITLE
feat(spider-storage): Add `JobCache` and `StorageServerError`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,11 +129,12 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const_format"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
 dependencies = [
  "const_format_proc_macros",
+ "konst",
 ]
 
 [[package]]
@@ -167,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crossbeam-queue"
@@ -395,6 +396,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +426,7 @@ checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -639,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -667,13 +680,30 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "lazy_static"
@@ -692,9 +722,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -711,7 +741,7 @@ dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall 0.7.4",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -793,7 +823,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -1010,9 +1040,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -1078,9 +1108,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags",
 ]
@@ -1359,6 +1389,7 @@ dependencies = [
  "tabled",
  "thiserror",
  "tokio",
+ "tokio-util",
  "uuid",
 ]
 
@@ -1517,7 +1548,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "sha1",
@@ -1556,7 +1587,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",
@@ -1751,9 +1782,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.0"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",
@@ -1782,6 +1813,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -1820,9 +1865,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-bidi"
@@ -1883,9 +1928,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -1913,11 +1958,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -1926,7 +1971,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -1937,9 +1982,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1950,9 +1995,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1960,9 +2005,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1973,9 +2018,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -2135,6 +2180,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/components/spider-storage/Cargo.toml
+++ b/components/spider-storage/Cargo.toml
@@ -39,4 +39,5 @@ rand = "0.9.1"
 serial_test = { version = "3.2.0", features = ["file_locks"] }
 tabled = "0.20.0"
 tokio = { version = "1.50.0", features = ["macros", "rt-multi-thread", "sync"] }
+tokio-util = { version = "0.7", features = ["rt"] }
 uuid = { version = "1.19.0", features = ["v4"] }

--- a/components/spider-storage/Cargo.toml
+++ b/components/spider-storage/Cargo.toml
@@ -16,6 +16,7 @@ path = "tests/test_spider_storage.rs"
 async-channel = "2.3.1"
 async-trait = "0.1.89"
 const_format = "0.2.35"
+dashmap = "6.1.0"
 rmp-serde = "1.3.1"
 secrecy = { version = "0.10.3", features = ["serde"] }
 serde = { version = "1.0.228", features = ["derive"] }
@@ -34,7 +35,6 @@ uuid = { version = "1.19.0", features = ["serde"] }
 
 [dev-dependencies]
 anyhow = "1.0.98"
-dashmap = "6.1.0"
 rand = "0.9.1"
 serial_test = { version = "3.2.0", features = ["file_locks"] }
 tabled = "0.20.0"

--- a/components/spider-storage/src/cache/job.rs
+++ b/components/spider-storage/src/cache/job.rs
@@ -154,13 +154,12 @@ impl<
     /// * [`JobState::CleanupReady`] — the cleanup task via
     ///   [`ReadyQueueSender::send_cleanup_ready`].
     ///
+    /// For other job states, this method is a no-op and returns `Ok(())`.
+    ///
     /// # Errors
     ///
     /// Returns an error if:
     ///
-    /// * Forwards [`JobExecutionStateHandle::read_running`]'s return values on failure.
-    /// * Forwards [`JobExecutionStateHandle::read_commit_ready`]'s return values on failure.
-    /// * Forwards [`JobExecutionStateHandle::read_cleanup_ready`]'s return values on failure.
     /// * Forwards [`ReadyQueueSender::send_task_ready`]'s return values on failure.
     /// * Forwards [`ReadyQueueSender::send_commit_ready`]'s return values on failure.
     /// * Forwards [`ReadyQueueSender::send_cleanup_ready`]'s return values on failure.

--- a/components/spider-storage/src/cache/job.rs
+++ b/components/spider-storage/src/cache/job.rs
@@ -103,6 +103,12 @@ impl<
         })
     }
 
+    /// Returns the job ID.
+    #[must_use]
+    pub fn id(&self) -> JobId {
+        self.inner.id
+    }
+
     /// Starts the job.
     ///
     /// Any tasks in [`TaskState::Ready`] will be enqueued to the ready queue on success.

--- a/components/spider-storage/src/cache/job.rs
+++ b/components/spider-storage/src/cache/job.rs
@@ -140,6 +140,8 @@ impl<
 
     /// Resends all ready tasks to the ready queue.
     ///
+    /// The method handles the following job states:
+    ///
     /// * [`JobState::Running`] — all tasks in [`TaskState::Ready`] via
     ///   [`ReadyQueueSender::send_task_ready`].
     /// * [`JobState::CommitReady`] — the commit task via [`ReadyQueueSender::send_commit_ready`].

--- a/components/spider-storage/src/cache/job.rs
+++ b/components/spider-storage/src/cache/job.rs
@@ -138,6 +138,54 @@ impl<
         Ok(())
     }
 
+    /// Resends all ready tasks to the ready queue.
+    ///
+    /// * [`JobState::Running`] — all tasks in [`TaskState::Ready`] via
+    ///   [`ReadyQueueSender::send_task_ready`].
+    /// * [`JobState::CommitReady`] — the commit task via [`ReadyQueueSender::send_commit_ready`].
+    /// * [`JobState::CleanupReady`] — the cleanup task via
+    ///   [`ReadyQueueSender::send_cleanup_ready`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * Forwards [`JobExecutionStateHandle::read_running`]'s return values on failure.
+    /// * Forwards [`JobExecutionStateHandle::read_commit_ready`]'s return values on failure.
+    /// * Forwards [`JobExecutionStateHandle::read_cleanup_ready`]'s return values on failure.
+    /// * Forwards [`ReadyQueueSender::send_task_ready`]'s return values on failure.
+    /// * Forwards [`ReadyQueueSender::send_commit_ready`]'s return values on failure.
+    /// * Forwards [`ReadyQueueSender::send_cleanup_ready`]'s return values on failure.
+    pub async fn resend_ready_tasks(&self) -> Result<(), CacheError> {
+        let jcb = &self.inner;
+
+        if let Ok(job) = jcb.job_execution_state.read_running().await {
+            let ready_task_indices = job.task_graph.get_all_ready_task_indices().await;
+            if !ready_task_indices.is_empty() {
+                job.ready_queue_sender
+                    .send_task_ready(jcb.owner_id, jcb.id, ready_task_indices)
+                    .await?;
+            }
+            return Ok(());
+        }
+
+        if let Ok(job) = jcb.job_execution_state.read_commit_ready().await {
+            job.ready_queue_sender
+                .send_commit_ready(jcb.owner_id, jcb.id)
+                .await?;
+            return Ok(());
+        }
+
+        if let Ok(job) = jcb.job_execution_state.read_cleanup_ready().await {
+            job.ready_queue_sender
+                .send_cleanup_ready(jcb.owner_id, jcb.id)
+                .await?;
+            return Ok(());
+        }
+
+        Ok(())
+    }
+
     /// Creates a task instance for the given task and registers it in the task instance pool.
     ///
     /// # Returns

--- a/components/spider-storage/src/lib.rs
+++ b/components/spider-storage/src/lib.rs
@@ -2,6 +2,7 @@ pub mod cache;
 mod config;
 pub mod db;
 pub mod ready_queue;
+pub mod state;
 pub mod task_instance_pool;
 
 pub use config::DatabaseConfig;

--- a/components/spider-storage/src/state.rs
+++ b/components/spider-storage/src/state.rs
@@ -1,0 +1,5 @@
+pub mod error;
+pub mod job_cache;
+
+pub use error::StorageServerError;
+pub use job_cache::JobCache;

--- a/components/spider-storage/src/state/error.rs
+++ b/components/spider-storage/src/state/error.rs
@@ -9,10 +9,10 @@ use crate::{
 #[derive(thiserror::Error, Debug)]
 pub enum StorageServerError {
     #[error(transparent)]
-    Internal(#[from] InternalError),
+    CacheInternal(#[from] InternalError),
 
     #[error(transparent)]
-    StaleState(#[from] StaleStateError),
+    CacheStaleState(#[from] StaleStateError),
 
     #[error("stale session")]
     StaleSession,

--- a/components/spider-storage/src/state/error.rs
+++ b/components/spider-storage/src/state/error.rs
@@ -21,10 +21,10 @@ pub enum StorageServerError {
     Db(#[from] DbError),
 
     #[error("server is shutting down: {0}")]
-    Stopping(&'static str),
+    Stopping(String),
 
     #[error("bad request: {0}")]
-    BadRequest(&'static str),
+    BadRequest(String),
 
     #[error("job already exists: {0:?}")]
     JobAlreadyExists(JobId),

--- a/components/spider-storage/src/state/error.rs
+++ b/components/spider-storage/src/state/error.rs
@@ -1,18 +1,12 @@
 use spider_core::types::id::JobId;
 
-use crate::{
-    cache::error::{InternalError, StaleStateError},
-    db::DbError,
-};
+use crate::{cache::error::CacheError, db::DbError};
 
 /// Errors that can occur during storage server operations.
 #[derive(thiserror::Error, Debug)]
 pub enum StorageServerError {
     #[error(transparent)]
-    CacheInternal(#[from] InternalError),
-
-    #[error(transparent)]
-    CacheStaleState(#[from] StaleStateError),
+    Cache(#[from] CacheError),
 
     #[error("stale session")]
     StaleSession,

--- a/components/spider-storage/src/state/error.rs
+++ b/components/spider-storage/src/state/error.rs
@@ -1,6 +1,6 @@
 use spider_core::types::id::JobId;
 
-use crate::{cache::error::CacheError, db::DbError};
+use crate::cache::error::CacheError;
 
 /// Errors that can occur during storage server operations.
 #[derive(thiserror::Error, Debug)]
@@ -10,9 +10,6 @@ pub enum StorageServerError {
 
     #[error("stale session")]
     StaleSession,
-
-    #[error(transparent)]
-    Db(#[from] DbError),
 
     #[error("server is shutting down: {0}")]
     Stopping(String),

--- a/components/spider-storage/src/state/error.rs
+++ b/components/spider-storage/src/state/error.rs
@@ -1,3 +1,5 @@
+use spider_core::types::id::JobId;
+
 use crate::{
     cache::error::{InternalError, StaleStateError},
     db::DbError,
@@ -18,9 +20,12 @@ pub enum StorageServerError {
     #[error(transparent)]
     Db(#[from] DbError),
 
-    #[error("server is stopping: {0}")]
+    #[error("server is shutting down: {0}")]
     Stopping(&'static str),
 
     #[error("bad request: {0}")]
     BadRequest(&'static str),
+
+    #[error("job already exists: {0:?}")]
+    JobAlreadyExists(JobId),
 }

--- a/components/spider-storage/src/state/error.rs
+++ b/components/spider-storage/src/state/error.rs
@@ -1,0 +1,26 @@
+use crate::{
+    cache::error::{InternalError, StaleStateError},
+    db::DbError,
+};
+
+/// Errors that can occur during storage server operations.
+#[derive(thiserror::Error, Debug)]
+pub enum StorageServerError {
+    #[error(transparent)]
+    Internal(#[from] InternalError),
+
+    #[error(transparent)]
+    StaleState(#[from] StaleStateError),
+
+    #[error("stale session")]
+    StaleSession,
+
+    #[error(transparent)]
+    Db(#[from] DbError),
+
+    #[error("server is stopping: {0}")]
+    Stopping(&'static str),
+
+    #[error("bad request: {0}")]
+    BadRequest(&'static str),
+}

--- a/components/spider-storage/src/state/job_cache.rs
+++ b/components/spider-storage/src/state/job_cache.rs
@@ -54,13 +54,13 @@ impl<
     ///   exists.
     pub fn insert(
         &self,
-        job_id: JobId,
         jcb: SharedJobControlBlock<
             ReadyQueueSenderType,
             DbConnectorType,
             TaskInstancePoolConnectorType,
         >,
     ) -> Result<(), StorageServerError> {
+        let job_id = jcb.id();
         match self.jobs.entry(job_id) {
             Entry::Vacant(e) => {
                 e.insert(jcb);
@@ -296,7 +296,7 @@ mod tests {
         let job_id = JobId::new();
 
         let jcb = create_test_jcb(job_id).await;
-        cache.insert(job_id, jcb)?;
+        cache.insert(jcb)?;
 
         let result = cache.get(job_id);
         assert!(result.is_some(), "inserted JCB should be retrievable");
@@ -310,7 +310,7 @@ mod tests {
         let job_id = JobId::new();
 
         let jcb = create_test_jcb(job_id).await;
-        cache.insert(job_id, jcb)?;
+        cache.insert(jcb)?;
 
         let removed = cache.remove(job_id);
         assert!(removed.is_some(), "remove should return the JCB");
@@ -341,10 +341,10 @@ mod tests {
         let job_id = JobId::new();
 
         let jcb1 = create_test_jcb(job_id).await;
-        cache.insert(job_id, jcb1)?;
+        cache.insert(jcb1)?;
 
         let jcb2 = create_test_jcb(job_id).await;
-        let result = cache.insert(job_id, jcb2);
+        let result = cache.insert(jcb2);
         assert!(
             matches!(result, Err(StorageServerError::JobAlreadyExists(_))),
             "insert should return JobAlreadyExists error for duplicate key"
@@ -372,7 +372,7 @@ mod tests {
                 let job_id = JobId::new();
                 let jcb = create_test_jcb(job_id).await;
                 cache
-                    .insert(job_id, jcb)
+                    .insert(jcb)
                     .expect("insert should succeed for new job");
 
                 let result = cache.get(job_id);
@@ -472,23 +472,24 @@ mod tests {
         .await
         .expect("JCB creation should succeed");
         jcb.start().await.expect("start should succeed");
+        calls.lock().expect("lock").clear();
 
         let cache: JobCache<
             TrackingReadyQueueSender,
             MockDbConnector,
             MockTaskInstancePoolConnector,
         > = JobCache::new();
-        cache.insert(job_id, jcb)?;
+        cache.insert(jcb)?;
 
         cache.resend_ready_tasks().await?;
 
-        let has_task_ready = {
+        let task_ready_count = {
             let recorded = calls.lock().expect("lock");
-            recorded.iter().any(|c| c == "task_ready")
+            recorded.iter().filter(|c| **c == "task_ready").count()
         };
-        assert!(
-            has_task_ready,
-            "resend_ready_tasks should have sent task_ready"
+        assert_eq!(
+            task_ready_count, 1,
+            "resend_ready_tasks should send one task_ready after the reset"
         );
         Ok(())
     }

--- a/components/spider-storage/src/state/job_cache.rs
+++ b/components/spider-storage/src/state/job_cache.rs
@@ -99,6 +99,20 @@ impl<
     > {
         self.jobs.remove(&job_id).map(|(_, v)| v)
     }
+
+    /// Resends all ready tasks for every job in the cache to the ready queue.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * Forwards [`SharedJobControlBlock::resend_ready_tasks`]'s return values on failure.
+    pub async fn resend_ready_tasks(&self) -> Result<(), StorageServerError> {
+        for entry in &self.jobs {
+            entry.value().resend_ready_tasks().await?;
+        }
+        Ok(())
+    }
 }
 
 impl<
@@ -114,6 +128,8 @@ impl<
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use spider_core::{
         task::{
             DataTypeDescriptor,
@@ -128,7 +144,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        cache::error::InternalError,
+        cache::{error::InternalError, job::SharedJobControlBlock},
         ready_queue::ReadyQueueSender,
         task_instance_pool::{TaskInstanceMetadata, TaskInstancePoolConnector},
     };
@@ -382,5 +398,108 @@ mod tests {
 
         tracker.close();
         tracker.wait().await;
+    }
+
+    /// A tracking ready queue sender that records calls.
+    #[derive(Clone, Default)]
+    struct TrackingReadyQueueSender {
+        calls: Arc<std::sync::Mutex<Vec<String>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl ReadyQueueSender for TrackingReadyQueueSender {
+        async fn send_task_ready(
+            &self,
+            _rg_id: spider_core::types::id::ResourceGroupId,
+            _job_id: JobId,
+            _task_indices: Vec<usize>,
+        ) -> Result<(), InternalError> {
+            self.calls
+                .lock()
+                .expect("lock")
+                .push("task_ready".to_owned());
+            Ok(())
+        }
+
+        async fn send_commit_ready(
+            &self,
+            _rg_id: spider_core::types::id::ResourceGroupId,
+            _job_id: JobId,
+        ) -> Result<(), InternalError> {
+            self.calls
+                .lock()
+                .expect("lock")
+                .push("commit_ready".to_owned());
+            Ok(())
+        }
+
+        async fn send_cleanup_ready(
+            &self,
+            _rg_id: spider_core::types::id::ResourceGroupId,
+            _job_id: JobId,
+        ) -> Result<(), InternalError> {
+            self.calls
+                .lock()
+                .expect("lock")
+                .push("cleanup_ready".to_owned());
+            Ok(())
+        }
+    }
+
+    async fn create_started_test_jcb(
+        job_id: JobId,
+    ) -> SharedJobControlBlock<
+        TrackingReadyQueueSender,
+        MockDbConnector,
+        MockTaskInstancePoolConnector,
+    > {
+        let bytes_type = DataTypeDescriptor::Value(ValueTypeDescriptor::bytes());
+        let mut submitted =
+            SubmittedTaskGraph::new(None, None).expect("task graph creation should succeed");
+        submitted
+            .insert_task(TaskDescriptor {
+                tdl_context: TdlContext {
+                    package: "test_pkg".to_owned(),
+                    task_func: "test_fn".to_owned(),
+                },
+                execution_policy: Some(ExecutionPolicy::default()),
+                inputs: vec![bytes_type.clone()],
+                outputs: vec![bytes_type],
+                input_sources: None,
+            })
+            .expect("task insertion should succeed");
+
+        let jcb = SharedJobControlBlock::create(
+            job_id,
+            spider_core::types::id::ResourceGroupId::new(),
+            &submitted,
+            vec![TaskInput::ValuePayload(vec![0u8; 4])],
+            TrackingReadyQueueSender::default(),
+            MockDbConnector,
+            MockTaskInstancePoolConnector,
+        )
+        .await
+        .expect("JCB creation should succeed");
+
+        jcb.start().await.expect("start should succeed");
+        jcb
+    }
+
+    #[tokio::test]
+    async fn job_cache_resend_ready_tasks_sends_for_running_job() {
+        let cache: JobCache<
+            TrackingReadyQueueSender,
+            MockDbConnector,
+            MockTaskInstancePoolConnector,
+        > = JobCache::new();
+        let job_id = JobId::new();
+
+        let jcb = create_started_test_jcb(job_id).await;
+        cache.insert(job_id, jcb).expect("insert should succeed");
+
+        cache
+            .resend_ready_tasks()
+            .await
+            .expect("resend should succeed");
     }
 }

--- a/components/spider-storage/src/state/job_cache.rs
+++ b/components/spider-storage/src/state/job_cache.rs
@@ -131,6 +131,7 @@ mod tests {
     use std::sync::Arc;
 
     use spider_core::{
+        job::JobState,
         task::{
             DataTypeDescriptor,
             ExecutionPolicy,
@@ -139,12 +140,20 @@ mod tests {
             TdlContext,
             ValueTypeDescriptor,
         },
-        types::{id::JobId, io::TaskInput},
+        types::{
+            id::JobId,
+            io::{TaskInput, TaskOutput},
+        },
     };
 
     use super::*;
     use crate::{
-        cache::{error::InternalError, job::SharedJobControlBlock},
+        cache::{
+            error::InternalError,
+            job::SharedJobControlBlock,
+            task::{SharedTaskControlBlock, SharedTerminationTaskControlBlock},
+        },
+        db::DbError,
         ready_queue::ReadyQueueSender,
         task_instance_pool::{TaskInstanceMetadata, TaskInstancePoolConnector},
     };
@@ -187,47 +196,35 @@ mod tests {
 
     #[async_trait::async_trait]
     impl InternalJobOrchestration for MockDbConnector {
-        async fn start(&self, _job_id: JobId) -> Result<(), crate::db::DbError> {
+        async fn start(&self, _job_id: JobId) -> Result<(), DbError> {
             Ok(())
         }
 
-        async fn set_state(
-            &self,
-            _job_id: JobId,
-            _state: spider_core::job::JobState,
-        ) -> Result<(), crate::db::DbError> {
+        async fn set_state(&self, _job_id: JobId, _state: JobState) -> Result<(), DbError> {
             Ok(())
         }
 
         async fn commit_outputs(
             &self,
             _job_id: JobId,
-            _outputs: Vec<spider_core::types::io::TaskOutput>,
+            _outputs: Vec<TaskOutput>,
             _has_commit_task: bool,
-        ) -> Result<(), crate::db::DbError> {
+        ) -> Result<(), DbError> {
             Ok(())
         }
 
-        async fn cancel(
-            &self,
-            _job_id: JobId,
-            _has_cleanup_task: bool,
-        ) -> Result<(), crate::db::DbError> {
+        async fn cancel(&self, _job_id: JobId, _has_cleanup_task: bool) -> Result<(), DbError> {
             Ok(())
         }
 
-        async fn fail(
-            &self,
-            _job_id: JobId,
-            _error_message: String,
-        ) -> Result<(), crate::db::DbError> {
+        async fn fail(&self, _job_id: JobId, _error_message: String) -> Result<(), DbError> {
             Ok(())
         }
 
         async fn delete_expired_terminated_jobs(
             &self,
             _expire_after_sec: u64,
-        ) -> Result<Vec<JobId>, crate::db::DbError> {
+        ) -> Result<Vec<JobId>, DbError> {
             Ok(Vec::new())
         }
     }
@@ -244,7 +241,7 @@ mod tests {
 
         async fn register_task_instance(
             &self,
-            _tcb: crate::cache::task::SharedTaskControlBlock,
+            _tcb: SharedTaskControlBlock,
             _registration: TaskInstanceMetadata,
         ) -> Result<(), InternalError> {
             Ok(())
@@ -252,7 +249,7 @@ mod tests {
 
         async fn register_termination_task_instance(
             &self,
-            _termination_tcb: crate::cache::task::SharedTerminationTaskControlBlock,
+            _termination_tcb: SharedTerminationTaskControlBlock,
             _registration: TaskInstanceMetadata,
         ) -> Result<(), InternalError> {
             Ok(())
@@ -293,40 +290,38 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn job_cache_insert_and_get() {
+    async fn job_cache_insert_and_get() -> anyhow::Result<()> {
         let cache: JobCache<MockReadyQueueSender, MockDbConnector, MockTaskInstancePoolConnector> =
             JobCache::new();
         let job_id = JobId::new();
 
         let jcb = create_test_jcb(job_id).await;
-        cache
-            .insert(job_id, jcb)
-            .expect("insert should succeed for new job");
+        cache.insert(job_id, jcb)?;
 
         let result = cache.get(job_id);
         assert!(result.is_some(), "inserted JCB should be retrievable");
+        Ok(())
     }
 
     #[tokio::test]
-    async fn job_cache_remove_returns_inserted_jcb() {
+    async fn job_cache_remove_returns_inserted_jcb() -> anyhow::Result<()> {
         let cache: JobCache<MockReadyQueueSender, MockDbConnector, MockTaskInstancePoolConnector> =
             JobCache::new();
         let job_id = JobId::new();
 
         let jcb = create_test_jcb(job_id).await;
-        cache
-            .insert(job_id, jcb)
-            .expect("insert should succeed for new job");
+        cache.insert(job_id, jcb)?;
 
         let removed = cache.remove(job_id);
         assert!(removed.is_some(), "remove should return the JCB");
 
         let result = cache.get(job_id);
         assert!(result.is_none(), "JCB should no longer exist after removal");
+        Ok(())
     }
 
     #[tokio::test]
-    async fn job_cache_get_returns_none_for_nonexistent_job() {
+    async fn job_cache_get_returns_none_for_nonexistent_job() -> anyhow::Result<()> {
         let cache: JobCache<MockReadyQueueSender, MockDbConnector, MockTaskInstancePoolConnector> =
             JobCache::new();
         let job_id = JobId::new();
@@ -336,18 +331,17 @@ mod tests {
             result.is_none(),
             "get should return None for nonexistent job"
         );
+        Ok(())
     }
 
     #[tokio::test]
-    async fn job_cache_insert_duplicate_returns_error() {
+    async fn job_cache_insert_duplicate_returns_error() -> anyhow::Result<()> {
         let cache: JobCache<MockReadyQueueSender, MockDbConnector, MockTaskInstancePoolConnector> =
             JobCache::new();
         let job_id = JobId::new();
 
         let jcb1 = create_test_jcb(job_id).await;
-        cache
-            .insert(job_id, jcb1)
-            .expect("first insert should succeed");
+        cache.insert(job_id, jcb1)?;
 
         let jcb2 = create_test_jcb(job_id).await;
         let result = cache.insert(job_id, jcb2);
@@ -358,12 +352,11 @@ mod tests {
         if let Err(StorageServerError::JobAlreadyExists(id)) = result {
             assert_eq!(id, job_id, "error should contain the duplicate job ID");
         }
+        Ok(())
     }
 
     #[tokio::test]
     async fn job_cache_concurrent_insert_get() {
-        use std::sync::Arc;
-
         use tokio_util::task::TaskTracker;
 
         let cache: Arc<
@@ -382,15 +375,12 @@ mod tests {
                     .insert(job_id, jcb)
                     .expect("insert should succeed for new job");
 
-                // Immediately try to get it
                 let result = cache.get(job_id);
                 assert!(result.is_some(), "task {i} should find inserted JCB");
 
-                // Try to remove it
                 let removed = cache.remove(job_id);
                 assert!(removed.is_some(), "task {i} should remove inserted JCB");
 
-                // Verify it's gone
                 let result = cache.get(job_id);
                 assert!(result.is_none(), "task {i} should not find removed JCB");
             });
@@ -446,13 +436,13 @@ mod tests {
         }
     }
 
-    async fn create_started_test_jcb(
-        job_id: JobId,
-    ) -> SharedJobControlBlock<
-        TrackingReadyQueueSender,
-        MockDbConnector,
-        MockTaskInstancePoolConnector,
-    > {
+    #[tokio::test]
+    async fn job_cache_resend_ready_tasks_sends_for_running_job() -> anyhow::Result<()> {
+        let calls: Arc<std::sync::Mutex<Vec<String>>> = Arc::default();
+        let sender = TrackingReadyQueueSender {
+            calls: Arc::clone(&calls),
+        };
+
         let bytes_type = DataTypeDescriptor::Value(ValueTypeDescriptor::bytes());
         let mut submitted =
             SubmittedTaskGraph::new(None, None).expect("task graph creation should succeed");
@@ -469,37 +459,37 @@ mod tests {
             })
             .expect("task insertion should succeed");
 
+        let job_id = JobId::new();
         let jcb = SharedJobControlBlock::create(
             job_id,
             spider_core::types::id::ResourceGroupId::new(),
             &submitted,
             vec![TaskInput::ValuePayload(vec![0u8; 4])],
-            TrackingReadyQueueSender::default(),
+            sender,
             MockDbConnector,
             MockTaskInstancePoolConnector,
         )
         .await
         .expect("JCB creation should succeed");
-
         jcb.start().await.expect("start should succeed");
-        jcb
-    }
 
-    #[tokio::test]
-    async fn job_cache_resend_ready_tasks_sends_for_running_job() {
         let cache: JobCache<
             TrackingReadyQueueSender,
             MockDbConnector,
             MockTaskInstancePoolConnector,
         > = JobCache::new();
-        let job_id = JobId::new();
+        cache.insert(job_id, jcb)?;
 
-        let jcb = create_started_test_jcb(job_id).await;
-        cache.insert(job_id, jcb).expect("insert should succeed");
+        cache.resend_ready_tasks().await?;
 
-        cache
-            .resend_ready_tasks()
-            .await
-            .expect("resend should succeed");
+        let has_task_ready = {
+            let recorded = calls.lock().expect("lock");
+            recorded.iter().any(|c| c == "task_ready")
+        };
+        assert!(
+            has_task_ready,
+            "resend_ready_tasks should have sent task_ready"
+        );
+        Ok(())
     }
 }

--- a/components/spider-storage/src/state/job_cache.rs
+++ b/components/spider-storage/src/state/job_cache.rs
@@ -74,7 +74,7 @@ impl<
     ///
     /// # Returns
     ///
-    /// A clone of the job control block if it exists, or [`None`] if not found.
+    /// The job control block of the given ID if it exists, [`None`] otherwise.
     #[must_use]
     pub fn get(
         &self,
@@ -89,7 +89,7 @@ impl<
     ///
     /// # Returns
     ///
-    /// The removed job control block if it existed, or [`None`] if not found.
+    /// The removed job control block if it existed, [`None`] otherwise.
     #[must_use]
     pub fn remove(
         &self,

--- a/components/spider-storage/src/state/job_cache.rs
+++ b/components/spider-storage/src/state/job_cache.rs
@@ -348,16 +348,18 @@ mod tests {
     async fn job_cache_concurrent_insert_get() {
         use std::sync::Arc;
 
+        use tokio_util::task::TaskTracker;
+
         let cache: Arc<
             JobCache<MockReadyQueueSender, MockDbConnector, MockTaskInstancePoolConnector>,
         > = Arc::new(JobCache::new());
 
+        let tracker = TaskTracker::new();
         let num_tasks = 10;
-        let mut handles = Vec::new();
 
         for i in 0..num_tasks {
             let cache = Arc::clone(&cache);
-            let handle = tokio::spawn(async move {
+            tracker.spawn(async move {
                 let job_id = JobId::new();
                 let jcb = create_test_jcb(job_id).await;
                 cache
@@ -376,11 +378,9 @@ mod tests {
                 let result = cache.get(job_id);
                 assert!(result.is_none(), "task {i} should not find removed JCB");
             });
-            handles.push(handle);
         }
 
-        for handle in handles {
-            handle.await.expect("task should complete successfully");
-        }
+        tracker.close();
+        tracker.wait().await;
     }
 }

--- a/components/spider-storage/src/state/job_cache.rs
+++ b/components/spider-storage/src/state/job_cache.rs
@@ -1,0 +1,346 @@
+use dashmap::DashMap;
+use spider_core::types::id::JobId;
+
+use crate::{
+    cache::job::SharedJobControlBlock,
+    db::InternalJobOrchestration,
+    ready_queue::ReadyQueueSender,
+    task_instance_pool::TaskInstancePoolConnector,
+};
+
+/// An in-memory cache for job control blocks.
+///
+/// This type provides concurrent access to job control blocks via a `DashMap`.
+/// It is generic over the same type parameters as [`SharedJobControlBlock`].
+///
+/// # Type Parameters
+///
+/// * `ReadyQueueSenderType` - The type of the ready queue sender.
+/// * `DbConnectorType` - The type of the DB-layer connector.
+/// * `TaskInstancePoolConnectorType` - The type of the task instance pool connector.
+pub struct JobCache<
+    ReadyQueueSenderType: ReadyQueueSender,
+    DbConnectorType: InternalJobOrchestration,
+    TaskInstancePoolConnectorType: TaskInstancePoolConnector,
+> {
+    jobs: DashMap<
+        JobId,
+        SharedJobControlBlock<ReadyQueueSenderType, DbConnectorType, TaskInstancePoolConnectorType>,
+    >,
+}
+
+impl<
+    ReadyQueueSenderType: ReadyQueueSender,
+    DbConnectorType: InternalJobOrchestration,
+    TaskInstancePoolConnectorType: TaskInstancePoolConnector,
+> JobCache<ReadyQueueSenderType, DbConnectorType, TaskInstancePoolConnectorType>
+{
+    /// Creates a new empty job cache.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            jobs: DashMap::new(),
+        }
+    }
+
+    /// Inserts a job control block into the cache.
+    ///
+    /// If a job control block with the same ID already exists, it will be replaced.
+    pub fn insert(
+        &self,
+        job_id: JobId,
+        jcb: SharedJobControlBlock<
+            ReadyQueueSenderType,
+            DbConnectorType,
+            TaskInstancePoolConnectorType,
+        >,
+    ) {
+        self.jobs.insert(job_id, jcb);
+    }
+
+    /// Gets a job control block from the cache.
+    ///
+    /// # Returns
+    ///
+    /// A clone of the job control block if it exists, or [`None`] if not found.
+    #[must_use]
+    pub fn get(
+        &self,
+        job_id: JobId,
+    ) -> Option<
+        SharedJobControlBlock<ReadyQueueSenderType, DbConnectorType, TaskInstancePoolConnectorType>,
+    > {
+        self.jobs.get(&job_id).map(|entry| entry.clone())
+    }
+
+    /// Removes a job control block from the cache.
+    ///
+    /// # Returns
+    ///
+    /// The removed job control block if it existed, or [`None`] if not found.
+    #[must_use]
+    pub fn remove(
+        &self,
+        job_id: JobId,
+    ) -> Option<
+        SharedJobControlBlock<ReadyQueueSenderType, DbConnectorType, TaskInstancePoolConnectorType>,
+    > {
+        self.jobs.remove(&job_id).map(|(_, v)| v)
+    }
+}
+
+impl<
+    ReadyQueueSenderType: ReadyQueueSender,
+    DbConnectorType: InternalJobOrchestration,
+    TaskInstancePoolConnectorType: TaskInstancePoolConnector,
+> Default for JobCache<ReadyQueueSenderType, DbConnectorType, TaskInstancePoolConnectorType>
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use spider_core::{
+        task::{
+            DataTypeDescriptor,
+            ExecutionPolicy,
+            TaskDescriptor,
+            TaskGraph as SubmittedTaskGraph,
+            TdlContext,
+            ValueTypeDescriptor,
+        },
+        types::{id::JobId, io::TaskInput},
+    };
+
+    use super::*;
+    use crate::{
+        cache::error::InternalError,
+        ready_queue::ReadyQueueSender,
+        task_instance_pool::{TaskInstanceMetadata, TaskInstancePoolConnector},
+    };
+
+    /// A mock ready queue sender for testing.
+    #[derive(Clone, Default)]
+    struct MockReadyQueueSender;
+
+    #[async_trait::async_trait]
+    impl ReadyQueueSender for MockReadyQueueSender {
+        async fn send_task_ready(
+            &self,
+            _rg_id: spider_core::types::id::ResourceGroupId,
+            _job_id: JobId,
+            _task_indices: Vec<usize>,
+        ) -> Result<(), InternalError> {
+            Ok(())
+        }
+
+        async fn send_commit_ready(
+            &self,
+            _rg_id: spider_core::types::id::ResourceGroupId,
+            _job_id: JobId,
+        ) -> Result<(), InternalError> {
+            Ok(())
+        }
+
+        async fn send_cleanup_ready(
+            &self,
+            _rg_id: spider_core::types::id::ResourceGroupId,
+            _job_id: JobId,
+        ) -> Result<(), InternalError> {
+            Ok(())
+        }
+    }
+
+    /// A mock DB connector for testing.
+    #[derive(Clone, Default)]
+    struct MockDbConnector;
+
+    #[async_trait::async_trait]
+    impl crate::db::InternalJobOrchestration for MockDbConnector {
+        async fn start(&self, _job_id: JobId) -> Result<(), crate::db::DbError> {
+            Ok(())
+        }
+
+        async fn set_state(
+            &self,
+            _job_id: JobId,
+            _state: spider_core::job::JobState,
+        ) -> Result<(), crate::db::DbError> {
+            Ok(())
+        }
+
+        async fn commit_outputs(
+            &self,
+            _job_id: JobId,
+            _outputs: Vec<spider_core::types::io::TaskOutput>,
+            _has_commit_task: bool,
+        ) -> Result<(), crate::db::DbError> {
+            Ok(())
+        }
+
+        async fn cancel(
+            &self,
+            _job_id: JobId,
+            _has_cleanup_task: bool,
+        ) -> Result<(), crate::db::DbError> {
+            Ok(())
+        }
+
+        async fn fail(
+            &self,
+            _job_id: JobId,
+            _error_message: String,
+        ) -> Result<(), crate::db::DbError> {
+            Ok(())
+        }
+
+        async fn delete_expired_terminated_jobs(
+            &self,
+            _expire_after_sec: u64,
+        ) -> Result<Vec<JobId>, crate::db::DbError> {
+            Ok(Vec::new())
+        }
+    }
+
+    /// A mock task instance pool connector for testing.
+    #[derive(Clone, Default)]
+    struct MockTaskInstancePoolConnector;
+
+    #[async_trait::async_trait]
+    impl TaskInstancePoolConnector for MockTaskInstancePoolConnector {
+        fn get_next_available_task_instance_id(&self) -> spider_core::types::id::TaskInstanceId {
+            1
+        }
+
+        async fn register_task_instance(
+            &self,
+            _tcb: crate::cache::task::SharedTaskControlBlock,
+            _registration: TaskInstanceMetadata,
+        ) -> Result<(), InternalError> {
+            Ok(())
+        }
+
+        async fn register_termination_task_instance(
+            &self,
+            _termination_tcb: crate::cache::task::SharedTerminationTaskControlBlock,
+            _registration: TaskInstanceMetadata,
+        ) -> Result<(), InternalError> {
+            Ok(())
+        }
+    }
+
+    async fn create_test_jcb(
+        job_id: JobId,
+    ) -> SharedJobControlBlock<MockReadyQueueSender, MockDbConnector, MockTaskInstancePoolConnector>
+    {
+        let bytes_type = DataTypeDescriptor::Value(ValueTypeDescriptor::bytes());
+        let mut submitted =
+            SubmittedTaskGraph::new(None, None).expect("task graph creation should succeed");
+        submitted
+            .insert_task(TaskDescriptor {
+                tdl_context: TdlContext {
+                    package: "test_pkg".to_owned(),
+                    task_func: "test_fn".to_owned(),
+                },
+                execution_policy: Some(ExecutionPolicy::default()),
+                inputs: vec![bytes_type.clone()],
+                outputs: vec![bytes_type],
+                input_sources: None,
+            })
+            .expect("task insertion should succeed");
+
+        SharedJobControlBlock::create(
+            job_id,
+            spider_core::types::id::ResourceGroupId::new(),
+            &submitted,
+            vec![TaskInput::ValuePayload(vec![0u8; 4])],
+            MockReadyQueueSender,
+            MockDbConnector,
+            MockTaskInstancePoolConnector,
+        )
+        .await
+        .expect("JCB creation should succeed")
+    }
+
+    #[tokio::test]
+    async fn job_cache_insert_and_get_roundtrip() {
+        let cache: JobCache<MockReadyQueueSender, MockDbConnector, MockTaskInstancePoolConnector> =
+            JobCache::new();
+        let job_id = JobId::new();
+
+        let jcb = create_test_jcb(job_id).await;
+        cache.insert(job_id, jcb);
+
+        let result = cache.get(job_id);
+        assert!(result.is_some(), "inserted JCB should be retrievable");
+    }
+
+    #[tokio::test]
+    async fn job_cache_remove_returns_inserted_jcb() {
+        let cache: JobCache<MockReadyQueueSender, MockDbConnector, MockTaskInstancePoolConnector> =
+            JobCache::new();
+        let job_id = JobId::new();
+
+        let jcb = create_test_jcb(job_id).await;
+        cache.insert(job_id, jcb);
+
+        let removed = cache.remove(job_id);
+        assert!(removed.is_some(), "remove should return the JCB");
+
+        let result = cache.get(job_id);
+        assert!(result.is_none(), "JCB should no longer exist after removal");
+    }
+
+    #[tokio::test]
+    async fn job_cache_get_returns_none_for_nonexistent_job() {
+        let cache: JobCache<MockReadyQueueSender, MockDbConnector, MockTaskInstancePoolConnector> =
+            JobCache::new();
+        let job_id = JobId::new();
+
+        let result = cache.get(job_id);
+        assert!(
+            result.is_none(),
+            "get should return None for nonexistent job"
+        );
+    }
+
+    #[tokio::test]
+    async fn job_cache_concurrent_insert_get() {
+        use std::sync::Arc;
+
+        let cache: Arc<
+            JobCache<MockReadyQueueSender, MockDbConnector, MockTaskInstancePoolConnector>,
+        > = Arc::new(JobCache::new());
+
+        let num_tasks = 10;
+        let mut handles = Vec::new();
+
+        for i in 0..num_tasks {
+            let cache = Arc::clone(&cache);
+            let handle = tokio::spawn(async move {
+                let job_id = JobId::new();
+                let jcb = create_test_jcb(job_id).await;
+                cache.insert(job_id, jcb);
+
+                // Immediately try to get it
+                let result = cache.get(job_id);
+                assert!(result.is_some(), "task {i} should find inserted JCB");
+
+                // Try to remove it
+                let removed = cache.remove(job_id);
+                assert!(removed.is_some(), "task {i} should remove inserted JCB");
+
+                // Verify it's gone
+                let result = cache.get(job_id);
+                assert!(result.is_none(), "task {i} should not find removed JCB");
+            });
+            handles.push(handle);
+        }
+
+        for handle in handles {
+            handle.await.expect("task should complete successfully");
+        }
+    }
+}

--- a/components/spider-storage/src/state/job_cache.rs
+++ b/components/spider-storage/src/state/job_cache.rs
@@ -390,10 +390,10 @@ mod tests {
         tracker.wait().await;
     }
 
-    /// A tracking ready queue sender that records calls.
+    /// A tracking ready queue sender that records the number of calls.
     #[derive(Clone, Default)]
     struct TrackingReadyQueueSender {
-        calls: Arc<std::sync::Mutex<Vec<String>>>,
+        call_count: Arc<std::sync::atomic::AtomicUsize>,
     }
 
     #[async_trait::async_trait]
@@ -404,10 +404,8 @@ mod tests {
             _job_id: JobId,
             _task_indices: Vec<usize>,
         ) -> Result<(), InternalError> {
-            self.calls
-                .lock()
-                .expect("lock")
-                .push("task_ready".to_owned());
+            self.call_count
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             Ok(())
         }
 
@@ -416,10 +414,8 @@ mod tests {
             _rg_id: spider_core::types::id::ResourceGroupId,
             _job_id: JobId,
         ) -> Result<(), InternalError> {
-            self.calls
-                .lock()
-                .expect("lock")
-                .push("commit_ready".to_owned());
+            self.call_count
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             Ok(())
         }
 
@@ -428,19 +424,17 @@ mod tests {
             _rg_id: spider_core::types::id::ResourceGroupId,
             _job_id: JobId,
         ) -> Result<(), InternalError> {
-            self.calls
-                .lock()
-                .expect("lock")
-                .push("cleanup_ready".to_owned());
+            self.call_count
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             Ok(())
         }
     }
 
     #[tokio::test]
     async fn job_cache_resend_ready_tasks_sends_for_running_job() -> anyhow::Result<()> {
-        let calls: Arc<std::sync::Mutex<Vec<String>>> = Arc::default();
+        let call_count: Arc<std::sync::atomic::AtomicUsize> = Arc::default();
         let sender = TrackingReadyQueueSender {
-            calls: Arc::clone(&calls),
+            call_count: Arc::clone(&call_count),
         };
 
         let bytes_type = DataTypeDescriptor::Value(ValueTypeDescriptor::bytes());
@@ -472,7 +466,7 @@ mod tests {
         .await
         .expect("JCB creation should succeed");
         jcb.start().await.expect("start should succeed");
-        calls.lock().expect("lock").clear();
+        call_count.store(0, std::sync::atomic::Ordering::Relaxed);
 
         let cache: JobCache<
             TrackingReadyQueueSender,
@@ -483,13 +477,10 @@ mod tests {
 
         cache.resend_ready_tasks().await?;
 
-        let task_ready_count = {
-            let recorded = calls.lock().expect("lock");
-            recorded.iter().filter(|c| **c == "task_ready").count()
-        };
         assert_eq!(
-            task_ready_count, 1,
-            "resend_ready_tasks should send one task_ready after the reset"
+            call_count.load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "resend_ready_tasks should send one call after the reset"
         );
         Ok(())
     }

--- a/components/spider-storage/src/state/job_cache.rs
+++ b/components/spider-storage/src/state/job_cache.rs
@@ -1,10 +1,11 @@
-use dashmap::DashMap;
+use dashmap::{DashMap, mapref::entry::Entry};
 use spider_core::types::id::JobId;
 
 use crate::{
     cache::job::SharedJobControlBlock,
     db::InternalJobOrchestration,
     ready_queue::ReadyQueueSender,
+    state::error::StorageServerError,
     task_instance_pool::TaskInstancePoolConnector,
 };
 
@@ -45,7 +46,12 @@ impl<
 
     /// Inserts a job control block into the cache.
     ///
-    /// If a job control block with the same ID already exists, it will be replaced.
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * [`StorageServerError::JobAlreadyExists`] if a job control block with the same ID already
+    ///   exists.
     pub fn insert(
         &self,
         job_id: JobId,
@@ -54,8 +60,14 @@ impl<
             DbConnectorType,
             TaskInstancePoolConnectorType,
         >,
-    ) {
-        self.jobs.insert(job_id, jcb);
+    ) -> Result<(), StorageServerError> {
+        match self.jobs.entry(job_id) {
+            Entry::Vacant(e) => {
+                e.insert(jcb);
+                Ok(())
+            }
+            Entry::Occupied(_) => Err(StorageServerError::JobAlreadyExists(job_id)),
+        }
     }
 
     /// Gets a job control block from the cache.
@@ -265,13 +277,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn job_cache_insert_and_get_roundtrip() {
+    async fn job_cache_insert_and_get() {
         let cache: JobCache<MockReadyQueueSender, MockDbConnector, MockTaskInstancePoolConnector> =
             JobCache::new();
         let job_id = JobId::new();
 
         let jcb = create_test_jcb(job_id).await;
-        cache.insert(job_id, jcb);
+        cache
+            .insert(job_id, jcb)
+            .expect("insert should succeed for new job");
 
         let result = cache.get(job_id);
         assert!(result.is_some(), "inserted JCB should be retrievable");
@@ -284,7 +298,9 @@ mod tests {
         let job_id = JobId::new();
 
         let jcb = create_test_jcb(job_id).await;
-        cache.insert(job_id, jcb);
+        cache
+            .insert(job_id, jcb)
+            .expect("insert should succeed for new job");
 
         let removed = cache.remove(job_id);
         assert!(removed.is_some(), "remove should return the JCB");
@@ -307,6 +323,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn job_cache_insert_duplicate_returns_error() {
+        let cache: JobCache<MockReadyQueueSender, MockDbConnector, MockTaskInstancePoolConnector> =
+            JobCache::new();
+        let job_id = JobId::new();
+
+        let jcb1 = create_test_jcb(job_id).await;
+        cache
+            .insert(job_id, jcb1)
+            .expect("first insert should succeed");
+
+        let jcb2 = create_test_jcb(job_id).await;
+        let result = cache.insert(job_id, jcb2);
+        assert!(
+            matches!(result, Err(StorageServerError::JobAlreadyExists(_))),
+            "insert should return JobAlreadyExists error for duplicate key"
+        );
+        if let Err(StorageServerError::JobAlreadyExists(id)) = result {
+            assert_eq!(id, job_id, "error should contain the duplicate job ID");
+        }
+    }
+
+    #[tokio::test]
     async fn job_cache_concurrent_insert_get() {
         use std::sync::Arc;
 
@@ -322,7 +360,9 @@ mod tests {
             let handle = tokio::spawn(async move {
                 let job_id = JobId::new();
                 let jcb = create_test_jcb(job_id).await;
-                cache.insert(job_id, jcb);
+                cache
+                    .insert(job_id, jcb)
+                    .expect("insert should succeed for new job");
 
                 // Immediately try to get it
                 let result = cache.get(job_id);

--- a/components/spider-storage/src/state/job_cache.rs
+++ b/components/spider-storage/src/state/job_cache.rs
@@ -11,8 +11,8 @@ use crate::{
 
 /// An in-memory cache for job control blocks.
 ///
-/// This type provides concurrent access to job control blocks via a `DashMap`.
-/// It is generic over the same type parameters as [`SharedJobControlBlock`].
+/// This type provides concurrent access to job control blocks via a `DashMap`. It is generic over
+/// the same type parameters as [`SharedJobControlBlock`].
 ///
 /// # Type Parameters
 ///
@@ -170,7 +170,7 @@ mod tests {
     struct MockDbConnector;
 
     #[async_trait::async_trait]
-    impl crate::db::InternalJobOrchestration for MockDbConnector {
+    impl InternalJobOrchestration for MockDbConnector {
         async fn start(&self, _job_id: JobId) -> Result<(), crate::db::DbError> {
             Ok(())
         }


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR adds the following storage server infra:
- `DashMap` dependency
- `JobCache` that maps job id to JCB
- `StorageServerError` enum



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
- [x] Adds unit tests for `JobCache`
- [x] GitHub workflows pass



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted storage component layout and updated dependency declarations.

* **New Features**
  * Public storage state surface added with clearer error variants for conflicts and shutdowns.
  * Concurrent in-memory job cache introduced with insert/get/remove, job ID access, and a resend-ready-tasks capability to re-dispatch pending work and improve resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->