### PR TITLE
feat(spider-storage): Add scheduler registration protocols and MariaDB implementation.

### DIFF
--- a/components/spider-core/src/types.rs
+++ b/components/spider-core/src/types.rs
@@ -1,2 +1,3 @@
 pub mod id;
 pub mod io;
+pub mod scheduler;

--- a/components/spider-core/src/types/scheduler.rs
+++ b/components/spider-core/src/types/scheduler.rs
@@ -1,0 +1,11 @@
+use std::net::IpAddr;
+
+use crate::types::id::SchedulerId;
+
+/// The currently registered scheduler endpoint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RegisteredScheduler {
+    pub id: SchedulerId,
+    pub ip_address: IpAddr,
+    pub port: u16,
+}

--- a/components/spider-proto-rust/src/generated/storage.rs
+++ b/components/spider-proto-rust/src/generated/storage.rs
@@ -336,9 +336,7 @@ pub struct Scheduler {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SchedulerRegistrations {
-    #[prost(uint64, tag = "1")]
-    pub session_id: u64,
-    #[prost(message, repeated, tag = "2")]
+    #[prost(message, repeated, tag = "1")]
     pub schedulers: ::prost::alloc::vec::Vec<Scheduler>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/components/spider-proto-rust/src/generated/storage.rs
+++ b/components/spider-proto-rust/src/generated/storage.rs
@@ -296,6 +296,13 @@ pub mod update_execution_manager_heartbeat_response {
         Error(super::ExecutionManagerLivenessError),
     }
 }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RegisterSchedulerRequest {
+    #[prost(string, tag = "1")]
+    pub ip_address: ::prost::alloc::string::String,
+    #[prost(uint32, tag = "2")]
+    pub port: u32,
+}
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct SchedulerRegistration {
     #[prost(uint64, tag = "1")]
@@ -314,6 +321,37 @@ pub mod register_scheduler_response {
     pub enum Result {
         #[prost(message, tag = "1")]
         Registration(super::SchedulerRegistration),
+        #[prost(message, tag = "2")]
+        Error(super::SchedulerRegistrationError),
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Scheduler {
+    #[prost(uint64, tag = "1")]
+    pub scheduler_id: u64,
+    #[prost(string, tag = "2")]
+    pub ip_address: ::prost::alloc::string::String,
+    #[prost(uint32, tag = "3")]
+    pub port: u32,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SchedulerRegistrations {
+    #[prost(uint64, tag = "1")]
+    pub session_id: u64,
+    #[prost(message, repeated, tag = "2")]
+    pub schedulers: ::prost::alloc::vec::Vec<Scheduler>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetSchedulersResponse {
+    #[prost(oneof = "get_schedulers_response::Result", tags = "1, 2")]
+    pub result: ::core::option::Option<get_schedulers_response::Result>,
+}
+/// Nested message and enum types in `GetSchedulersResponse`.
+pub mod get_schedulers_response {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Result {
+        #[prost(message, tag = "1")]
+        Schedulers(super::SchedulerRegistrations),
         #[prost(message, tag = "2")]
         Error(super::SchedulerRegistrationError),
     }
@@ -1841,7 +1879,7 @@ pub mod scheduler_registration_service_client {
         }
         pub async fn register_scheduler(
             &mut self,
-            request: impl tonic::IntoRequest<super::Void>,
+            request: impl tonic::IntoRequest<super::RegisterSchedulerRequest>,
         ) -> std::result::Result<
             tonic::Response<super::RegisterSchedulerResponse>,
             tonic::Status,
@@ -1864,6 +1902,35 @@ pub mod scheduler_registration_service_client {
                     GrpcMethod::new(
                         "storage.SchedulerRegistrationService",
                         "RegisterScheduler",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn get_schedulers(
+            &mut self,
+            request: impl tonic::IntoRequest<super::Void>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetSchedulersResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/storage.SchedulerRegistrationService/GetSchedulers",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "storage.SchedulerRegistrationService",
+                        "GetSchedulers",
                     ),
                 );
             self.inner.unary(req, path, codec).await
@@ -3732,9 +3799,16 @@ pub mod scheduler_registration_service_server {
     pub trait SchedulerRegistrationService: std::marker::Send + std::marker::Sync + 'static {
         async fn register_scheduler(
             &self,
-            request: tonic::Request<super::Void>,
+            request: tonic::Request<super::RegisterSchedulerRequest>,
         ) -> std::result::Result<
             tonic::Response<super::RegisterSchedulerResponse>,
+            tonic::Status,
+        >;
+        async fn get_schedulers(
+            &self,
+            request: tonic::Request<super::Void>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetSchedulersResponse>,
             tonic::Status,
         >;
     }
@@ -3822,7 +3896,7 @@ pub mod scheduler_registration_service_server {
                     );
                     impl<
                         T: SchedulerRegistrationService,
-                    > tonic::server::UnaryService<super::Void>
+                    > tonic::server::UnaryService<super::RegisterSchedulerRequest>
                     for RegisterSchedulerSvc<T> {
                         type Response = super::RegisterSchedulerResponse;
                         type Future = BoxFuture<
@@ -3831,7 +3905,7 @@ pub mod scheduler_registration_service_server {
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::Void>,
+                            request: tonic::Request<super::RegisterSchedulerRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
@@ -3851,6 +3925,54 @@ pub mod scheduler_registration_service_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = RegisterSchedulerSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/storage.SchedulerRegistrationService/GetSchedulers" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetSchedulersSvc<T: SchedulerRegistrationService>(pub Arc<T>);
+                    impl<
+                        T: SchedulerRegistrationService,
+                    > tonic::server::UnaryService<super::Void> for GetSchedulersSvc<T> {
+                        type Response = super::GetSchedulersResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::Void>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as SchedulerRegistrationService>::get_schedulers(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetSchedulersSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/components/spider-proto-rust/src/generated/storage.rs
+++ b/components/spider-proto-rust/src/generated/storage.rs
@@ -297,6 +297,28 @@ pub mod update_execution_manager_heartbeat_response {
     }
 }
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct SchedulerRegistration {
+    #[prost(uint64, tag = "1")]
+    pub scheduler_id: u64,
+    #[prost(uint64, tag = "2")]
+    pub session_id: u64,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RegisterSchedulerResponse {
+    #[prost(oneof = "register_scheduler_response::Result", tags = "1, 2")]
+    pub result: ::core::option::Option<register_scheduler_response::Result>,
+}
+/// Nested message and enum types in `RegisterSchedulerResponse`.
+pub mod register_scheduler_response {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Result {
+        #[prost(message, tag = "1")]
+        Registration(super::SchedulerRegistration),
+        #[prost(message, tag = "2")]
+        Error(super::SchedulerRegistrationError),
+    }
+}
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct GetSessionResponse {
     #[prost(uint64, tag = "1")]
     pub session_id: u64,
@@ -631,6 +653,52 @@ pub mod execution_manager_liveness_error {
                 "ERR_CODE_UNSPECIFIED" => Some(Self::Unspecified),
                 "MARKED_DEAD" => Some(Self::MarkedDead),
                 "INVALID_INPUT" => Some(Self::InvalidInput),
+                "SERVER" => Some(Self::Server),
+                _ => None,
+            }
+        }
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SchedulerRegistrationError {
+    #[prost(enumeration = "scheduler_registration_error::ErrCode", tag = "1")]
+    pub err_code: i32,
+    #[prost(string, tag = "2")]
+    pub message: ::prost::alloc::string::String,
+}
+/// Nested message and enum types in `SchedulerRegistrationError`.
+pub mod scheduler_registration_error {
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
+    #[repr(i32)]
+    pub enum ErrCode {
+        Unspecified = 0,
+        Server = 1,
+    }
+    impl ErrCode {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Self::Unspecified => "ERR_CODE_UNSPECIFIED",
+                Self::Server => "SERVER",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "ERR_CODE_UNSPECIFIED" => Some(Self::Unspecified),
                 "SERVER" => Some(Self::Server),
                 _ => None,
             }
@@ -1672,6 +1740,130 @@ pub mod execution_manager_liveness_service_client {
                     GrpcMethod::new(
                         "storage.ExecutionManagerLivenessService",
                         "UpdateExecutionManagerHeartbeat",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+    }
+}
+/// Generated client implementations.
+pub mod scheduler_registration_service_client {
+    #![allow(
+        unused_variables,
+        dead_code,
+        missing_docs,
+        clippy::wildcard_imports,
+        clippy::let_unit_value,
+    )]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    #[derive(Debug, Clone)]
+    pub struct SchedulerRegistrationServiceClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl SchedulerRegistrationServiceClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> SchedulerRegistrationServiceClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> SchedulerRegistrationServiceClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+        {
+            SchedulerRegistrationServiceClient::new(
+                InterceptedService::new(inner, interceptor),
+            )
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        pub async fn register_scheduler(
+            &mut self,
+            request: impl tonic::IntoRequest<super::Void>,
+        ) -> std::result::Result<
+            tonic::Response<super::RegisterSchedulerResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/storage.SchedulerRegistrationService/RegisterScheduler",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "storage.SchedulerRegistrationService",
+                        "RegisterScheduler",
                     ),
                 );
             self.inner.unary(req, path, codec).await
@@ -3522,6 +3714,193 @@ pub mod execution_manager_liveness_service_server {
     /// Generated gRPC service name
     pub const SERVICE_NAME: &str = "storage.ExecutionManagerLivenessService";
     impl<T> tonic::server::NamedService for ExecutionManagerLivenessServiceServer<T> {
+        const NAME: &'static str = SERVICE_NAME;
+    }
+}
+/// Generated server implementations.
+pub mod scheduler_registration_service_server {
+    #![allow(
+        unused_variables,
+        dead_code,
+        missing_docs,
+        clippy::wildcard_imports,
+        clippy::let_unit_value,
+    )]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with SchedulerRegistrationServiceServer.
+    #[async_trait]
+    pub trait SchedulerRegistrationService: std::marker::Send + std::marker::Sync + 'static {
+        async fn register_scheduler(
+            &self,
+            request: tonic::Request<super::Void>,
+        ) -> std::result::Result<
+            tonic::Response<super::RegisterSchedulerResponse>,
+            tonic::Status,
+        >;
+    }
+    #[derive(Debug)]
+    pub struct SchedulerRegistrationServiceServer<T> {
+        inner: Arc<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
+    }
+    impl<T> SchedulerRegistrationServiceServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>>
+    for SchedulerRegistrationServiceServer<T>
+    where
+        T: SchedulerRegistrationService,
+        B: Body + std::marker::Send + 'static,
+        B::Error: Into<StdError> + std::marker::Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            match req.uri().path() {
+                "/storage.SchedulerRegistrationService/RegisterScheduler" => {
+                    #[allow(non_camel_case_types)]
+                    struct RegisterSchedulerSvc<T: SchedulerRegistrationService>(
+                        pub Arc<T>,
+                    );
+                    impl<
+                        T: SchedulerRegistrationService,
+                    > tonic::server::UnaryService<super::Void>
+                    for RegisterSchedulerSvc<T> {
+                        type Response = super::RegisterSchedulerResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::Void>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as SchedulerRegistrationService>::register_scheduler(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = RegisterSchedulerSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
+            }
+        }
+    }
+    impl<T> Clone for SchedulerRegistrationServiceServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
+            }
+        }
+    }
+    /// Generated gRPC service name
+    pub const SERVICE_NAME: &str = "storage.SchedulerRegistrationService";
+    impl<T> tonic::server::NamedService for SchedulerRegistrationServiceServer<T> {
         const NAME: &'static str = SERVICE_NAME;
     }
 }

--- a/components/spider-proto/storage/storage.proto
+++ b/components/spider-proto/storage/storage.proto
@@ -240,8 +240,7 @@ message Scheduler {
 }
 
 message SchedulerRegistrations {
-  uint64 session_id = 1;
-  repeated Scheduler schedulers = 2;
+  repeated Scheduler schedulers = 1;
 }
 
 message GetSchedulersResponse {

--- a/components/spider-proto/storage/storage.proto
+++ b/components/spider-proto/storage/storage.proto
@@ -39,6 +39,10 @@ service ExecutionManagerLivenessService {
       returns (UpdateExecutionManagerHeartbeatResponse);
 }
 
+service SchedulerRegistrationService {
+  rpc RegisterScheduler(Void) returns (RegisterSchedulerResponse);
+}
+
 service SessionManagementService {
   rpc GetSession(Void) returns (GetSessionResponse);
 }
@@ -211,6 +215,18 @@ message UpdateExecutionManagerHeartbeatResponse {
   }
 }
 
+message SchedulerRegistration {
+  uint64 scheduler_id = 1;
+  uint64 session_id = 2;
+}
+
+message RegisterSchedulerResponse {
+  oneof result {
+    SchedulerRegistration registration = 1;
+    SchedulerRegistrationError error = 2;
+  }
+}
+
 message GetSessionResponse {
   uint64 session_id = 1;
 }
@@ -316,6 +332,16 @@ message ExecutionManagerLivenessError {
     MARKED_DEAD = 1;
     INVALID_INPUT = 2;
     SERVER = 3;
+  }
+
+  ErrCode err_code = 1;
+  string message = 2;
+}
+
+message SchedulerRegistrationError {
+  enum ErrCode {
+    ERR_CODE_UNSPECIFIED = 0;
+    SERVER = 1;
   }
 
   ErrCode err_code = 1;

--- a/components/spider-proto/storage/storage.proto
+++ b/components/spider-proto/storage/storage.proto
@@ -40,7 +40,8 @@ service ExecutionManagerLivenessService {
 }
 
 service SchedulerRegistrationService {
-  rpc RegisterScheduler(Void) returns (RegisterSchedulerResponse);
+  rpc RegisterScheduler(RegisterSchedulerRequest) returns (RegisterSchedulerResponse);
+  rpc GetSchedulers(Void) returns (GetSchedulersResponse);
 }
 
 service SessionManagementService {
@@ -215,6 +216,11 @@ message UpdateExecutionManagerHeartbeatResponse {
   }
 }
 
+message RegisterSchedulerRequest {
+  string ip_address = 1;
+  uint32 port = 2;
+}
+
 message SchedulerRegistration {
   uint64 scheduler_id = 1;
   uint64 session_id = 2;
@@ -223,6 +229,24 @@ message SchedulerRegistration {
 message RegisterSchedulerResponse {
   oneof result {
     SchedulerRegistration registration = 1;
+    SchedulerRegistrationError error = 2;
+  }
+}
+
+message Scheduler {
+  uint64 scheduler_id = 1;
+  string ip_address = 2;
+  uint32 port = 3;
+}
+
+message SchedulerRegistrations {
+  uint64 session_id = 1;
+  repeated Scheduler schedulers = 2;
+}
+
+message GetSchedulersResponse {
+  oneof result {
+    SchedulerRegistrations schedulers = 1;
     SchedulerRegistrationError error = 2;
   }
 }

--- a/components/spider-storage/src/db.rs
+++ b/components/spider-storage/src/db.rs
@@ -11,5 +11,6 @@ pub use protocol::{
     InternalJobOrchestration,
     RecoverableJobContext,
     ResourceGroupManagement,
+    SchedulerRegistrationManagement,
     SessionManagement,
 };

--- a/components/spider-storage/src/db.rs
+++ b/components/spider-storage/src/db.rs
@@ -10,7 +10,6 @@ pub use protocol::{
     ExternalJobOrchestration,
     InternalJobOrchestration,
     RecoverableJobContext,
-    RegisteredScheduler,
     ResourceGroupManagement,
     SchedulerRegistrationManagement,
     SessionManagement,

--- a/components/spider-storage/src/db.rs
+++ b/components/spider-storage/src/db.rs
@@ -10,6 +10,7 @@ pub use protocol::{
     ExternalJobOrchestration,
     InternalJobOrchestration,
     RecoverableJobContext,
+    RegisteredScheduler,
     ResourceGroupManagement,
     SchedulerRegistrationManagement,
     SessionManagement,

--- a/components/spider-storage/src/db/mariadb.rs
+++ b/components/spider-storage/src/db/mariadb.rs
@@ -9,6 +9,7 @@ use spider_core::{
     types::{
         id::{ExecutionManagerId, JobId, ResourceGroupId, SchedulerId, SessionId},
         io::{TaskInput, TaskOutput},
+        scheduler::RegisteredScheduler,
     },
 };
 use spider_derive::MySqlEnum;
@@ -24,7 +25,6 @@ use crate::{
         ExternalJobOrchestration,
         InternalJobOrchestration,
         RecoverableJobContext,
-        RegisteredScheduler,
         ResourceGroupManagement,
         SchedulerRegistrationManagement,
         SessionManagement,

--- a/components/spider-storage/src/db/mariadb.rs
+++ b/components/spider-storage/src/db/mariadb.rs
@@ -7,7 +7,7 @@ use spider_core::{
     job::JobState,
     task::TaskGraph,
     types::{
-        id::{ExecutionManagerId, JobId, ResourceGroupId, SessionId},
+        id::{ExecutionManagerId, JobId, ResourceGroupId, SchedulerId, SessionId},
         io::{TaskInput, TaskOutput},
     },
 };
@@ -25,6 +25,7 @@ use crate::{
         InternalJobOrchestration,
         RecoverableJobContext,
         ResourceGroupManagement,
+        SchedulerRegistrationManagement,
         SessionManagement,
         error::ExpectedStates,
     },
@@ -84,6 +85,9 @@ impl MariaDbStorageConnector {
             .execute(&pool)
             .await?;
         sqlx::query(execution_managers_creation_query())
+            .execute(&pool)
+            .await?;
+        sqlx::query(schedulers_creation_query())
             .execute(&pool)
             .await?;
 
@@ -589,6 +593,37 @@ impl ExecutionManagerLivenessManagement for MariaDbStorageConnector {
     }
 }
 
+#[async_trait]
+impl SchedulerRegistrationManagement for MariaDbStorageConnector {
+    async fn register_scheduler(&self) -> Result<SchedulerId, DbError> {
+        const DELETE_QUERY: &str =
+            formatcp!("DELETE FROM `{table}`;", table = SCHEDULERS_TABLE_NAME,);
+        const INSERT_QUERY: &str = formatcp!(
+            "INSERT INTO `{table}` () VALUES () RETURNING `id`;",
+            table = SCHEDULERS_TABLE_NAME,
+        );
+
+        let mut tx = self.pool.begin().await?;
+        sqlx::query(DELETE_QUERY).execute(&mut *tx).await?;
+        let scheduler_id = sqlx::query_scalar(INSERT_QUERY).fetch_one(&mut *tx).await?;
+        tx.commit().await?;
+        Ok(scheduler_id)
+    }
+
+    async fn is_scheduler_registered(&self, scheduler_id: SchedulerId) -> Result<bool, DbError> {
+        const QUERY: &str = formatcp!(
+            "SELECT `id` FROM `{table}` WHERE `id` = ?;",
+            table = SCHEDULERS_TABLE_NAME,
+        );
+
+        let registered_scheduler_id: Option<SchedulerId> = sqlx::query_scalar(QUERY)
+            .bind(scheduler_id)
+            .fetch_optional(&self.pool)
+            .await?;
+        Ok(registered_scheduler_id.is_some())
+    }
+}
+
 impl SessionManagement for MariaDbStorageConnector {
     fn session_id(&self) -> SessionId {
         self.session_id
@@ -606,6 +641,7 @@ const MYSQL_ER_DUP_ENTRY: u16 = 1062;
 const RESOURCE_GROUPS_TABLE_NAME: &str = "resource_groups";
 const JOBS_TABLE_NAME: &str = "jobs";
 const EXECUTION_MANAGERS_TABLE_NAME: &str = "execution_managers";
+const SCHEDULERS_TABLE_NAME: &str = "schedulers";
 const SESSIONS_TABLE_NAME: &str = "sessions";
 
 const UPDATE_JOB_STATE: &str = formatcp!(
@@ -671,6 +707,18 @@ CREATE TABLE IF NOT EXISTS `{EXECUTION_MANAGERS_TABLE_NAME}` (
 );",
         state_enum = ExecutionManagerState::as_mysql_enum_decl(),
         default_state = ExecutionManagerState::Alive.as_quoted_str(),
+    )
+}
+
+#[must_use]
+const fn schedulers_creation_query() -> &'static str {
+    formatcp!(
+        r"
+CREATE TABLE IF NOT EXISTS `{SCHEDULERS_TABLE_NAME}` (
+  `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`)
+);"
     )
 }
 

--- a/components/spider-storage/src/db/mariadb.rs
+++ b/components/spider-storage/src/db/mariadb.rs
@@ -767,41 +767,6 @@ struct RecoverableJobRowProjection {
     serialized_job_outputs: Option<Vec<u8>>,
 }
 
-/// A raw row selected from the schedulers table.
-#[derive(sqlx::FromRow)]
-struct SchedulerRowProjection {
-    id: SchedulerId,
-    ip_address: String,
-    port: u16,
-}
-
-impl SchedulerRowProjection {
-    /// Converts the row projection into [`RegisteredScheduler`].
-    ///
-    /// # Returns
-    ///
-    /// The registered scheduler on success.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if:
-    ///
-    /// * [`DbError::CorruptedDbState`] if the scheduler IP address is invalid.
-    fn into_registered_scheduler(self) -> Result<RegisteredScheduler, DbError> {
-        let ip_address = self.ip_address.parse().map_err(|error| {
-            DbError::CorruptedDbState(format!(
-                "scheduler `{}` has invalid IP address `{}`: {error}",
-                self.id, self.ip_address
-            ))
-        })?;
-        Ok(RegisteredScheduler {
-            id: self.id,
-            ip_address,
-            port: self.port,
-        })
-    }
-}
-
 impl RecoverableJobRowProjection {
     /// Converts the row projection into [`RecoverableJobContext`].
     ///
@@ -834,6 +799,41 @@ impl RecoverableJobRowProjection {
             state: self.state,
             submission,
             outputs,
+        })
+    }
+}
+
+/// A raw row selected from the schedulers table.
+#[derive(sqlx::FromRow)]
+struct SchedulerRowProjection {
+    id: SchedulerId,
+    ip_address: String,
+    port: u16,
+}
+
+impl SchedulerRowProjection {
+    /// Converts the row projection into [`RegisteredScheduler`].
+    ///
+    /// # Returns
+    ///
+    /// The registered scheduler on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * [`DbError::CorruptedDbState`] if the scheduler IP address is invalid.
+    fn into_registered_scheduler(self) -> Result<RegisteredScheduler, DbError> {
+        let ip_address = self.ip_address.parse().map_err(|error| {
+            DbError::CorruptedDbState(format!(
+                "scheduler `{}` has invalid IP address `{}`: {error}",
+                self.id, self.ip_address
+            ))
+        })?;
+        Ok(RegisteredScheduler {
+            id: self.id,
+            ip_address,
+            port: self.port,
         })
     }
 }

--- a/components/spider-storage/src/db/mariadb.rs
+++ b/components/spider-storage/src/db/mariadb.rs
@@ -24,6 +24,7 @@ use crate::{
         ExternalJobOrchestration,
         InternalJobOrchestration,
         RecoverableJobContext,
+        RegisteredScheduler,
         ResourceGroupManagement,
         SchedulerRegistrationManagement,
         SessionManagement,
@@ -595,19 +596,39 @@ impl ExecutionManagerLivenessManagement for MariaDbStorageConnector {
 
 #[async_trait]
 impl SchedulerRegistrationManagement for MariaDbStorageConnector {
-    async fn register_scheduler(&self) -> Result<SchedulerId, DbError> {
+    async fn register_scheduler(
+        &self,
+        ip_address: IpAddr,
+        port: u16,
+    ) -> Result<SchedulerId, DbError> {
         const DELETE_QUERY: &str =
             formatcp!("DELETE FROM `{table}`;", table = SCHEDULERS_TABLE_NAME,);
         const INSERT_QUERY: &str = formatcp!(
-            "INSERT INTO `{table}` () VALUES () RETURNING `id`;",
+            "INSERT INTO `{table}` (`ip_address`, `port`) VALUES (?, ?) RETURNING `id`;",
             table = SCHEDULERS_TABLE_NAME,
         );
 
         let mut tx = self.pool.begin().await?;
         sqlx::query(DELETE_QUERY).execute(&mut *tx).await?;
-        let scheduler_id = sqlx::query_scalar(INSERT_QUERY).fetch_one(&mut *tx).await?;
+        let scheduler_id = sqlx::query_scalar(INSERT_QUERY)
+            .bind(ip_address.to_string())
+            .bind(port)
+            .fetch_one(&mut *tx)
+            .await?;
         tx.commit().await?;
         Ok(scheduler_id)
+    }
+
+    async fn get_schedulers(&self) -> Result<Vec<RegisteredScheduler>, DbError> {
+        const QUERY: &str = formatcp!(
+            "SELECT `id`, `ip_address`, `port` FROM `{table}` ORDER BY `id` ASC;",
+            table = SCHEDULERS_TABLE_NAME,
+        );
+
+        let rows: Vec<SchedulerRowProjection> = sqlx::query_as(QUERY).fetch_all(&self.pool).await?;
+        rows.into_iter()
+            .map(SchedulerRowProjection::into_registered_scheduler)
+            .collect()
     }
 
     async fn is_scheduler_registered(&self, scheduler_id: SchedulerId) -> Result<bool, DbError> {
@@ -716,6 +737,8 @@ const fn schedulers_creation_query() -> &'static str {
         r"
 CREATE TABLE IF NOT EXISTS `{SCHEDULERS_TABLE_NAME}` (
   `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `ip_address` VARCHAR(45) NOT NULL,
+  `port` SMALLINT UNSIGNED NOT NULL,
   `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
 );"
@@ -742,6 +765,41 @@ struct RecoverableJobRowProjection {
     serialized_task_graph: String,
     serialized_job_inputs: Vec<u8>,
     serialized_job_outputs: Option<Vec<u8>>,
+}
+
+/// A raw row selected from the schedulers table.
+#[derive(sqlx::FromRow)]
+struct SchedulerRowProjection {
+    id: SchedulerId,
+    ip_address: String,
+    port: u16,
+}
+
+impl SchedulerRowProjection {
+    /// Converts the row projection into [`RegisteredScheduler`].
+    ///
+    /// # Returns
+    ///
+    /// The registered scheduler on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * [`DbError::CorruptedDbState`] if the scheduler IP address is invalid.
+    fn into_registered_scheduler(self) -> Result<RegisteredScheduler, DbError> {
+        let ip_address = self.ip_address.parse().map_err(|error| {
+            DbError::CorruptedDbState(format!(
+                "scheduler `{}` has invalid IP address `{}`: {error}",
+                self.id, self.ip_address
+            ))
+        })?;
+        Ok(RegisteredScheduler {
+            id: self.id,
+            ip_address,
+            port: self.port,
+        })
+    }
 }
 
 impl RecoverableJobRowProjection {

--- a/components/spider-storage/src/db/protocol.rs
+++ b/components/spider-storage/src/db/protocol.rs
@@ -22,6 +22,14 @@ pub struct RecoverableJobContext {
     pub outputs: Option<Vec<TaskOutput>>,
 }
 
+/// The currently registered scheduler endpoint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RegisteredScheduler {
+    pub id: SchedulerId,
+    pub ip_address: IpAddr,
+    pub port: u16,
+}
+
 /// The database storage interface. A database storage must implement the following traits:
 ///
 /// * [`ExternalJobOrchestration`]
@@ -436,6 +444,11 @@ pub trait SchedulerRegistrationManagement: Clone + Send + Sync {
     /// For now, only one scheduler can be registered at a time. Registering a new scheduler removes
     /// any previously registered scheduler before allocating the new scheduler ID.
     ///
+    /// # Parameters
+    ///
+    /// * `ip_address` - The scheduler IP address.
+    /// * `port` - The scheduler port.
+    ///
     /// # Returns
     ///
     /// The ID of the registered scheduler on success.
@@ -445,7 +458,24 @@ pub trait SchedulerRegistrationManagement: Clone + Send + Sync {
     /// Returns an error if:
     ///
     /// * Forwards [`sqlx::error::Error`] on DB operation failure.
-    async fn register_scheduler(&self) -> Result<SchedulerId, DbError>;
+    async fn register_scheduler(
+        &self,
+        ip_address: IpAddr,
+        port: u16,
+    ) -> Result<SchedulerId, DbError>;
+
+    /// Gets registered schedulers.
+    ///
+    /// # Returns
+    ///
+    /// The registered schedulers on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * Forwards [`sqlx::error::Error`] on DB operation failure.
+    async fn get_schedulers(&self) -> Result<Vec<RegisteredScheduler>, DbError>;
 
     /// Checks whether the scheduler with the given ID is registered.
     ///

--- a/components/spider-storage/src/db/protocol.rs
+++ b/components/spider-storage/src/db/protocol.rs
@@ -6,6 +6,7 @@ use spider_core::{
     types::{
         id::{ExecutionManagerId, JobId, ResourceGroupId, SchedulerId, SessionId},
         io::TaskOutput,
+        scheduler::RegisteredScheduler,
     },
 };
 
@@ -20,14 +21,6 @@ pub struct RecoverableJobContext {
     pub state: JobState,
     pub submission: ValidatedJobSubmission,
     pub outputs: Option<Vec<TaskOutput>>,
-}
-
-/// The currently registered scheduler endpoint.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct RegisteredScheduler {
-    pub id: SchedulerId,
-    pub ip_address: IpAddr,
-    pub port: u16,
 }
 
 /// The database storage interface. A database storage must implement the following traits:

--- a/components/spider-storage/src/db/protocol.rs
+++ b/components/spider-storage/src/db/protocol.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use spider_core::{
     job::JobState,
     types::{
-        id::{ExecutionManagerId, JobId, ResourceGroupId, SessionId},
+        id::{ExecutionManagerId, JobId, ResourceGroupId, SchedulerId, SessionId},
         io::TaskOutput,
     },
 };
@@ -28,6 +28,7 @@ pub struct RecoverableJobContext {
 /// * [`InternalJobOrchestration`]
 /// * [`ResourceGroupManagement`]
 /// * [`ExecutionManagerLivenessManagement`]
+/// * [`SchedulerRegistrationManagement`]
 /// * [`SessionManagement`]
 #[async_trait]
 pub trait DbStorage:
@@ -35,6 +36,7 @@ pub trait DbStorage:
     + InternalJobOrchestration
     + ResourceGroupManagement
     + ExecutionManagerLivenessManagement
+    + SchedulerRegistrationManagement
     + SessionManagement {
 }
 
@@ -424,6 +426,43 @@ pub trait ExecutionManagerLivenessManagement: Clone + Send + Sync {
         &self,
         stale_after_sec: u64,
     ) -> Result<Vec<ExecutionManagerId>, DbError>;
+}
+
+/// Defines the storage interface for scheduler registration in the database.
+#[async_trait]
+pub trait SchedulerRegistrationManagement: Clone + Send + Sync {
+    /// Registers the scheduler in the database.
+    ///
+    /// For now, only one scheduler can be registered at a time. Registering a new scheduler removes
+    /// any previously registered scheduler before allocating the new scheduler ID.
+    ///
+    /// # Returns
+    ///
+    /// The ID of the registered scheduler on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * Forwards [`sqlx::error::Error`] on DB operation failure.
+    async fn register_scheduler(&self) -> Result<SchedulerId, DbError>;
+
+    /// Checks whether the scheduler with the given ID is registered.
+    ///
+    /// # Parameters
+    ///
+    /// * `scheduler_id` - The scheduler ID to check.
+    ///
+    /// # Returns
+    ///
+    /// Whether the scheduler is registered on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * Forwards [`sqlx::error::Error`] on DB operation failure.
+    async fn is_scheduler_registered(&self, scheduler_id: SchedulerId) -> Result<bool, DbError>;
 }
 
 /// Defines the storage interface for session management.

--- a/components/spider-storage/src/state/service.rs
+++ b/components/spider-storage/src/state/service.rs
@@ -4,7 +4,15 @@ use spider_core::{
     job::JobState,
     task::{TaskGraph, TaskIndex},
     types::{
-        id::{ExecutionManagerId, JobId, ResourceGroupId, SessionId, TaskId, TaskInstanceId},
+        id::{
+            ExecutionManagerId,
+            JobId,
+            ResourceGroupId,
+            SchedulerId,
+            SessionId,
+            TaskId,
+            TaskInstanceId,
+        },
         io::{ExecutionContext, TaskInput, TaskOutput},
     },
 };
@@ -653,6 +661,29 @@ impl<
         Ok(())
     }
 
+    /// Registers the scheduler.
+    ///
+    /// Registering a scheduler invalidates any previously registered scheduler.
+    ///
+    /// # Returns
+    ///
+    /// The ID of the registered scheduler on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * Forwards [`SchedulerRegistrationManagement::register_scheduler`]'s return values on
+    ///   failure.
+    pub async fn register_scheduler(&self) -> Result<SchedulerId, StorageServerError> {
+        let scheduler_id = self.inner.db.register_scheduler().await?;
+        tracing::info!(
+            scheduler_id = ? scheduler_id,
+            "Scheduler registered.",
+        );
+        Ok(scheduler_id)
+    }
+
     /// Validates that the given `session_id` matches the session ID captured at service creation
     /// time.
     ///
@@ -710,7 +741,7 @@ mod tests {
             ValueTypeDescriptor,
         },
         types::{
-            id::{ExecutionManagerId, JobId, ResourceGroupId},
+            id::{ExecutionManagerId, JobId, ResourceGroupId, SchedulerId},
             io::{TaskInput, TaskOutput},
         },
     };
@@ -718,7 +749,7 @@ mod tests {
     use super::*;
     use crate::{
         cache::{job::SharedJobControlBlock, job_submission::ValidatedJobSubmission},
-        db::DbError,
+        db::{DbError, SchedulerRegistrationManagement},
         ready_queue::ReadyQueueSenderHandle,
         state::{
             JobCacheGcHandle,
@@ -1643,6 +1674,38 @@ mod tests {
                 )))
             ),
             "update heartbeat should fail for unregistered execution manager"
+        );
+        Ok(())
+    }
+
+    /// # Returns
+    ///
+    /// Whether the scheduler is registered.
+    async fn is_scheduler_registered(db: &MockDbConnector, scheduler_id: SchedulerId) -> bool {
+        db.is_scheduler_registered(scheduler_id)
+            .await
+            .expect("is_scheduler_registered should succeed")
+    }
+
+    #[tokio::test]
+    async fn register_scheduler_replaces_previous_scheduler() -> anyhow::Result<()> {
+        let db = MockDbConnector::default();
+        let service = create_test_service_with_db(db.clone());
+
+        let first_scheduler_id = service.register_scheduler().await?;
+        let second_scheduler_id = service.register_scheduler().await?;
+
+        assert_ne!(
+            first_scheduler_id, second_scheduler_id,
+            "new registration should allocate a fresh scheduler ID"
+        );
+        assert!(
+            !is_scheduler_registered(&db, first_scheduler_id).await,
+            "old scheduler should be removed after a new registration"
+        );
+        assert!(
+            is_scheduler_registered(&db, second_scheduler_id).await,
+            "new scheduler should remain registered"
         );
         Ok(())
     }

--- a/components/spider-storage/src/state/service.rs
+++ b/components/spider-storage/src/state/service.rs
@@ -27,7 +27,7 @@ use crate::{
         job::SharedJobControlBlock,
         job_submission::ValidatedJobSubmission,
     },
-    db::DbStorage,
+    db::{DbStorage, RegisteredScheduler},
     ready_queue::{
         CleanupTaskMarker,
         CommitTaskMarker,
@@ -675,13 +675,38 @@ impl<
     ///
     /// * Forwards [`SchedulerRegistrationManagement::register_scheduler`]'s return values on
     ///   failure.
-    pub async fn register_scheduler(&self) -> Result<SchedulerId, StorageServerError> {
-        let scheduler_id = self.inner.db.register_scheduler().await?;
+    pub async fn register_scheduler(
+        &self,
+        ip_address: IpAddr,
+        port: u16,
+    ) -> Result<SchedulerId, StorageServerError> {
+        let scheduler_id = self.inner.db.register_scheduler(ip_address, port).await?;
         tracing::info!(
             scheduler_id = ? scheduler_id,
+            ip = ? ip_address,
+            port,
             "Scheduler registered.",
         );
         Ok(scheduler_id)
+    }
+
+    /// Gets registered schedulers.
+    ///
+    /// # Returns
+    ///
+    /// The registered schedulers on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * Forwards [`SchedulerRegistrationManagement::get_schedulers`]'s return values on failure.
+    pub async fn get_schedulers(&self) -> Result<Vec<RegisteredScheduler>, StorageServerError> {
+        self.inner
+            .db
+            .get_schedulers()
+            .await
+            .map_err(StorageServerError::from)
     }
 
     /// Validates that the given `session_id` matches the session ID captured at service creation
@@ -730,6 +755,8 @@ struct ServiceStateInner<
 
 #[cfg(test)]
 mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+
     use spider_core::{
         job::JobState,
         task::{
@@ -765,6 +792,8 @@ mod tests {
         ServiceState<ReadyQueueSenderHandle, MockDbConnector, MockTaskInstancePoolConnector>;
 
     const TEST_SESSION_ID: SessionId = 0;
+    const TEST_SCHEDULER_PORT: u16 = 5678;
+    const TEST_UPDATED_SCHEDULER_PORT: u16 = 6789;
 
     fn create_test_service() -> TestServiceState {
         create_test_service_with_db(MockDbConnector::default())
@@ -1691,9 +1720,16 @@ mod tests {
     async fn register_scheduler_replaces_previous_scheduler() -> anyhow::Result<()> {
         let db = MockDbConnector::default();
         let service = create_test_service_with_db(db.clone());
+        let scheduler_ip_address = IpAddr::V4(Ipv4Addr::LOCALHOST);
+        let updated_scheduler_ip_address = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2));
 
-        let first_scheduler_id = service.register_scheduler().await?;
-        let second_scheduler_id = service.register_scheduler().await?;
+        let first_scheduler_id = service
+            .register_scheduler(scheduler_ip_address, TEST_SCHEDULER_PORT)
+            .await?;
+        let second_scheduler_id = service
+            .register_scheduler(updated_scheduler_ip_address, TEST_UPDATED_SCHEDULER_PORT)
+            .await?;
+        let schedulers = service.get_schedulers().await?;
 
         assert_ne!(
             first_scheduler_id, second_scheduler_id,
@@ -1707,6 +1743,14 @@ mod tests {
             is_scheduler_registered(&db, second_scheduler_id).await,
             "new scheduler should remain registered"
         );
+        assert_eq!(
+            schedulers.len(),
+            1,
+            "only the latest scheduler should remain"
+        );
+        assert_eq!(schedulers[0].id, second_scheduler_id);
+        assert_eq!(schedulers[0].ip_address, updated_scheduler_ip_address);
+        assert_eq!(schedulers[0].port, TEST_UPDATED_SCHEDULER_PORT);
         Ok(())
     }
 }

--- a/components/spider-storage/src/state/service.rs
+++ b/components/spider-storage/src/state/service.rs
@@ -14,6 +14,7 @@ use spider_core::{
             TaskInstanceId,
         },
         io::{ExecutionContext, TaskInput, TaskOutput},
+        scheduler::RegisteredScheduler,
     },
 };
 use spider_tdl::{
@@ -27,7 +28,7 @@ use crate::{
         job::SharedJobControlBlock,
         job_submission::ValidatedJobSubmission,
     },
-    db::{DbStorage, RegisteredScheduler},
+    db::DbStorage,
     ready_queue::{
         CleanupTaskMarker,
         CommitTaskMarker,
@@ -755,7 +756,6 @@ struct ServiceStateInner<
 
 #[cfg(test)]
 mod tests {
-    use std::net::{IpAddr, Ipv4Addr};
 
     use spider_core::{
         job::JobState,
@@ -768,7 +768,7 @@ mod tests {
             ValueTypeDescriptor,
         },
         types::{
-            id::{ExecutionManagerId, JobId, ResourceGroupId, SchedulerId},
+            id::{ExecutionManagerId, JobId, ResourceGroupId},
             io::{TaskInput, TaskOutput},
         },
     };
@@ -776,7 +776,7 @@ mod tests {
     use super::*;
     use crate::{
         cache::{job::SharedJobControlBlock, job_submission::ValidatedJobSubmission},
-        db::{DbError, SchedulerRegistrationManagement},
+        db::DbError,
         ready_queue::ReadyQueueSenderHandle,
         state::{
             JobCacheGcHandle,
@@ -792,8 +792,6 @@ mod tests {
         ServiceState<ReadyQueueSenderHandle, MockDbConnector, MockTaskInstancePoolConnector>;
 
     const TEST_SESSION_ID: SessionId = 0;
-    const TEST_SCHEDULER_PORT: u16 = 5678;
-    const TEST_UPDATED_SCHEDULER_PORT: u16 = 6789;
 
     fn create_test_service() -> TestServiceState {
         create_test_service_with_db(MockDbConnector::default())
@@ -1704,53 +1702,6 @@ mod tests {
             ),
             "update heartbeat should fail for unregistered execution manager"
         );
-        Ok(())
-    }
-
-    /// # Returns
-    ///
-    /// Whether the scheduler is registered.
-    async fn is_scheduler_registered(db: &MockDbConnector, scheduler_id: SchedulerId) -> bool {
-        db.is_scheduler_registered(scheduler_id)
-            .await
-            .expect("is_scheduler_registered should succeed")
-    }
-
-    #[tokio::test]
-    async fn register_scheduler_replaces_previous_scheduler() -> anyhow::Result<()> {
-        let db = MockDbConnector::default();
-        let service = create_test_service_with_db(db.clone());
-        let scheduler_ip_address = IpAddr::V4(Ipv4Addr::LOCALHOST);
-        let updated_scheduler_ip_address = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2));
-
-        let first_scheduler_id = service
-            .register_scheduler(scheduler_ip_address, TEST_SCHEDULER_PORT)
-            .await?;
-        let second_scheduler_id = service
-            .register_scheduler(updated_scheduler_ip_address, TEST_UPDATED_SCHEDULER_PORT)
-            .await?;
-        let schedulers = service.get_schedulers().await?;
-
-        assert_ne!(
-            first_scheduler_id, second_scheduler_id,
-            "new registration should allocate a fresh scheduler ID"
-        );
-        assert!(
-            !is_scheduler_registered(&db, first_scheduler_id).await,
-            "old scheduler should be removed after a new registration"
-        );
-        assert!(
-            is_scheduler_registered(&db, second_scheduler_id).await,
-            "new scheduler should remain registered"
-        );
-        assert_eq!(
-            schedulers.len(),
-            1,
-            "only the latest scheduler should remain"
-        );
-        assert_eq!(schedulers[0].id, second_scheduler_id);
-        assert_eq!(schedulers[0].ip_address, updated_scheduler_ip_address);
-        assert_eq!(schedulers[0].port, TEST_UPDATED_SCHEDULER_PORT);
         Ok(())
     }
 }

--- a/components/spider-storage/src/state/test_utils.rs
+++ b/components/spider-storage/src/state/test_utils.rs
@@ -12,6 +12,7 @@ use spider_core::{
     types::{
         id::{ExecutionManagerId, JobId, ResourceGroupId, SchedulerId, SessionId, TaskInstanceId},
         io::TaskOutput,
+        scheduler::RegisteredScheduler,
     },
 };
 
@@ -28,7 +29,6 @@ use crate::{
         ExternalJobOrchestration,
         InternalJobOrchestration,
         RecoverableJobContext,
-        RegisteredScheduler,
         ResourceGroupManagement,
         SchedulerRegistrationManagement,
         SessionManagement,
@@ -79,8 +79,6 @@ pub struct MockDbConnector {
     pub next_resource_group_id: Arc<AtomicUsize>,
     pub execution_managers: Arc<DashMap<ExecutionManagerId, IpAddr>>,
     pub next_execution_manager_id: Arc<AtomicUsize>,
-    pub schedulers: Arc<DashMap<SchedulerId, RegisteredScheduler>>,
-    pub next_scheduler_id: Arc<AtomicUsize>,
     pub session_id: SessionId,
 }
 
@@ -94,8 +92,6 @@ impl Default for MockDbConnector {
             next_resource_group_id: Arc::new(AtomicUsize::new(1)),
             execution_managers: Arc::new(DashMap::new()),
             next_execution_manager_id: Arc::new(AtomicUsize::new(1)),
-            schedulers: Arc::new(DashMap::new()),
-            next_scheduler_id: Arc::new(AtomicUsize::new(1)),
             session_id: 0,
         }
     }
@@ -261,33 +257,18 @@ impl ExecutionManagerLivenessManagement for MockDbConnector {
 impl SchedulerRegistrationManagement for MockDbConnector {
     async fn register_scheduler(
         &self,
-        ip_address: IpAddr,
-        port: u16,
+        _ip_address: IpAddr,
+        _port: u16,
     ) -> Result<SchedulerId, DbError> {
-        self.schedulers.clear();
-        let counter = self.next_scheduler_id.fetch_add(1, Ordering::Relaxed);
-        let scheduler_id = SchedulerId::from(counter as u64);
-        self.schedulers.insert(
-            scheduler_id,
-            RegisteredScheduler {
-                id: scheduler_id,
-                ip_address,
-                port,
-            },
-        );
-        Ok(scheduler_id)
+        unreachable!("not implemented for mock connector")
     }
 
     async fn get_schedulers(&self) -> Result<Vec<RegisteredScheduler>, DbError> {
-        Ok(self
-            .schedulers
-            .iter()
-            .map(|scheduler| *scheduler.value())
-            .collect())
+        unreachable!("not implemented for mock connector")
     }
 
-    async fn is_scheduler_registered(&self, scheduler_id: SchedulerId) -> Result<bool, DbError> {
-        Ok(self.schedulers.contains_key(&scheduler_id))
+    async fn is_scheduler_registered(&self, _scheduler_id: SchedulerId) -> Result<bool, DbError> {
+        unreachable!("not implemented for mock connector")
     }
 }
 

--- a/components/spider-storage/src/state/test_utils.rs
+++ b/components/spider-storage/src/state/test_utils.rs
@@ -10,7 +10,7 @@ use dashmap::DashMap;
 use spider_core::{
     job::JobState,
     types::{
-        id::{ExecutionManagerId, JobId, ResourceGroupId, SessionId, TaskInstanceId},
+        id::{ExecutionManagerId, JobId, ResourceGroupId, SchedulerId, SessionId, TaskInstanceId},
         io::TaskOutput,
     },
 };
@@ -29,6 +29,7 @@ use crate::{
         InternalJobOrchestration,
         RecoverableJobContext,
         ResourceGroupManagement,
+        SchedulerRegistrationManagement,
         SessionManagement,
     },
     ready_queue::ReadyQueueSender,
@@ -77,6 +78,8 @@ pub struct MockDbConnector {
     pub next_resource_group_id: Arc<AtomicUsize>,
     pub execution_managers: Arc<DashMap<ExecutionManagerId, IpAddr>>,
     pub next_execution_manager_id: Arc<AtomicUsize>,
+    pub schedulers: Arc<DashMap<SchedulerId, ()>>,
+    pub next_scheduler_id: Arc<AtomicUsize>,
     pub session_id: SessionId,
 }
 
@@ -90,6 +93,8 @@ impl Default for MockDbConnector {
             next_resource_group_id: Arc::new(AtomicUsize::new(1)),
             execution_managers: Arc::new(DashMap::new()),
             next_execution_manager_id: Arc::new(AtomicUsize::new(1)),
+            schedulers: Arc::new(DashMap::new()),
+            next_scheduler_id: Arc::new(AtomicUsize::new(1)),
             session_id: 0,
         }
     }
@@ -248,6 +253,21 @@ impl ExecutionManagerLivenessManagement for MockDbConnector {
         _stale_after_sec: u64,
     ) -> Result<Vec<ExecutionManagerId>, DbError> {
         Ok(Vec::new())
+    }
+}
+
+#[async_trait::async_trait]
+impl SchedulerRegistrationManagement for MockDbConnector {
+    async fn register_scheduler(&self) -> Result<SchedulerId, DbError> {
+        self.schedulers.clear();
+        let counter = self.next_scheduler_id.fetch_add(1, Ordering::Relaxed);
+        let scheduler_id = SchedulerId::from(counter as u64);
+        self.schedulers.insert(scheduler_id, ());
+        Ok(scheduler_id)
+    }
+
+    async fn is_scheduler_registered(&self, scheduler_id: SchedulerId) -> Result<bool, DbError> {
+        Ok(self.schedulers.contains_key(&scheduler_id))
     }
 }
 

--- a/components/spider-storage/src/state/test_utils.rs
+++ b/components/spider-storage/src/state/test_utils.rs
@@ -28,6 +28,7 @@ use crate::{
         ExternalJobOrchestration,
         InternalJobOrchestration,
         RecoverableJobContext,
+        RegisteredScheduler,
         ResourceGroupManagement,
         SchedulerRegistrationManagement,
         SessionManagement,
@@ -78,7 +79,7 @@ pub struct MockDbConnector {
     pub next_resource_group_id: Arc<AtomicUsize>,
     pub execution_managers: Arc<DashMap<ExecutionManagerId, IpAddr>>,
     pub next_execution_manager_id: Arc<AtomicUsize>,
-    pub schedulers: Arc<DashMap<SchedulerId, ()>>,
+    pub schedulers: Arc<DashMap<SchedulerId, RegisteredScheduler>>,
     pub next_scheduler_id: Arc<AtomicUsize>,
     pub session_id: SessionId,
 }
@@ -258,12 +259,31 @@ impl ExecutionManagerLivenessManagement for MockDbConnector {
 
 #[async_trait::async_trait]
 impl SchedulerRegistrationManagement for MockDbConnector {
-    async fn register_scheduler(&self) -> Result<SchedulerId, DbError> {
+    async fn register_scheduler(
+        &self,
+        ip_address: IpAddr,
+        port: u16,
+    ) -> Result<SchedulerId, DbError> {
         self.schedulers.clear();
         let counter = self.next_scheduler_id.fetch_add(1, Ordering::Relaxed);
         let scheduler_id = SchedulerId::from(counter as u64);
-        self.schedulers.insert(scheduler_id, ());
+        self.schedulers.insert(
+            scheduler_id,
+            RegisteredScheduler {
+                id: scheduler_id,
+                ip_address,
+                port,
+            },
+        );
         Ok(scheduler_id)
+    }
+
+    async fn get_schedulers(&self) -> Result<Vec<RegisteredScheduler>, DbError> {
+        Ok(self
+            .schedulers
+            .iter()
+            .map(|scheduler| *scheduler.value())
+            .collect())
     }
 
     async fn is_scheduler_registered(&self, scheduler_id: SchedulerId) -> Result<bool, DbError> {

--- a/components/spider-storage/tests/mariadb_test.rs
+++ b/components/spider-storage/tests/mariadb_test.rs
@@ -6,7 +6,7 @@ use std::{
 use spider_core::{
     job::JobState,
     types::{
-        id::{ExecutionManagerId, JobId, ResourceGroupId},
+        id::{ExecutionManagerId, JobId, ResourceGroupId, SchedulerId},
         io::TaskInput,
     },
 };
@@ -19,6 +19,7 @@ use spider_storage::{
         InternalJobOrchestration,
         MariaDbStorageConnector,
         ResourceGroupManagement,
+        SchedulerRegistrationManagement,
         SessionManagement,
     },
 };
@@ -53,6 +54,19 @@ async fn register_test_em(storage: &MariaDbStorageConnector) -> ExecutionManager
         .register_execution_manager(IpAddr::V4(Ipv4Addr::LOCALHOST))
         .await
         .expect("register_execution_manager should succeed")
+}
+
+/// # Returns
+///
+/// Whether the scheduler is registered.
+async fn is_scheduler_registered(
+    storage: &MariaDbStorageConnector,
+    scheduler_id: SchedulerId,
+) -> bool {
+    storage
+        .is_scheduler_registered(scheduler_id)
+        .await
+        .expect("is_scheduler_registered should succeed")
 }
 
 #[tokio::test]
@@ -1003,6 +1017,35 @@ async fn test_get_dead_execution_managers_multiple() {
             "expected em_id {em_id:?} in dead list, got {dead:?}"
         );
     }
+}
+
+#[tokio::test]
+#[ignore = "requires MariaDB"]
+#[serial_test::file_serial]
+async fn test_register_scheduler_replaces_previous_scheduler() {
+    let storage = create_mariadb_connector().await;
+
+    let first_scheduler_id = storage
+        .register_scheduler()
+        .await
+        .expect("first register_scheduler should succeed");
+    let second_scheduler_id = storage
+        .register_scheduler()
+        .await
+        .expect("second register_scheduler should succeed");
+
+    assert_ne!(
+        first_scheduler_id, second_scheduler_id,
+        "new registration should allocate a fresh scheduler ID"
+    );
+    assert!(
+        !is_scheduler_registered(&storage, first_scheduler_id).await,
+        "old scheduler should be removed after a new registration"
+    );
+    assert!(
+        is_scheduler_registered(&storage, second_scheduler_id).await,
+        "new scheduler should remain registered"
+    );
 }
 
 #[tokio::test]

--- a/components/spider-storage/tests/mariadb_test.rs
+++ b/components/spider-storage/tests/mariadb_test.rs
@@ -34,6 +34,8 @@ const TEST_INPUT_PAYLOAD_SIZE: usize = 128;
 
 /// Number of execution managers to register in multi-EM tests.
 const TEST_NUM_EMS: usize = 3;
+const TEST_SCHEDULER_PORT: u16 = 5678;
+const TEST_UPDATED_SCHEDULER_PORT: u16 = 6789;
 
 /// Builds a task graph with a single task for DB-layer tests.
 ///
@@ -1024,15 +1026,21 @@ async fn test_get_dead_execution_managers_multiple() {
 #[serial_test::file_serial]
 async fn test_register_scheduler_replaces_previous_scheduler() {
     let storage = create_mariadb_connector().await;
+    let scheduler_ip_address = IpAddr::V4(Ipv4Addr::LOCALHOST);
+    let updated_scheduler_ip_address = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2));
 
     let first_scheduler_id = storage
-        .register_scheduler()
+        .register_scheduler(scheduler_ip_address, TEST_SCHEDULER_PORT)
         .await
         .expect("first register_scheduler should succeed");
     let second_scheduler_id = storage
-        .register_scheduler()
+        .register_scheduler(updated_scheduler_ip_address, TEST_UPDATED_SCHEDULER_PORT)
         .await
         .expect("second register_scheduler should succeed");
+    let schedulers = storage
+        .get_schedulers()
+        .await
+        .expect("get_schedulers should succeed");
 
     assert_ne!(
         first_scheduler_id, second_scheduler_id,
@@ -1046,6 +1054,14 @@ async fn test_register_scheduler_replaces_previous_scheduler() {
         is_scheduler_registered(&storage, second_scheduler_id).await,
         "new scheduler should remain registered"
     );
+    assert_eq!(
+        schedulers.len(),
+        1,
+        "only the latest scheduler should remain"
+    );
+    assert_eq!(schedulers[0].id, second_scheduler_id);
+    assert_eq!(schedulers[0].ip_address, updated_scheduler_ip_address);
+    assert_eq!(schedulers[0].port, TEST_UPDATED_SCHEDULER_PORT);
 }
 
 #[tokio::test]


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR:
- Adds scheduler table in MariaDB, and its insertion and query.
- Adds scheduler registration and get in gRPC.

> [!Note]
> We assume at any given time, there is only one scheduler. The current registration removes all previous scheduler registration.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
- [x] Adds new database tests.
- [x] GitHub workflows pass.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added scheduler registration and management support across the storage layer, including registering scheduler endpoints (IP + port), retrieving the full list of registered schedulers, and checking whether a scheduler is registered.

* **Tests**
  * Added MariaDB coverage for scheduler registration, including verifying that a new registration replaces any previously registered scheduler entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->