### PR TITLE
refactor(spider-huntsman): Use auto-incrementing u64 IDs instead of UUIDv7 for database-generated IDs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,6 +1394,7 @@ name = "spider-core"
 version = "0.1.0"
 dependencies = [
  "non-empty-string",
+ "rand 0.9.4",
  "rmp-serde",
  "semver",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,12 +101,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
-
-[[package]]
 name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,21 +491,8 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 5.3.0",
+ "r-efi",
  "wasip2",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -685,12 +666,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,8 +694,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.0",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -736,18 +709,6 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "js-sys"
-version = "0.3.97"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
-dependencies = [
- "cfg-if",
- "futures-util",
- "once_cell",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "konst"
@@ -772,12 +733,6 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1055,16 +1010,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,12 +1054,6 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1248,12 +1187,6 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -1471,7 +1404,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
- "uuid",
 ]
 
 [[package]]
@@ -1524,7 +1456,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
- "uuid",
 ]
 
 [[package]]
@@ -1633,7 +1564,6 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "uuid",
 ]
 
 [[package]]
@@ -1713,7 +1643,6 @@ dependencies = [
  "stringprep",
  "thiserror",
  "tracing",
- "uuid",
  "whoami",
 ]
 
@@ -1751,7 +1680,6 @@ dependencies = [
  "stringprep",
  "thiserror",
  "tracing",
- "uuid",
  "whoami",
 ]
 
@@ -1777,7 +1705,6 @@ dependencies = [
  "thiserror",
  "tracing",
  "url",
- "uuid",
 ]
 
 [[package]]
@@ -2166,18 +2093,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
-name = "uuid"
-version = "1.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
-dependencies = [
- "getrandom 0.4.2",
- "js-sys",
- "serde_core",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2207,16 +2122,7 @@ version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -2224,85 +2130,6 @@ name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.120"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
-dependencies = [
- "cfg-if",
- "once_cell",
- "rustversion",
- "wasm-bindgen-macro",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.120"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.120"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
-dependencies = [
- "bumpalo",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.120"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
 
 [[package]]
 name = "whoami"
@@ -2419,97 +2246,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"

--- a/components/spider-core/Cargo.toml
+++ b/components/spider-core/Cargo.toml
@@ -9,6 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 non-empty-string = { version = "0.2.6", features = ["serde"] }
+rand = "0.9.1"
 rmp-serde = "1.3.1"
 semver = "1.0.27"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/components/spider-core/Cargo.toml
+++ b/components/spider-core/Cargo.toml
@@ -14,10 +14,9 @@ semver = "1.0.27"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 spider-derive = { path = "../spider-derive" }
-sqlx = { version = "0.8.6", features = ["mysql", "uuid"] }
+sqlx = { version = "0.8.6", features = ["mysql"] }
 strum = { version = "0.28.0", features = ["derive"] }
 thiserror = "2.0.18"
-uuid = { version = "1.19.0", features = ["serde", "v4"] }
 
 [dev-dependencies]
 tokio = { version = "1.50.0", features = ["macros", "rt-multi-thread"] }

--- a/components/spider-core/src/types/id.rs
+++ b/components/spider-core/src/types/id.rs
@@ -24,7 +24,10 @@ use crate::task::TaskIndex;
 /// type SomeTypeId = Id<SomeTypeIdMarker>;
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct Id<TypeMarker: Debug + PartialEq + Eq>(u64, PhantomData<TypeMarker>);
+pub struct Id<TypeMarker: Debug + PartialEq + Eq> {
+    raw: u64,
+    _marker: PhantomData<TypeMarker>,
+}
 
 impl<TypeMarker: Debug + PartialEq + Eq> Default for Id<TypeMarker> {
     fn default() -> Self {
@@ -38,24 +41,25 @@ impl<TypeMarker: Debug + PartialEq + Eq> Id<TypeMarker> {
     /// Production IDs should be assigned by persistent storage instead.
     #[must_use]
     pub fn random() -> Self {
-        Self(rand::random(), PhantomData)
+        Self::from(rand::random())
     }
 
     #[must_use]
     pub const fn from(id: u64) -> Self {
-        Self(id, PhantomData)
+        Self {
+            raw: id,
+            _marker: PhantomData,
+        }
     }
 
     #[must_use]
     pub const fn get(&self) -> u64 {
-        self.0
+        self.raw
     }
 }
 
-impl<TypeMarker, Db> sqlx::Type<Db> for Id<TypeMarker>
+impl<TypeMarker: Debug + PartialEq + Eq, Db: Database> sqlx::Type<Db> for Id<TypeMarker>
 where
-    TypeMarker: Debug + PartialEq + Eq,
-    Db: Database,
     u64: sqlx::Type<Db>,
 {
     fn type_info() -> <Db as Database>::TypeInfo {
@@ -67,65 +71,52 @@ where
     }
 }
 
-impl<'encode, TypeMarker, Db> sqlx::Encode<'encode, Db> for Id<TypeMarker>
+impl<'encode, TypeMarker: Debug + PartialEq + Eq, Db: Database> sqlx::Encode<'encode, Db>
+    for Id<TypeMarker>
 where
-    TypeMarker: Debug + PartialEq + Eq,
-    Db: Database,
     u64: sqlx::Encode<'encode, Db>,
 {
     fn encode_by_ref(
         &self,
         buf: &mut <Db as Database>::ArgumentBuffer<'encode>,
     ) -> Result<IsNull, sqlx::error::BoxDynError> {
-        self.0.encode_by_ref(buf)
+        self.get().encode_by_ref(buf)
     }
 }
 
-impl<'decode, TypeMarker, Db> sqlx::Decode<'decode, Db> for Id<TypeMarker>
+impl<'decode, TypeMarker: Debug + PartialEq + Eq, Db: Database> sqlx::Decode<'decode, Db>
+    for Id<TypeMarker>
 where
-    TypeMarker: Debug + PartialEq + Eq,
-    Db: Database,
     u64: sqlx::Decode<'decode, Db>,
 {
     fn decode(
         value: <Db as Database>::ValueRef<'decode>,
     ) -> Result<Self, sqlx::error::BoxDynError> {
-        u64::decode(value).map(|id| Self(id, PhantomData))
+        u64::decode(value).map(|id| Self::from(id))
     }
 }
 
-impl<TypeMarker> Display for Id<TypeMarker>
-where
-    TypeMarker: Debug + PartialEq + Eq,
-{
+impl<TypeMarker: Debug + PartialEq + Eq> Display for Id<TypeMarker> {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        Display::fmt(&self.0, formatter)
+        Display::fmt(&self.get(), formatter)
     }
 }
 
-impl<TypeMarker> Serialize for Id<TypeMarker>
-where
-    TypeMarker: Debug + PartialEq + Eq,
-{
-    fn serialize<SerializerImpl>(
+impl<TypeMarker: Debug + PartialEq + Eq> Serialize for Id<TypeMarker> {
+    fn serialize<SerializerImpl: Serializer>(
         &self,
         serializer: SerializerImpl,
-    ) -> Result<SerializerImpl::Ok, SerializerImpl::Error>
-    where
-        SerializerImpl: Serializer, {
-        self.0.serialize(serializer)
+    ) -> Result<SerializerImpl::Ok, SerializerImpl::Error> {
+        self.get().serialize(serializer)
     }
 }
 
-impl<'deserializer_lifetime, TypeMarker> Deserialize<'deserializer_lifetime> for Id<TypeMarker>
-where
-    TypeMarker: Debug + PartialEq + Eq,
+impl<'deserializer_lifetime, TypeMarker: Debug + PartialEq + Eq> Deserialize<'deserializer_lifetime>
+    for Id<TypeMarker>
 {
-    fn deserialize<DeserializerImpl>(
+    fn deserialize<DeserializerImpl: Deserializer<'deserializer_lifetime>>(
         deserializer: DeserializerImpl,
-    ) -> Result<Self, DeserializerImpl::Error>
-    where
-        DeserializerImpl: Deserializer<'deserializer_lifetime>, {
+    ) -> Result<Self, DeserializerImpl::Error> {
         u64::deserialize(deserializer).map(Self::from)
     }
 }

--- a/components/spider-core/src/types/id.rs
+++ b/components/spider-core/src/types/id.rs
@@ -1,15 +1,12 @@
 use std::{
     fmt::{Debug, Display},
     marker::PhantomData,
-    sync::atomic::{AtomicU64, Ordering},
 };
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sqlx::{Database, encode::IsNull};
 
 use crate::task::TaskIndex;
-
-static NEXT_SYNTHETIC_ID: AtomicU64 = AtomicU64::new(u64::MAX);
 
 /// A generic identifier type that wraps a numeric ID and a type marker.
 ///
@@ -31,17 +28,17 @@ pub struct Id<TypeMarker: Debug + PartialEq + Eq>(u64, PhantomData<TypeMarker>);
 
 impl<TypeMarker: Debug + PartialEq + Eq> Default for Id<TypeMarker> {
     fn default() -> Self {
-        Self::new()
+        Self::from(0)
     }
 }
 
 impl<TypeMarker: Debug + PartialEq + Eq> Id<TypeMarker> {
+    /// Creates a random ID for tests.
+    ///
+    /// Production IDs should be assigned by persistent storage instead.
     #[must_use]
-    pub fn new() -> Self {
-        Self(
-            NEXT_SYNTHETIC_ID.fetch_sub(1, Ordering::Relaxed),
-            PhantomData,
-        )
+    pub fn random() -> Self {
+        Self(rand::random(), PhantomData)
     }
 
     #[must_use]
@@ -242,11 +239,9 @@ mod tests {
     }
 
     #[test]
-    fn synthetic_ids_count_down_from_u64_max() {
-        let first = JobId::new();
-        let second = JobId::new();
+    fn default_id_is_zero() {
+        let job_id = JobId::default();
 
-        assert!(first.get() > second.get());
-        assert!(first.get() > u64::MAX / 2);
+        assert_eq!(job_id.get(), 0);
     }
 }

--- a/components/spider-core/src/types/id.rs
+++ b/components/spider-core/src/types/id.rs
@@ -1,12 +1,17 @@
-use std::{fmt::Debug, marker::PhantomData};
+use std::{
+    fmt::{Debug, Display},
+    marker::PhantomData,
+    sync::atomic::{AtomicU64, Ordering},
+};
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sqlx::{Database, encode::IsNull};
-use uuid::Uuid;
 
 use crate::task::TaskIndex;
 
-/// A generic identifier type that wraps a UUID and a type marker.
+static NEXT_SYNTHETIC_ID: AtomicU64 = AtomicU64::new(u64::MAX);
+
+/// A generic identifier type that wraps a numeric ID and a type marker.
 ///
 /// # Type Parameters:
 ///
@@ -15,12 +20,14 @@ use crate::task::TaskIndex;
 /// # Examples
 ///
 /// ```rust
+/// use spider_core::types::id::Id;
+///
 /// #[derive(Debug, PartialEq, Eq)]
 /// enum SomeTypeIdMarker {}
 /// type SomeTypeId = Id<SomeTypeIdMarker>;
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct Id<TypeMarker: Debug + PartialEq + Eq>(Uuid, PhantomData<TypeMarker>);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Id<TypeMarker: Debug + PartialEq + Eq>(u64, PhantomData<TypeMarker>);
 
 impl<TypeMarker: Debug + PartialEq + Eq> Default for Id<TypeMarker> {
     fn default() -> Self {
@@ -31,22 +38,20 @@ impl<TypeMarker: Debug + PartialEq + Eq> Default for Id<TypeMarker> {
 impl<TypeMarker: Debug + PartialEq + Eq> Id<TypeMarker> {
     #[must_use]
     pub fn new() -> Self {
-        Self(Uuid::new_v4(), PhantomData)
+        Self(
+            NEXT_SYNTHETIC_ID.fetch_sub(1, Ordering::Relaxed),
+            PhantomData,
+        )
     }
 
     #[must_use]
-    pub const fn from(uid: Uuid) -> Self {
-        Self(uid, PhantomData)
+    pub const fn from(id: u64) -> Self {
+        Self(id, PhantomData)
     }
 
     #[must_use]
-    pub const fn as_uuid_ref(&self) -> &Uuid {
-        &self.0
-    }
-
-    #[must_use]
-    pub const fn as_bytes(&self) -> &UuidBytes {
-        self.0.as_bytes()
+    pub const fn get(&self) -> u64 {
+        self.0
     }
 }
 
@@ -54,14 +59,14 @@ impl<TypeMarker, Db> sqlx::Type<Db> for Id<TypeMarker>
 where
     TypeMarker: Debug + PartialEq + Eq,
     Db: Database,
-    Uuid: sqlx::Type<Db>,
+    u64: sqlx::Type<Db>,
 {
     fn type_info() -> <Db as Database>::TypeInfo {
-        <Uuid as sqlx::Type<Db>>::type_info()
+        <u64 as sqlx::Type<Db>>::type_info()
     }
 
     fn compatible(ty: &<Db as Database>::TypeInfo) -> bool {
-        <Uuid as sqlx::Type<Db>>::compatible(ty)
+        <u64 as sqlx::Type<Db>>::compatible(ty)
     }
 }
 
@@ -69,7 +74,7 @@ impl<'encode, TypeMarker, Db> sqlx::Encode<'encode, Db> for Id<TypeMarker>
 where
     TypeMarker: Debug + PartialEq + Eq,
     Db: Database,
-    Uuid: sqlx::Encode<'encode, Db>,
+    u64: sqlx::Encode<'encode, Db>,
 {
     fn encode_by_ref(
         &self,
@@ -83,16 +88,50 @@ impl<'decode, TypeMarker, Db> sqlx::Decode<'decode, Db> for Id<TypeMarker>
 where
     TypeMarker: Debug + PartialEq + Eq,
     Db: Database,
-    Uuid: sqlx::Decode<'decode, Db>,
+    u64: sqlx::Decode<'decode, Db>,
 {
     fn decode(
         value: <Db as Database>::ValueRef<'decode>,
     ) -> Result<Self, sqlx::error::BoxDynError> {
-        Uuid::decode(value).map(|uuid| Self(uuid, PhantomData))
+        u64::decode(value).map(|id| Self(id, PhantomData))
     }
 }
 
-pub type UuidBytes = uuid::Bytes;
+impl<TypeMarker> Display for Id<TypeMarker>
+where
+    TypeMarker: Debug + PartialEq + Eq,
+{
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.0, formatter)
+    }
+}
+
+impl<TypeMarker> Serialize for Id<TypeMarker>
+where
+    TypeMarker: Debug + PartialEq + Eq,
+{
+    fn serialize<SerializerImpl>(
+        &self,
+        serializer: SerializerImpl,
+    ) -> Result<SerializerImpl::Ok, SerializerImpl::Error>
+    where
+        SerializerImpl: Serializer, {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'deserializer_lifetime, TypeMarker> Deserialize<'deserializer_lifetime> for Id<TypeMarker>
+where
+    TypeMarker: Debug + PartialEq + Eq,
+{
+    fn deserialize<DeserializerImpl>(
+        deserializer: DeserializerImpl,
+    ) -> Result<Self, DeserializerImpl::Error>
+    where
+        DeserializerImpl: Deserializer<'deserializer_lifetime>, {
+        u64::deserialize(deserializer).map(Self::from)
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ResourceGroupIdMarker {}
@@ -180,3 +219,34 @@ where
 }
 
 pub type SignedJobId = SignedId<JobIdMarker>;
+
+#[cfg(test)]
+mod tests {
+    use super::{JobId, ResourceGroupId};
+
+    #[test]
+    fn id_serializes_as_u64() {
+        let job_id = JobId::from(42);
+        let serialized =
+            serde_json::to_string(&job_id).expect("job id serialization should succeed");
+
+        assert_eq!(serialized, "42");
+    }
+
+    #[test]
+    fn distinct_id_markers_can_share_numeric_values() {
+        let job_id = JobId::from(7);
+        let resource_group_id = ResourceGroupId::from(7);
+
+        assert_eq!(job_id.get(), resource_group_id.get());
+    }
+
+    #[test]
+    fn synthetic_ids_count_down_from_u64_max() {
+        let first = JobId::new();
+        let second = JobId::new();
+
+        assert!(first.get() > second.get());
+        assert!(first.get() > u64::MAX / 2);
+    }
+}

--- a/components/spider-execution-manager/src/liveness.rs
+++ b/components/spider-execution-manager/src/liveness.rs
@@ -290,7 +290,7 @@ mod tests {
         cancellation_token: CancellationToken,
     ) -> (LivenessHandle, JoinHandle<()>) {
         spawn(
-            ExecutionManagerId::new(),
+            ExecutionManagerId::random(),
             client,
             tracker,
             cancellation_token,

--- a/components/spider-execution-manager/src/process_pool.rs
+++ b/components/spider-execution-manager/src/process_pool.rs
@@ -217,10 +217,10 @@ impl ProcessPool {
     fn spawn_executor(&self) -> Result<ExecutorHandle, InternalError> {
         let executor_id = self.next_executor_id.fetch_add(1, Ordering::Relaxed);
         std::fs::create_dir_all(&self.config.log_dir)?;
-        let log_path = self.config.log_dir.join(format!(
-            "{}-{executor_id}.log",
-            self.config.em_id.as_uuid_ref()
-        ));
+        let log_path = self
+            .config
+            .log_dir
+            .join(format!("{}-{executor_id}.log", self.config.em_id));
         let log_file = File::options().create(true).append(true).open(&log_path)?;
 
         let mut command = Command::new(&self.config.executor_binary_path);

--- a/components/spider-storage/Cargo.toml
+++ b/components/spider-storage/Cargo.toml
@@ -29,7 +29,6 @@ tokio = {
   version = "1.50.0",
   features = ["macros", "rt-multi-thread", "sync", "time"]
 }
-uuid = { version = "1.19.0", features = ["serde"] }
 
 [dev-dependencies]
 anyhow = "1.0.98"
@@ -38,4 +37,3 @@ serial_test = { version = "3.2.0", features = ["file_locks"] }
 tabled = "0.20.0"
 tokio = { version = "1.50.0", features = ["macros", "rt-multi-thread", "sync"] }
 tokio-util = { version = "0.7", features = ["rt"] }
-uuid = { version = "1.19.0", features = ["v4"] }

--- a/components/spider-storage/src/db/mariadb.rs
+++ b/components/spider-storage/src/db/mariadb.rs
@@ -102,7 +102,7 @@ impl ExternalJobOrchestration for MariaDbStorageConnector {
     ) -> Result<JobId, DbError> {
         const INSERT_QUERY: &str = formatcp!(
             "INSERT INTO `{table}` (`resource_group_id`, `serialized_task_graph`, \
-             `serialized_job_inputs`) VALUES (?, ?, ?) RETURNING CAST(`id` AS BINARY(16)) AS `id`;",
+             `serialized_job_inputs`) VALUES (?, ?, ?) RETURNING `id`;",
             table = JOBS_TABLE_NAME,
         );
 
@@ -170,8 +170,7 @@ impl ExternalJobOrchestration for MariaDbStorageConnector {
 
         let outputs_bytes = serialized_outputs.ok_or_else(|| {
             DbError::CorruptedDbState(format!(
-                "job `{}` succeeded but has no serialized outputs",
-                job_id.as_uuid_ref()
+                "job `{job_id}` succeeded but has no serialized outputs"
             ))
         })?;
         let outputs: Vec<TaskOutput> =
@@ -201,10 +200,7 @@ impl ExternalJobOrchestration for MariaDbStorageConnector {
         }
 
         let message = error_message.ok_or_else(|| {
-            DbError::CorruptedDbState(format!(
-                "job `{}` failed but has no error message",
-                job_id.as_uuid_ref()
-            ))
+            DbError::CorruptedDbState(format!("job `{job_id}` failed but has no error message"))
         })?;
         Ok(message)
     }
@@ -344,7 +340,7 @@ impl InternalJobOrchestration for MariaDbStorageConnector {
         const DELETE_BATCH_SIZE: usize = 1000;
 
         const SELECT_QUERY: &str = formatcp!(
-            "SELECT CAST(`id` AS BINARY(16)) FROM `{table}` WHERE `state` IN \
+            "SELECT `id` FROM `{table}` WHERE `state` IN \
              ('{succeeded_state}','{failed_state}','{cancelled_state}') AND `ended_at` < NOW() - \
              INTERVAL ? SECOND LIMIT {DELETE_BATCH_SIZE} FOR UPDATE;",
             table = JOBS_TABLE_NAME,
@@ -394,8 +390,7 @@ impl ResourceGroupManagement for MariaDbStorageConnector {
         password: Vec<u8>,
     ) -> Result<ResourceGroupId, DbError> {
         const QUERY: &str = formatcp!(
-            "INSERT INTO `{table}` (`external_id`, `password`) VALUES (?, ?) RETURNING CAST(`id` \
-             AS BINARY(16)) AS `id`;",
+            "INSERT INTO `{table}` (`external_id`, `password`) VALUES (?, ?) RETURNING `id`;",
             table = RESOURCE_GROUPS_TABLE_NAME,
         );
 
@@ -462,7 +457,7 @@ impl ExecutionManagerLivenessManagement for MariaDbStorageConnector {
         ip_address: IpAddr,
     ) -> Result<ExecutionManagerId, DbError> {
         const INSERT_QUERY: &str = formatcp!(
-            "INSERT INTO `{table}` (`ip_address`) VALUES (?) RETURNING CAST(`id` AS BINARY(16));",
+            "INSERT INTO `{table}` (`ip_address`) VALUES (?) RETURNING `id`;",
             table = EXECUTION_MANAGERS_TABLE_NAME,
         );
 
@@ -539,8 +534,8 @@ impl ExecutionManagerLivenessManagement for MariaDbStorageConnector {
         const UPDATE_BATCH_SIZE: usize = 1000;
 
         const SELECT_QUERY: &str = formatcp!(
-            "SELECT CAST(`id` AS BINARY(16)) FROM `{table}` WHERE `state` = '{alive_state}' AND \
-             `last_heartbeat_at` < CURRENT_TIMESTAMP - INTERVAL ? SECOND FOR UPDATE;",
+            "SELECT `id` FROM `{table}` WHERE `state` = '{alive_state}' AND `last_heartbeat_at` < \
+             CURRENT_TIMESTAMP - INTERVAL ? SECOND FOR UPDATE;",
             table = EXECUTION_MANAGERS_TABLE_NAME,
             alive_state = ExecutionManagerState::Alive.as_str(),
         );
@@ -601,7 +596,7 @@ const fn resource_groups_creation_query() -> &'static str {
     formatcp!(
         r"
 CREATE TABLE IF NOT EXISTS `{RESOURCE_GROUPS_TABLE_NAME}` (
-  `id` UUID NOT NULL DEFAULT UUID_v7(),
+  `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
   `external_id` VARCHAR(256) NOT NULL,
   `password` VARBINARY(2048) NOT NULL,
   PRIMARY KEY (`id`),
@@ -615,8 +610,8 @@ const fn jobs_creation_query() -> &'static str {
     formatcp!(
         r"
 CREATE TABLE IF NOT EXISTS `{JOBS_TABLE_NAME}` (
-  `id` UUID NOT NULL DEFAULT UUID_v7(),
-  `resource_group_id` UUID NOT NULL,
+  `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `resource_group_id` BIGINT UNSIGNED NOT NULL,
   `state` {state_enum} NOT NULL DEFAULT {default_state},
   `serialized_task_graph` LONGTEXT NOT NULL,
   `serialized_job_inputs` LONGBLOB NOT NULL,
@@ -642,7 +637,7 @@ const fn execution_managers_creation_query() -> &'static str {
     formatcp!(
         r"
 CREATE TABLE IF NOT EXISTS `{EXECUTION_MANAGERS_TABLE_NAME}` (
-  `id` UUID NOT NULL DEFAULT UUID_v7(),
+  `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
   `ip_address` VARCHAR(45) NOT NULL,
   `state` {state_enum} NOT NULL DEFAULT {default_state},
   `last_heartbeat_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/components/spider-storage/src/state/job_cache.rs
+++ b/components/spider-storage/src/state/job_cache.rs
@@ -282,7 +282,7 @@ mod tests {
                 .expect("job submission should be valid");
         SharedJobControlBlock::create(
             job_id,
-            spider_core::types::id::ResourceGroupId::new(),
+            spider_core::types::id::ResourceGroupId::random(),
             job_submission,
             MockReadyQueueSender,
             MockDbConnector,
@@ -296,7 +296,7 @@ mod tests {
     async fn job_cache_insert_and_get() -> anyhow::Result<()> {
         let cache: JobCache<MockReadyQueueSender, MockDbConnector, MockTaskInstancePoolConnector> =
             JobCache::new();
-        let job_id = JobId::new();
+        let job_id = JobId::random();
 
         let jcb = create_test_jcb(job_id).await;
         cache.insert(jcb)?;
@@ -310,7 +310,7 @@ mod tests {
     async fn job_cache_remove_returns_inserted_jcb() -> anyhow::Result<()> {
         let cache: JobCache<MockReadyQueueSender, MockDbConnector, MockTaskInstancePoolConnector> =
             JobCache::new();
-        let job_id = JobId::new();
+        let job_id = JobId::random();
 
         let jcb = create_test_jcb(job_id).await;
         cache.insert(jcb)?;
@@ -327,7 +327,7 @@ mod tests {
     async fn job_cache_get_returns_none_for_nonexistent_job() -> anyhow::Result<()> {
         let cache: JobCache<MockReadyQueueSender, MockDbConnector, MockTaskInstancePoolConnector> =
             JobCache::new();
-        let job_id = JobId::new();
+        let job_id = JobId::random();
 
         let result = cache.get(job_id);
         assert!(
@@ -341,7 +341,7 @@ mod tests {
     async fn job_cache_insert_duplicate_returns_error() -> anyhow::Result<()> {
         let cache: JobCache<MockReadyQueueSender, MockDbConnector, MockTaskInstancePoolConnector> =
             JobCache::new();
-        let job_id = JobId::new();
+        let job_id = JobId::random();
 
         let jcb1 = create_test_jcb(job_id).await;
         cache.insert(jcb1)?;
@@ -372,7 +372,7 @@ mod tests {
         for i in 0..num_tasks {
             let cache = Arc::clone(&cache);
             tracker.spawn(async move {
-                let job_id = JobId::new();
+                let job_id = JobId::random();
                 let jcb = create_test_jcb(job_id).await;
                 cache
                     .insert(jcb)
@@ -456,13 +456,13 @@ mod tests {
             })
             .expect("task insertion should succeed");
 
-        let job_id = JobId::new();
+        let job_id = JobId::random();
         let job_submission =
             ValidatedJobSubmission::create(submitted, vec![TaskInput::ValuePayload(vec![0u8; 4])])
                 .expect("job submission should be valid");
         let jcb = SharedJobControlBlock::create(
             job_id,
-            spider_core::types::id::ResourceGroupId::new(),
+            spider_core::types::id::ResourceGroupId::random(),
             job_submission,
             sender,
             MockDbConnector,

--- a/components/spider-storage/src/task_instance_pool.rs
+++ b/components/spider-storage/src/task_instance_pool.rs
@@ -683,8 +683,8 @@ mod tests {
     ) -> TaskInstanceMetadata {
         const SOFT_TIMEOUT_MS: Duration = Duration::from_millis(100);
         TaskInstanceMetadata {
-            resource_group_id: ResourceGroupId::new(),
-            job_id: JobId::new(),
+            resource_group_id: ResourceGroupId::random(),
+            job_id: JobId::random(),
             task_id,
             task_instance_id,
             execution_manager_id,
@@ -767,7 +767,7 @@ mod tests {
         let metadata = make_task_instance_metadata(
             TaskId::Index(0),
             task_instance_id,
-            ExecutionManagerId::new(),
+            ExecutionManagerId::random(),
             SystemTime::now(),
         );
         let job_id = metadata.job_id;
@@ -797,7 +797,7 @@ mod tests {
             Duration::from_mins(1),
             DEFAULT_CHANNEL_SIZE,
         );
-        let execution_manager_id = ExecutionManagerId::new();
+        let execution_manager_id = ExecutionManagerId::random();
 
         let tcb1 = build_single_task_tcb().await;
         let metadata1 = make_task_instance_metadata(
@@ -840,7 +840,7 @@ mod tests {
             liveness_store,
             Duration::from_mins(1),
         );
-        let em_id = ExecutionManagerId::new();
+        let em_id = ExecutionManagerId::random();
 
         // Create a few tasks and terminate them immediately.
         for i in 0..NUM_TASKS {
@@ -884,7 +884,7 @@ mod tests {
             liveness_store,
             Duration::from_mins(1),
         );
-        let em_id = ExecutionManagerId::new();
+        let em_id = ExecutionManagerId::random();
         let gc_starting_time = SystemTime::now();
         // soft_timeout_ddl = registered_at + 100ms
         // deadline = now - 900ms
@@ -942,7 +942,7 @@ mod tests {
             liveness_store.clone(),
             Duration::from_mins(1),
         );
-        let em_id = ExecutionManagerId::new();
+        let em_id = ExecutionManagerId::random();
         let now = SystemTime::now();
 
         let mut expected_messages: Vec<ReadyMessage> = Vec::new();
@@ -1000,7 +1000,7 @@ mod tests {
             liveness_store.clone(),
             Duration::from_mins(1),
         );
-        let em_id = ExecutionManagerId::new();
+        let em_id = ExecutionManagerId::random();
         let now = SystemTime::now();
 
         for i in 0..NUM_TASKS {
@@ -1058,8 +1058,8 @@ mod tests {
             liveness_store.clone(),
             Duration::from_mins(1),
         );
-        let alive_em = ExecutionManagerId::new();
-        let dead_em = ExecutionManagerId::new();
+        let alive_em = ExecutionManagerId::random();
+        let dead_em = ExecutionManagerId::random();
         let now = SystemTime::now();
         // soft timeout deadline = now - 900ms
         let elapsed_registration = now - Duration::from_secs(1);

--- a/components/spider-storage/tests/mariadb_infra.rs
+++ b/components/spider-storage/tests/mariadb_infra.rs
@@ -47,7 +47,7 @@ pub async fn create_mariadb_connector() -> MariaDbStorageConnector {
 ///
 /// Panics if the resource group creation fails.
 pub async fn create_test_resource_group(storage: &MariaDbStorageConnector) -> ResourceGroupId {
-    let external_id = uuid::Uuid::new_v4().to_string();
+    let external_id = format!("test-resource-group-{}", rand::random::<u64>());
     storage
         .add(external_id, b"test-password".to_vec())
         .await

--- a/components/spider-storage/tests/mariadb_test.rs
+++ b/components/spider-storage/tests/mariadb_test.rs
@@ -555,7 +555,7 @@ async fn test_delete_expired_terminated_jobs() {
 #[ignore = "requires MariaDB"]
 async fn test_add_duplicate_resource_group() {
     let storage = create_mariadb_connector().await;
-    let external_id = uuid::Uuid::new_v4().to_string();
+    let external_id = format!("test-resource-group-{}", rand::random::<u64>());
 
     storage
         .add(external_id.clone(), b"password".to_vec())
@@ -576,7 +576,7 @@ async fn test_verify_correct_password() {
 
     let rg_id = storage
         .add(
-            uuid::Uuid::new_v4().to_string(),
+            format!("test-resource-group-{}", rand::random::<u64>()),
             b"correct-password".to_vec(),
         )
         .await
@@ -595,7 +595,7 @@ async fn test_verify_wrong_password() {
 
     let rg_id = storage
         .add(
-            uuid::Uuid::new_v4().to_string(),
+            format!("test-resource-group-{}", rand::random::<u64>()),
             b"correct-password".to_vec(),
         )
         .await

--- a/components/spider-storage/tests/mariadb_test.rs
+++ b/components/spider-storage/tests/mariadb_test.rs
@@ -80,7 +80,7 @@ async fn test_register_job() {
 #[ignore = "requires MariaDB"]
 async fn test_register_job_invalid_resource_group() {
     let storage = create_mariadb_connector().await;
-    let fake_rg_id = ResourceGroupId::new();
+    let fake_rg_id = ResourceGroupId::random();
     let (graph, inputs) = single_task_graph();
     let job_submission =
         ValidatedJobSubmission::create(graph, inputs).expect("job submission should be valid");
@@ -612,7 +612,7 @@ async fn test_verify_wrong_password() {
 #[ignore = "requires MariaDB"]
 async fn test_verify_nonexistent_resource_group() {
     let storage = create_mariadb_connector().await;
-    let fake_rg_id = ResourceGroupId::new();
+    let fake_rg_id = ResourceGroupId::random();
 
     let result = storage.verify(fake_rg_id, b"password").await;
     assert!(
@@ -625,7 +625,7 @@ async fn test_verify_nonexistent_resource_group() {
 #[ignore = "requires MariaDB"]
 async fn test_start_job_not_found() {
     let storage = create_mariadb_connector().await;
-    let fake_job_id = JobId::new();
+    let fake_job_id = JobId::random();
 
     let result = storage.start(fake_job_id).await;
     assert!(
@@ -638,7 +638,7 @@ async fn test_start_job_not_found() {
 #[ignore = "requires MariaDB"]
 async fn test_set_state_job_not_found() {
     let storage = create_mariadb_connector().await;
-    let fake_job_id = JobId::new();
+    let fake_job_id = JobId::random();
 
     let result =
         InternalJobOrchestration::set_state(&storage, fake_job_id, JobState::Running).await;
@@ -652,7 +652,7 @@ async fn test_set_state_job_not_found() {
 #[ignore = "requires MariaDB"]
 async fn test_get_state_job_not_found() {
     let storage = create_mariadb_connector().await;
-    let fake_job_id = JobId::new();
+    let fake_job_id = JobId::random();
 
     let result = storage.get_state(fake_job_id).await;
     assert!(
@@ -665,7 +665,7 @@ async fn test_get_state_job_not_found() {
 #[ignore = "requires MariaDB"]
 async fn test_get_outputs_job_not_found() {
     let storage = create_mariadb_connector().await;
-    let fake_job_id = JobId::new();
+    let fake_job_id = JobId::random();
 
     let result = storage.get_outputs(fake_job_id).await;
     assert!(
@@ -678,7 +678,7 @@ async fn test_get_outputs_job_not_found() {
 #[ignore = "requires MariaDB"]
 async fn test_get_error_job_not_found() {
     let storage = create_mariadb_connector().await;
-    let fake_job_id = JobId::new();
+    let fake_job_id = JobId::random();
 
     let result = storage.get_error(fake_job_id).await;
     assert!(
@@ -691,7 +691,7 @@ async fn test_get_error_job_not_found() {
 #[ignore = "requires MariaDB"]
 async fn test_commit_outputs_job_not_found() {
     let storage = create_mariadb_connector().await;
-    let fake_job_id = JobId::new();
+    let fake_job_id = JobId::random();
 
     let result =
         InternalJobOrchestration::commit_outputs(&storage, fake_job_id, vec![vec![]], false).await;
@@ -705,7 +705,7 @@ async fn test_commit_outputs_job_not_found() {
 #[ignore = "requires MariaDB"]
 async fn test_cancel_job_not_found() {
     let storage = create_mariadb_connector().await;
-    let fake_job_id = JobId::new();
+    let fake_job_id = JobId::random();
 
     let result = InternalJobOrchestration::cancel(&storage, fake_job_id, false).await;
     assert!(
@@ -718,7 +718,7 @@ async fn test_cancel_job_not_found() {
 #[ignore = "requires MariaDB"]
 async fn test_fail_job_not_found() {
     let storage = create_mariadb_connector().await;
-    let fake_job_id = JobId::new();
+    let fake_job_id = JobId::random();
 
     let result = InternalJobOrchestration::fail(&storage, fake_job_id, "error".to_string()).await;
     assert!(
@@ -822,7 +822,7 @@ async fn test_update_execution_manager_heartbeat() {
 #[ignore = "requires MariaDB"]
 async fn test_update_execution_manager_heartbeat_not_found() {
     let storage = create_mariadb_connector().await;
-    let fake_em_id = ExecutionManagerId::new();
+    let fake_em_id = ExecutionManagerId::random();
 
     let result = storage.update_execution_manager_heartbeat(fake_em_id).await;
     assert!(
@@ -873,7 +873,7 @@ async fn test_is_execution_manager_alive_em_alive() {
 #[ignore = "requires MariaDB"]
 async fn test_is_execution_manager_alive_em_not_found() {
     let storage = create_mariadb_connector().await;
-    let fake_em_id = ExecutionManagerId::new();
+    let fake_em_id = ExecutionManagerId::random();
 
     let result = storage.is_execution_manager_alive(fake_em_id).await;
     assert!(

--- a/components/spider-storage/tests/scheduling_infra.rs
+++ b/components/spider-storage/tests/scheduling_infra.rs
@@ -359,7 +359,7 @@ pub async fn run_workload<DbConnectorType: InternalJobOrchestration + 'static>(
     let ctx = EmContext {
         receiver: ready_receiver,
         jcb: jcb.clone(),
-        execution_manager_id: ExecutionManagerId::new(),
+        execution_manager_id: ExecutionManagerId::random(),
         terminal_state_sender: terminal_state_sender.clone(),
         done_receiver: done_receiver.clone(),
         seen_tasks: Arc::new(DashMap::new()),
@@ -374,7 +374,7 @@ pub async fn run_workload<DbConnectorType: InternalJobOrchestration + 'static>(
     let mut join_set = tokio::task::JoinSet::new();
     for _ in 0..NUM_EXECUTION_MANAGERS {
         let mut em_ctx = ctx.clone();
-        em_ctx.execution_manager_id = ExecutionManagerId::new();
+        em_ctx.execution_manager_id = ExecutionManagerId::random();
         join_set.spawn(async move { run_execution_manager(em_ctx).await });
     }
 

--- a/components/spider-tdl/src/task.rs
+++ b/components/spider-tdl/src/task.rs
@@ -253,10 +253,10 @@ mod tests {
 
     fn make_encoded_ctx() -> Vec<u8> {
         let ctx = TaskContext {
-            job_id: JobId::new(),
+            job_id: JobId::random(),
             task_id: TaskId::Index(0),
             task_instance_id: 1,
-            resource_group_id: ResourceGroupId::new(),
+            resource_group_id: ResourceGroupId::random(),
         };
         rmp_serde::to_vec(&ctx).expect("failed to serialize `TaskContext`")
     }

--- a/components/spider-tdl/src/task_context.rs
+++ b/components/spider-tdl/src/task_context.rs
@@ -30,10 +30,10 @@ mod tests {
     #[test]
     fn round_trip_msgpack() -> anyhow::Result<()> {
         let ctx = TaskContext {
-            job_id: JobId::new(),
+            job_id: JobId::random(),
             task_id: TaskId::Index(0),
             task_instance_id: 13,
-            resource_group_id: ResourceGroupId::new(),
+            resource_group_id: ResourceGroupId::random(),
         };
         let encoded = rmp_serde::to_vec(&ctx)?;
         let decoded: TaskContext = rmp_serde::from_slice(&encoded)?;

--- a/components/spider-tdl/tests/test_task_macro.rs
+++ b/components/spider-tdl/tests/test_task_macro.rs
@@ -80,10 +80,10 @@ fn translate(_ctx: TaskContext, p: Point, dx: int32, dy: int32) -> Result<(Point
 /// A mocked encoded task context for testing.
 fn make_encoded_ctx() -> Vec<u8> {
     let ctx = TaskContext {
-        job_id: JobId::new(),
+        job_id: JobId::random(),
         task_id: TaskId::Index(0),
         task_instance_id: 1,
-        resource_group_id: ResourceGroupId::new(),
+        resource_group_id: ResourceGroupId::random(),
     };
     rmp_serde::to_vec(&ctx).expect("failed to serialize `TaskContext`")
 }
@@ -302,10 +302,10 @@ fn direct_execute_call_round_trips() -> anyhow::Result<()> {
     const EXPECTED_SUM: int32 = OPERAND_A + OPERAND_B;
 
     let ctx = TaskContext {
-        job_id: JobId::new(),
+        job_id: JobId::random(),
         task_id: TaskId::Index(0),
         task_instance_id: 1,
-        resource_group_id: ResourceGroupId::new(),
+        resource_group_id: ResourceGroupId::random(),
     };
 
     let mut inputs = TaskInputsSerializer::new();

--- a/tests/huntsman/task-executor/tests/test_process_pool.rs
+++ b/tests/huntsman/task-executor/tests/test_process_pool.rs
@@ -58,7 +58,7 @@ const SLOW_FIB_INDEX: u64 = 45;
 ///
 /// Panics if [`ProcessPool::new`] fails — i.e., the task-executor binary cannot be spawned.
 fn build_pool() -> ProcessPool {
-    let em_id = ExecutionManagerId::new();
+    let em_id = ExecutionManagerId::random();
     let log_dir = std::env::temp_dir().join(format!("spider-em-pool-test-{em_id}"));
     let config = ProcessPoolConfig {
         em_id,
@@ -77,9 +77,9 @@ fn build_pool() -> ProcessPool {
 /// supplies `hard_timeout` directly to [`ProcessPool::execute`]), and the supplied `inputs`.
 fn make_request(task_func: &str, inputs: Vec<TaskInput>) -> ExecuteRequest {
     ExecuteRequest {
-        job_id: JobId::new(),
+        job_id: JobId::random(),
         task_id: TaskId::Index(0),
-        resource_group_id: ResourceGroupId::new(),
+        resource_group_id: ResourceGroupId::random(),
         ctx: ExecutionContext {
             task_instance_id: 1,
             tdl_context: TdlContext {

--- a/tests/huntsman/task-executor/tests/test_process_pool.rs
+++ b/tests/huntsman/task-executor/tests/test_process_pool.rs
@@ -59,7 +59,7 @@ const SLOW_FIB_INDEX: u64 = 45;
 /// Panics if [`ProcessPool::new`] fails — i.e., the task-executor binary cannot be spawned.
 fn build_pool() -> ProcessPool {
     let em_id = ExecutionManagerId::new();
-    let log_dir = std::env::temp_dir().join(format!("spider-em-pool-test-{}", em_id.as_uuid_ref()));
+    let log_dir = std::env::temp_dir().join(format!("spider-em-pool-test-{em_id}"));
     let config = ProcessPoolConfig {
         em_id,
         executor_binary_path: task_executor_bin(),

--- a/tests/huntsman/tdl-integration/tests/complex.rs
+++ b/tests/huntsman/tdl-integration/tests/complex.rs
@@ -32,10 +32,10 @@ fn lib_path() -> std::path::PathBuf {
 /// An encoded task context for testing.
 fn encode_ctx() -> Vec<u8> {
     let ctx = TaskContext {
-        job_id: JobId::new(),
+        job_id: JobId::random(),
         task_id: TaskId::Index(0),
         task_instance_id: 1,
-        resource_group_id: ResourceGroupId::new(),
+        resource_group_id: ResourceGroupId::random(),
     };
     rmp_serde::to_vec(&ctx).expect("failed to serialize `TaskContext`")
 }

--- a/tests/huntsman/test-utils/src/executor.rs
+++ b/tests/huntsman/test-utils/src/executor.rs
@@ -191,10 +191,10 @@ pub fn tdl_package_dir() -> PathBuf {
 #[must_use]
 pub fn build_ctx() -> Vec<u8> {
     let ctx = TaskContext {
-        job_id: JobId::new(),
+        job_id: JobId::random(),
         task_id: TaskId::Index(0),
         task_instance_id: 1,
-        resource_group_id: ResourceGroupId::new(),
+        resource_group_id: ResourceGroupId::random(),
     };
     rmp_serde::to_vec(&ctx).expect("serialize TaskContext")
 }

--- a/tests/huntsman/test-utils/src/mock.rs
+++ b/tests/huntsman/test-utils/src/mock.rs
@@ -54,7 +54,7 @@ impl MockLiveness {
     pub fn with_initial_session(initial_session: SessionId) -> Self {
         Self {
             inner: Arc::new(LivenessInner {
-                em_id: ExecutionManagerId::new(),
+                em_id: ExecutionManagerId::random(),
                 initial_session: AtomicU64::new(initial_session),
                 register_response: Mutex::new(None),
                 heartbeat_responses: Mutex::new(VecDeque::new()),


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR changes the following ids from `Uuid` to `u64`:
* job id
* resource group id
* execution manager id
Note that the task id stays `usize` as it is used as an index to vectors.

This PR also changes the database schema to use `AUTOINCREMENT BIGINT UNSIGNED` to match the change.

The old id `default` and `new` functions, both only used for tests, has changed to:
* `default` always return 0
* `new` renames to `random` and returns a randomly generated `u64`
This fulfills the need for tests. In production, neither functions should be used, as ids are generated by database.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* [x] No `Uuid` left, in code and in dependency.
* [x] GitHub workflows pass.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Migrated identifiers from UUIDs to numeric (u64) IDs across the system.
  * Updated storage to use auto-incrementing numeric primary keys and removed UUID dependency.
  * Adjusted logging/file naming to use numeric IDs.

* **Tests**
  * Updated unit and integration tests to generate and use randomized numeric IDs instead of UUIDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->