### PR TITLE
fix(ci): Limit parallelization of `lint-cpp` workflow.

### DIFF
--- a/.github/workflows/code-linting-checks.yaml
+++ b/.github/workflows/code-linting-checks.yaml
@@ -107,7 +107,7 @@ jobs:
           #   match and restore the most recent cache entry that shares that prefix.
           key: "lint:check-cpp-static-on-ubuntu-latest"
 
-      - run: "task lint:cpp-check"
+      - run: "task lint:cpp-check -C $(nproc)"
 
       - run: "task lint:cmake-check"
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Previous PR #305 adds path-filtering for GitHub workflows, but removes the parallelism limit when running `task lint:cpp-check`. This leads to all `clang-tidy` checks to run in parallel and consumes all memory allocated to the task, and fails the workflow.

This PR brings back the parallelism limit set at `-C $(nproc)` as before.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
- [x] [`lint-cpp` workflow](https://github.com/sitaowang1998/spider/actions/runs/25386202015/job/74447966234) succeeds.
- [x] GitHub workflows pass.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimised development build pipeline performance to leverage system resources more efficiently during code quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->