### PR TITLE
build: Split the Ubuntu dev-dependency install script into common, huntsman, and wolf variants.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,7 +5,8 @@ WORKDIR /root
 RUN mkdir -p ./tools/scripts/lib_install
 COPY ./tools/scripts/lib_install ./tools/scripts/lib_install
 
-RUN ./tools/scripts/lib_install/linux/install-dev.sh
+RUN ./tools/scripts/lib_install/ubuntu/install-dev-wolf.sh
+RUN ./tools/scripts/lib_install/ubuntu/install-dev-huntsman.sh
 
 # NOTE:
 # `task` doesn't have an apt/yum package so we use its install script.

--- a/.github/workflows/code-linting-checks.yaml
+++ b/.github/workflows/code-linting-checks.yaml
@@ -47,7 +47,7 @@ jobs:
       - uses: "./tools/yscope-dev-utils/exports/github/actions/install-uv"
 
       - name: "Install dev dependencies"
-        run: "./tools/scripts/lib_install/linux/install-dev.sh"
+        run: "./tools/scripts/lib_install/ubuntu/install-dev-common.sh"
 
       - run: "task lint:toml-check"
 
@@ -75,7 +75,7 @@ jobs:
       - uses: "./tools/yscope-dev-utils/exports/github/actions/install-uv"
 
       - name: "Install dev dependencies"
-        run: "./tools/scripts/lib_install/linux/install-dev.sh"
+        run: "./tools/scripts/lib_install/ubuntu/install-dev-wolf.sh"
 
       - uses: "./tools/yscope-dev-utils/exports/github/actions/print-tool-versions"
 
@@ -151,7 +151,7 @@ jobs:
       - uses: "./tools/yscope-dev-utils/exports/github/actions/install-uv"
 
       - name: "Install dev dependencies"
-        run: "./tools/scripts/lib_install/linux/install-dev.sh"
+        run: "./tools/scripts/lib_install/ubuntu/install-dev-common.sh"
 
       - run: "task lint:py-check"
 
@@ -174,7 +174,7 @@ jobs:
       - uses: "./tools/yscope-dev-utils/exports/github/actions/install-uv"
 
       - name: "Install dev dependencies"
-        run: "./tools/scripts/lib_install/linux/install-dev.sh"
+        run: "./tools/scripts/lib_install/ubuntu/install-dev-huntsman.sh"
 
       - run: "task lint:check-rust"
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -59,7 +59,7 @@ jobs:
       - uses: "./tools/yscope-dev-utils/exports/github/actions/install-uv"
 
       - name: "Install dev dependencies"
-        run: "./tools/scripts/lib_install/linux/install-dev.sh"
+        run: "./tools/scripts/lib_install/ubuntu/install-dev-wolf.sh"
 
       - uses: "./tools/yscope-dev-utils/exports/github/actions/print-tool-versions"
 
@@ -97,7 +97,7 @@ jobs:
       - uses: "./tools/yscope-dev-utils/exports/github/actions/install-uv"
 
       - name: "Install dev dependencies"
-        run: "./tools/scripts/lib_install/linux/install-dev.sh"
+        run: "./tools/scripts/lib_install/ubuntu/install-dev-huntsman.sh"
 
       - uses: "./tools/yscope-dev-utils/exports/github/actions/print-tool-versions"
 

--- a/tools/scripts/lib_install/ubuntu/install-dev-common.sh
+++ b/tools/scripts/lib_install/ubuntu/install-dev-common.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Installs the dev dependencies shared by all versions of Spider.
+
+# Exit on any error
+set -e
+
+# Error on undefined variable
+set -u
+
+echo "Checking for elevated privileges..."
+privileged_command_prefix=""
+if [ ${EUID:-$(id -u)} -ne 0 ] ; then
+  sudo echo "Script can elevate privileges."
+  privileged_command_prefix="${privileged_command_prefix} sudo"
+fi
+
+${privileged_command_prefix} apt-get update
+DEBIAN_FRONTEND=noninteractive ${privileged_command_prefix} \
+apt-get install --no-install-recommends -y \
+    ca-certificates \
+    curl \
+    git \
+    python3 \
+    python3-pip \
+    python3-venv
+
+# Install uv
+curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/tools/scripts/lib_install/ubuntu/install-dev-huntsman.sh
+++ b/tools/scripts/lib_install/ubuntu/install-dev-huntsman.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Installs the dev dependencies for Spider Huntsman.
+
+# Exit on any error
+set -e
+
+# Error on undefined variable
+set -u
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+"$script_dir"/install-dev-common.sh
+
+echo "Checking for elevated privileges..."
+privileged_command_prefix=""
+if [ ${EUID:-$(id -u)} -ne 0 ] ; then
+  sudo echo "Script can elevate privileges."
+  privileged_command_prefix="${privileged_command_prefix} sudo"
+fi
+
+# `gcc` and `libc6-dev` are required by `rustc`, which invokes the system C compiler driver to
+# link binaries against libc.
+DEBIAN_FRONTEND=noninteractive ${privileged_command_prefix} \
+apt-get install --no-install-recommends -y \
+    gcc \
+    libc6-dev

--- a/tools/scripts/lib_install/ubuntu/install-dev-wolf.sh
+++ b/tools/scripts/lib_install/ubuntu/install-dev-wolf.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 
+# Installs the dev dependencies for Spider Wolf.
+
 # Exit on any error
 set -e
 
 # Error on undefined variable
 set -u
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+"$script_dir"/install-dev-common.sh
 
 echo "Checking for elevated privileges..."
 privileged_command_prefix=""
@@ -12,14 +17,12 @@ if [ ${EUID:-$(id -u)} -ne 0 ] ; then
   sudo echo "Script can elevate privileges."
   privileged_command_prefix="${privileged_command_prefix} sudo"
 fi
-${privileged_command_prefix} apt-get update
-DEBIAN_FRONTEND=noninteractive ${privileged_command_prefix} apt-get install --no-install-recommends -y \
-    ca-certificates \
+
+DEBIAN_FRONTEND=noninteractive ${privileged_command_prefix} \
+apt-get install --no-install-recommends -y \
     checkinstall \
-    curl \
     g++ \
     gcc \
-    git \
     jq \
     libcurl4 \
     libcurl4-openssl-dev \
@@ -27,16 +30,9 @@ DEBIAN_FRONTEND=noninteractive ${privileged_command_prefix} apt-get install --no
     libssl-dev \
     make \
     openjdk-11-jdk \
-    pkg-config \
-    python3 \
-    python3-pip \
-    python3-venv
+    pkg-config
 
-script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 lib_install_scripts_dir="$script_dir/.."
 ${privileged_command_prefix} "$lib_install_scripts_dir"/install-cmake.sh 3.23.5
 # TODO https://github.com/y-scope/spider/issues/86
 "$lib_install_scripts_dir"/check-cmake-version.sh
-
-# Install uv
-curl -LsSf https://astral.sh/uv/install.sh | sh


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

`tools/scripts/lib_install/linux/install-dev.sh` installed everything required to build Spider Wolf (C++), but Spider Huntsman (Rust) only needs a small subset of those dependencies. This PR splits the script so each consumer installs exactly what it needs, and renames the containing directory to reflect what the scripts actually target.

## Changes

* Split `install-dev.sh` into three scripts:
  * `install-dev-common.sh` — dependencies shared by all versions: `ca-certificates`, `curl`, `git`, `python3`, `python3-pip`, `python3-venv`, and the `uv` installer. Owns the `apt-get update` and privilege-elevation preamble.
  * `install-dev-huntsman.sh` — runs the common script, then installs `gcc` and `libc6-dev`, which `rustc` requires to link binaries (it invokes the system C compiler driver). Note: `libc6-dev` is listed explicitly because it previously arrived transitively through `libssl-dev`/`libmariadb-dev`, which the huntsman variant no longer installs.
  * `install-dev-wolf.sh` — runs the common script, then installs the C++ toolchain and native libraries (`checkinstall`, `g++`, `gcc`, `jq`, `libcurl4`, `libcurl4-openssl-dev`, `libmariadb-dev`, `libssl-dev`, `make`, `openjdk-11-jdk`, `pkg-config`) and performs the CMake install + version check, which are Wolf-only.
* Renamed `tools/scripts/lib_install/linux` to `tools/scripts/lib_install/ubuntu`: the scripts use `apt-get` and Debian-family package names, which are not portable across Linux distributions, and all current consumers run Ubuntu (CI runners and the dev container). The new layout also telegraphs how support for another distribution would be added (a sibling directory with the same script names).
* Updated all consumers:
  * `.github/workflows/code-linting-checks.yaml`: `lint-common` and `lint-python` now use the common script; `lint-cpp` uses the wolf script; `lint-rust` uses the huntsman script.
  * `.github/workflows/tests.yaml`: `wolf-tests` uses the wolf script; `huntsman-tests` uses the huntsman script.
  * `.devcontainer/Dockerfile`: runs both the wolf and huntsman scripts since the dev container is a full development environment for both versions.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Ensure all workflows pass.
* [x] Verify that with the script, Huntsman testing workflow completing time changes from 15min to 7min:
  * Without this PR: https://github.com/y-scope/spider/actions/runs/26990922522/job/79650702498?pr=334
  * With this PR: https://github.com/y-scope/spider/actions/runs/27040259710/job/79814333430?pr=336

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Refactored development environment setup to use Ubuntu-specific installation scripts instead of generic Linux installers, improving system compatibility and reliability. The new modular approach separates common dependencies from component-specific requirements, streamlining both local development setup and continuous integration workflows. These changes enhance consistency and maintainability across all development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->