### PR TITLE
feat(spider-scheduler): Add registry for execution manager with liveness tracking.

### DIFF
--- a/components/spider-core/src/types/id.rs
+++ b/components/spider-core/src/types/id.rs
@@ -154,6 +154,10 @@ pub type ExecutionManagerId = Id<ExecutionManagerIdMarker>;
 pub enum SchedulerIdMarker {}
 pub type SchedulerId = Id<SchedulerIdMarker>;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TaskAssignmentIdMarker {}
+pub type TaskAssignmentId = Id<TaskAssignmentIdMarker>;
+
 pub type SessionId = u64;
 
 pub type TaskInstanceId = u64;

--- a/components/spider-scheduler/src/core.rs
+++ b/components/spider-scheduler/src/core.rs
@@ -1,12 +1,40 @@
 //! The abstract core of a Spider scheduler.
 
+use std::sync::{Arc, atomic::AtomicU64};
+
 use async_trait::async_trait;
+use spider_core::types::id::TaskAssignmentId;
 
 use crate::{
     dispatch_queue::DispatchQueueSink,
     error::SchedulerError,
     storage_client::SchedulerStorageClient,
 };
+
+/// Single-source ID issuer for creating globally unique IDs for task assignments.
+pub struct TaskAssignmentIdIssuer {
+    id: Arc<AtomicU64>,
+}
+
+impl Default for TaskAssignmentIdIssuer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TaskAssignmentIdIssuer {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            id: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    #[must_use]
+    pub fn next(&self) -> TaskAssignmentId {
+        TaskAssignmentId::from(self.id.fetch_add(1, std::sync::atomic::Ordering::Relaxed))
+    }
+}
 
 /// An abstracted core for a scheduling algorithm.
 ///
@@ -33,6 +61,8 @@ pub trait SchedulerCore: Send {
     /// * `storage_client` - The storage client used to poll the inbound queue and read state for
     ///   placement.
     /// * `sink` - The dispatch sink that assignments are written to.
+    /// * `id_issuer` - The single-source ID issuer for creating globally unique IDs for task
+    ///   assignments.
     /// * `cancellation_token` - The token to signal the scheduling loop to stop.
     ///
     /// # Errors
@@ -42,6 +72,7 @@ pub trait SchedulerCore: Send {
         self,
         storage_client: Self::StorageClient,
         sink: Self::Sink,
+        id_issuer: TaskAssignmentIdIssuer,
         cancellation_token: tokio_util::sync::CancellationToken,
     ) -> Result<(), SchedulerError>;
 }

--- a/components/spider-scheduler/src/core_impl/round_robin/implementation.rs
+++ b/components/spider-scheduler/src/core_impl/round_robin/implementation.rs
@@ -20,6 +20,7 @@ use crate::{
     SchedulerStorageClient,
     StorageClientError,
     TaskAssignment,
+    core::TaskAssignmentIdIssuer,
 };
 
 /// The configuration of the round-robin scheduler core.
@@ -160,12 +161,14 @@ impl<
         self,
         storage_client: Self::StorageClient,
         sink: Self::Sink,
+        id_issuer: TaskAssignmentIdIssuer,
         cancellation_token: CancellationToken,
     ) -> Result<(), SchedulerError> {
         RoundRobin::new(
             SessionId::default(),
             storage_client,
             sink,
+            id_issuer,
             cancellation_token,
             self.config,
         )
@@ -226,6 +229,7 @@ pub(super) struct RoundRobin<
 > {
     pub(super) sink: DispatchQueueSinkType,
     pub(super) cancellation_token: CancellationToken,
+    pub(super) id_issuer: TaskAssignmentIdIssuer,
     pub(super) config: RoundRobinConfig,
     pub(super) storage_session_id: SessionId,
 
@@ -264,6 +268,7 @@ impl<
         storage_session_id: SessionId,
         storage_client: SchedulerStorageClientType,
         sink: DispatchQueueSinkType,
+        id_issuer: TaskAssignmentIdIssuer,
         cancellation_token: CancellationToken,
         config: RoundRobinConfig,
     ) -> Self {
@@ -283,6 +288,7 @@ impl<
         Self {
             sink,
             cancellation_token,
+            id_issuer,
             config,
             storage_session_id,
             buffered_tasks,
@@ -769,6 +775,7 @@ impl<
                     };
                     self.sink
                         .enqueue(TaskAssignment {
+                            id: self.id_issuer.next(),
                             job_id,
                             resource_group_id,
                             task_id: TaskId::Cleanup,
@@ -788,6 +795,7 @@ impl<
                         };
                         self.sink
                             .enqueue(TaskAssignment {
+                                id: self.id_issuer.next(),
                                 job_id,
                                 resource_group_id,
                                 task_id: TaskId::Commit,
@@ -806,6 +814,7 @@ impl<
                     if let Some(task_id) = job_entry.dequeue() {
                         self.sink
                             .enqueue(TaskAssignment {
+                                id: self.id_issuer.next(),
                                 job_id,
                                 resource_group_id: job_entry.resource_group_id,
                                 task_id,

--- a/components/spider-scheduler/src/core_impl/round_robin/tests.rs
+++ b/components/spider-scheduler/src/core_impl/round_robin/tests.rs
@@ -27,6 +27,7 @@ use crate::{
     SchedulerStorageClient,
     StorageClientError,
     TaskAssignment,
+    core::TaskAssignmentIdIssuer,
     dispatch_queue::{DispatchQueueReader, DispatchQueueWriter, create_dispatch_queue},
 };
 
@@ -271,7 +272,15 @@ fn spawn_scheduler(
     let core = config.make_core().expect("config validation failed");
     let cancellation_token = CancellationToken::new();
     let scheduler_token = cancellation_token.clone();
-    let handle = tokio::spawn(async move { core.run(storage_client, sink, scheduler_token).await });
+    let handle = tokio::spawn(async move {
+        core.run(
+            storage_client,
+            sink,
+            TaskAssignmentIdIssuer::new(),
+            scheduler_token,
+        )
+        .await
+    });
     (handle, cancellation_token)
 }
 
@@ -468,6 +477,7 @@ fn make_scheduler(
         DEFAULT_SESSION_ID,
         storage_client,
         sink,
+        TaskAssignmentIdIssuer::new(),
         CancellationToken::new(),
         config,
     )

--- a/components/spider-scheduler/src/dispatch_queue.rs
+++ b/components/spider-scheduler/src/dispatch_queue.rs
@@ -208,7 +208,7 @@ mod tests {
 
     use anyhow::Result;
     use dashmap::{DashMap, DashSet};
-    use spider_core::types::id::{JobId, ResourceGroupId, SessionId, TaskId};
+    use spider_core::types::id::{JobId, ResourceGroupId, SessionId, TaskAssignmentId, TaskId};
     use tokio_util::task::TaskTracker;
 
     use super::*;
@@ -237,6 +237,7 @@ mod tests {
     /// A new [`TaskAssignment`] with the given `task_id` and other ID fields are auto-generated.
     fn make_assignment_with_task_id(task_id: TaskId) -> TaskAssignment {
         TaskAssignment {
+            id: TaskAssignmentId::random(),
             resource_group_id: ResourceGroupId::random(),
             job_id: JobId::random(),
             task_id,

--- a/components/spider-scheduler/src/execution_manager_registry.rs
+++ b/components/spider-scheduler/src/execution_manager_registry.rs
@@ -23,12 +23,46 @@ pub enum ExecutionManagerRegistryError {
 
     #[error("execution manager not found: {0}")]
     EmNotFound(ExecutionManagerId),
+
+    #[error("invalid config: {0}")]
+    InvalidConfig(String),
 }
 
 #[derive(Clone, Deserialize)]
 pub struct ExecutionManagerRegistryConfig {
+    /// The time, in seconds, that an execution manager is considered dead without receiving any
+    /// heartbeat.
     pub dead_em_cutoff_sec: u64,
+
+    /// The time interval, in milliseconds, between liveness checks.
     pub liveness_tracking_interval_ms: u64,
+}
+
+impl Default for ExecutionManagerRegistryConfig {
+    fn default() -> Self {
+        Self {
+            dead_em_cutoff_sec: 30,
+            liveness_tracking_interval_ms: 1000,
+        }
+    }
+}
+
+impl ExecutionManagerRegistryConfig {
+    /// Validates the configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * [`ExecutionManagerRegistryError::InvalidConfig`] if `dead_em_cutoff_sec` is 0.
+    fn validate(&self) -> Result<(), ExecutionManagerRegistryError> {
+        if self.dead_em_cutoff_sec == 0 {
+            return Err(ExecutionManagerRegistryError::InvalidConfig(
+                "dead_em_cutoff_sec must be greater than 0".to_string(),
+            ));
+        }
+        Ok(())
+    }
 }
 
 /// Execution manager registry service.
@@ -42,17 +76,23 @@ impl ExecutionManagerRegistry {
     ///
     /// # Returns
     ///
-    /// The newly created execution manager registry.
-    #[must_use]
+    /// The newly created execution manager registry on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * Forwards [`ExecutionManagerRegistryConfig::validate`]'s return values on failure.
     pub fn new(
         config: &ExecutionManagerRegistryConfig,
         cancellation_token: CancellationToken,
         reschedule_queue_sender: UnboundedSender<TaskAssignment>,
-    ) -> Self {
+    ) -> Result<Self, ExecutionManagerRegistryError> {
+        config.validate()?;
         let dead_em_cutoff = Duration::from_secs(config.dead_em_cutoff_sec);
         let liveness_tracking_interval =
             Duration::from_millis(config.liveness_tracking_interval_ms);
-        Self {
+        Ok(Self {
             inner: Arc::new(ExecutionManagerRegistryInner {
                 em_table: RwLock::new(HashMap::new()),
                 cancellation_token,
@@ -60,7 +100,7 @@ impl ExecutionManagerRegistry {
                 liveness_tracking_interval,
                 reschedule_queue_sender,
             }),
-        }
+        })
     }
 
     /// Assigns a task to an execution manager.
@@ -387,7 +427,8 @@ mod tests {
             &config,
             cancellation_token.clone(),
             reschedule_queue_sender,
-        );
+        )
+        .expect("the registry should be constructed successfully");
         (registry, reschedule_queue_receiver, cancellation_token)
     }
 

--- a/components/spider-scheduler/src/execution_manager_registry.rs
+++ b/components/spider-scheduler/src/execution_manager_registry.rs
@@ -201,7 +201,7 @@ impl ExecutionManagerRegistry {
     /// stopping once the manager is found dead or `cancellation_token` is cancelled. On stopping,
     /// it removes the manager from the registry and reschedules its outstanding task assignments.
     ///
-    /// This brackground task guarantees the following:
+    /// This background task guarantees the following:
     ///
     /// * The execution manager is inserted into the registry before this coroutine is spawned.
     /// * This coroutine is the single source of the manager's removal from the registry.
@@ -330,5 +330,373 @@ impl ExecutionManagerStateInner {
     /// Refreshes the last update time.
     fn refresh_liveness(&mut self) {
         self.last_update = Instant::now();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use spider_core::types::id::{JobId, ResourceGroupId, TaskId};
+    use tokio::{
+        sync::mpsc::{self, UnboundedReceiver},
+        time::timeout,
+    };
+    use tokio_util::task::TaskTracker;
+
+    use super::*;
+
+    /// The maximum time to wait for rescheduled assignments before failing a test.
+    const RESCHEDULE_TIMEOUT: Duration = Duration::from_secs(2);
+
+    /// The cutoff used by timeout-driven tests. One second is the smallest the seconds-granularity
+    /// config supports, so these tests run in real time on the order of a second.
+    const LIVENESS_CUTOFF_SEC: u64 = 1;
+
+    /// The tracking interval used by timeout-driven tests; short so that death is detected promptly
+    /// after the cutoff elapses.
+    const LIVENESS_INTERVAL_MS: u64 = 50;
+
+    /// A generous upper bound for waiting on a timeout-driven reschedule or removal.
+    const LIVENESS_TEST_TIMEOUT: Duration = Duration::from_secs(LIVENESS_CUTOFF_SEC * 4);
+
+    /// Builds a registry with the given liveness configuration.
+    ///
+    /// # Returns
+    ///
+    /// A tuple containing:
+    ///
+    /// * The registry.
+    /// * The receiver end of the re-schedule queue.
+    /// * The registry-level cancellation token.
+    fn build_registry(
+        dead_em_cutoff_sec: u64,
+        liveness_tracking_interval_ms: u64,
+    ) -> (
+        ExecutionManagerRegistry,
+        UnboundedReceiver<TaskAssignment>,
+        CancellationToken,
+    ) {
+        let config = ExecutionManagerRegistryConfig {
+            dead_em_cutoff_sec,
+            liveness_tracking_interval_ms,
+        };
+        let cancellation_token = CancellationToken::new();
+        let (reschedule_queue_sender, reschedule_queue_receiver) = mpsc::unbounded_channel();
+        let registry = ExecutionManagerRegistry::new(
+            &config,
+            cancellation_token.clone(),
+            reschedule_queue_sender,
+        );
+        (registry, reschedule_queue_receiver, cancellation_token)
+    }
+
+    /// Builds a registry whose background liveness tracker never fires during a test (a one-hour
+    /// cutoff with a one-minute interval), so that registration, completion, and teardown can be
+    /// driven explicitly rather than by timeouts.
+    ///
+    /// # Returns
+    ///
+    /// The same tuple as [`build_registry`].
+    fn build_test_registry() -> (
+        ExecutionManagerRegistry,
+        UnboundedReceiver<TaskAssignment>,
+        CancellationToken,
+    ) {
+        build_registry(3600, 60_000)
+    }
+
+    /// Builds a task assignment whose ID is derived from `id`; the remaining fields are irrelevant
+    /// to the registry and are randomized.
+    ///
+    /// # Returns
+    ///
+    /// The task assignment.
+    fn build_assignment(id: u64) -> TaskAssignment {
+        TaskAssignment {
+            id: TaskAssignmentId::from(id),
+            resource_group_id: ResourceGroupId::random(),
+            job_id: JobId::random(),
+            task_id: TaskId::Index(0),
+        }
+    }
+
+    /// # Returns
+    ///
+    /// Whether the given execution manager is currently registered.
+    async fn is_registered(registry: &ExecutionManagerRegistry, em_id: ExecutionManagerId) -> bool {
+        registry.inner.em_table.read().await.contains_key(&em_id)
+    }
+
+    /// # Returns
+    ///
+    /// The set of task assignment IDs recorded for the given execution manager, or `None` if it is
+    /// not registered.
+    async fn assignment_ids(
+        registry: &ExecutionManagerRegistry,
+        em_id: ExecutionManagerId,
+    ) -> Option<HashSet<TaskAssignmentId>> {
+        let ids = registry
+            .inner
+            .em_table
+            .read()
+            .await
+            .get(&em_id)?
+            .inner
+            .lock()
+            .await
+            .task_assignments
+            .keys()
+            .copied()
+            .collect();
+        Some(ids)
+    }
+
+    /// Polls until the given execution manager is no longer registered, panicking if it is still
+    /// registered after `deadline`. Used to observe a timeout-driven removal that produces no
+    /// rescheduling signal (an execution manager with no outstanding assignments).
+    async fn wait_until_unregistered(
+        registry: &ExecutionManagerRegistry,
+        em_id: ExecutionManagerId,
+        deadline: Duration,
+    ) {
+        timeout(deadline, async {
+            while is_registered(registry, em_id).await {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("the execution manager should be unregistered before the deadline");
+    }
+
+    #[tokio::test]
+    async fn assign_registers_new_execution_manager() -> anyhow::Result<()> {
+        let (registry, _reschedule_queue_receiver, _cancellation_token) = build_test_registry();
+        let em_id = ExecutionManagerId::from(1);
+        let task_assignment = build_assignment(1);
+
+        registry.assign(em_id, task_assignment).await;
+
+        assert!(is_registered(&registry, em_id).await);
+        assert_eq!(
+            assignment_ids(&registry, em_id).await,
+            Some(HashSet::from([task_assignment.id]))
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn update_heartbeat_registers_new_execution_manager() -> anyhow::Result<()> {
+        let (registry, _reschedule_queue_receiver, _cancellation_token) = build_test_registry();
+        let em_id = ExecutionManagerId::from(1);
+
+        registry.update_heartbeat(em_id).await;
+
+        assert!(is_registered(&registry, em_id).await);
+        assert_eq!(assignment_ids(&registry, em_id).await, Some(HashSet::new()));
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn assign_records_multiple_assignments() -> anyhow::Result<()> {
+        const NUM_ASSIGNMENTS: u64 = 100;
+
+        let (registry, _reschedule_queue_receiver, _cancellation_token) = build_test_registry();
+        let em_id = ExecutionManagerId::from(1);
+        let task_assignments: Vec<TaskAssignment> =
+            (0..NUM_ASSIGNMENTS).map(build_assignment).collect();
+
+        let task_tracker = TaskTracker::new();
+        for &task_assignment in &task_assignments {
+            let registry = registry.clone();
+            task_tracker.spawn(async move { registry.assign(em_id, task_assignment).await });
+        }
+        task_tracker.close();
+        task_tracker.wait().await;
+
+        let expected_ids: HashSet<TaskAssignmentId> = task_assignments
+            .iter()
+            .map(|task_assignment| task_assignment.id)
+            .collect();
+        assert_eq!(assignment_ids(&registry, em_id).await, Some(expected_ids));
+
+        for task_assignment in &task_assignments {
+            registry
+                .complete(em_id, task_assignment.id)
+                .await
+                .expect("completing a recorded assignment should succeed");
+        }
+        assert_eq!(assignment_ids(&registry, em_id).await, Some(HashSet::new()));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn mark_as_dead_reschedules_outstanding_assignments() -> anyhow::Result<()> {
+        const NUM_ASSIGNMENTS: u64 = 10;
+
+        let (registry, mut reschedule_queue_receiver, _cancellation_token) = build_test_registry();
+        let em_id = ExecutionManagerId::from(1);
+        let task_assignments: Vec<TaskAssignment> =
+            (0..NUM_ASSIGNMENTS).map(build_assignment).collect();
+
+        for &task_assignment in &task_assignments {
+            registry.assign(em_id, task_assignment).await;
+        }
+
+        registry
+            .mark_as_dead(em_id)
+            .await
+            .expect("marking a registered execution manager as dead should succeed");
+
+        // Teardown runs asynchronously after the cancellation; collect every rescheduled
+        // assignment.
+        let mut rescheduled = HashSet::new();
+        for _ in 0..NUM_ASSIGNMENTS {
+            let task_assignment = timeout(RESCHEDULE_TIMEOUT, reschedule_queue_receiver.recv())
+                .await
+                .expect("a reschedule should arrive before the timeout")
+                .expect("the reschedule queue should remain open");
+            rescheduled.insert(task_assignment.id);
+        }
+
+        let expected_ids: HashSet<TaskAssignmentId> = task_assignments
+            .iter()
+            .map(|task_assignment| task_assignment.id)
+            .collect();
+        assert_eq!(rescheduled, expected_ids);
+        assert!(!is_registered(&registry, em_id).await);
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn concurrent_assigns_racing_mark_as_dead_reschedule_every_assignment()
+    -> anyhow::Result<()> {
+        const NUM_ASSIGNMENTS: u64 = 100;
+
+        // The rescheduling timeout (`LIVENESS_TEST_TIMEOUT`) must comfortably exceed the cutoff,
+        // since the assignments that re-register the execution manager after teardown are only
+        // reclaimed once it times out.
+        let (registry, mut reschedule_queue_receiver, _cancellation_token) =
+            build_registry(LIVENESS_CUTOFF_SEC, LIVENESS_INTERVAL_MS);
+        let em_id = ExecutionManagerId::from(1);
+        let task_assignments: Vec<TaskAssignment> =
+            (0..NUM_ASSIGNMENTS).map(build_assignment).collect();
+
+        // Assign all tasks to the same execution manager concurrently, marking it dead in between.
+        // An assign that races ahead of the teardown re-registers the execution manager under a
+        // fresh tracker; that incarnation is later removed by the liveness timeout rather than by
+        // the cancellation.
+        let task_tracker = TaskTracker::new();
+        for &task_assignment in &task_assignments {
+            let registry = registry.clone();
+            task_tracker.spawn(async move { registry.assign(em_id, task_assignment).await });
+        }
+        // The mark may no-op if it observes the execution manager before the first assign registers
+        // it; either way every incarnation eventually tears down.
+        registry.mark_as_dead(em_id).await.ok();
+        task_tracker.close();
+        task_tracker.wait().await;
+
+        // Every assignment lands in exactly one incarnation, and each incarnation reschedules its
+        // assignments exactly once, so the queue ends up holding each assignment exactly once --
+        // none lost to the teardown race, none duplicated.
+        let mut rescheduled = HashSet::new();
+        for _ in 0..NUM_ASSIGNMENTS {
+            let task_assignment = timeout(LIVENESS_TEST_TIMEOUT, reschedule_queue_receiver.recv())
+                .await
+                .expect("a reschedule should arrive before the timeout")
+                .expect("the reschedule queue should remain open");
+            rescheduled.insert(task_assignment.id);
+        }
+
+        let expected_ids: HashSet<TaskAssignmentId> = task_assignments
+            .iter()
+            .map(|task_assignment| task_assignment.id)
+            .collect();
+        assert_eq!(rescheduled, expected_ids);
+
+        // Exactly `NUM_ASSIGNMENTS` were rescheduled: nothing remains once all are drained.
+        assert!(reschedule_queue_receiver.try_recv().is_err());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn idle_execution_manager_is_removed_after_cutoff() -> anyhow::Result<()> {
+        let (registry, mut reschedule_queue_receiver, _cancellation_token) =
+            build_registry(LIVENESS_CUTOFF_SEC, LIVENESS_INTERVAL_MS);
+        let em_id = ExecutionManagerId::from(1);
+        let task_assignment = build_assignment(1);
+
+        registry.assign(em_id, task_assignment).await;
+
+        // With no further heartbeats, the tracker removes the execution manager after the cutoff
+        // and reschedules its outstanding assignment.
+        let rescheduled = timeout(LIVENESS_TEST_TIMEOUT, reschedule_queue_receiver.recv())
+            .await
+            .expect("a reschedule should arrive before the timeout")
+            .expect("the reschedule queue should remain open");
+        assert_eq!(rescheduled.id, task_assignment.id);
+        assert!(!is_registered(&registry, em_id).await);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn idle_heartbeat_only_execution_manager_is_removed_after_cutoff() -> anyhow::Result<()> {
+        let (registry, mut reschedule_queue_receiver, _cancellation_token) =
+            build_registry(LIVENESS_CUTOFF_SEC, LIVENESS_INTERVAL_MS);
+        let em_id = ExecutionManagerId::from(1);
+
+        registry.update_heartbeat(em_id).await;
+        assert!(is_registered(&registry, em_id).await);
+        wait_until_unregistered(&registry, em_id, LIVENESS_TEST_TIMEOUT).await;
+        assert!(reschedule_queue_receiver.try_recv().is_err());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn heartbeats_keep_execution_manager_alive() -> anyhow::Result<()> {
+        const REFRESH_INTERVAL: Duration = Duration::from_millis(250);
+        const NUM_REFRESHES: u32 = 6;
+
+        let (registry, mut reschedule_queue_receiver, _cancellation_token) =
+            build_registry(LIVENESS_CUTOFF_SEC, LIVENESS_INTERVAL_MS);
+        let em_id = ExecutionManagerId::from(1);
+
+        for _ in 0..NUM_REFRESHES {
+            registry.update_heartbeat(em_id).await;
+            tokio::time::sleep(REFRESH_INTERVAL).await;
+            assert!(is_registered(&registry, em_id).await);
+        }
+        wait_until_unregistered(&registry, em_id, LIVENESS_TEST_TIMEOUT).await;
+        assert!(reschedule_queue_receiver.try_recv().is_err());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn assign_and_complete_keep_execution_manager_alive() -> anyhow::Result<()> {
+        const REFRESH_INTERVAL: Duration = Duration::from_millis(250);
+        const NUM_TASK_ASSIGNMENTS: u64 = 3;
+
+        let (registry, mut reschedule_queue_receiver, _cancellation_token) =
+            build_registry(LIVENESS_CUTOFF_SEC, LIVENESS_INTERVAL_MS);
+        let em_id = ExecutionManagerId::from(1);
+
+        for i in 0..NUM_TASK_ASSIGNMENTS {
+            let task_assignment = build_assignment(i);
+            registry.assign(em_id, task_assignment).await;
+            tokio::time::sleep(REFRESH_INTERVAL).await;
+            assert!(is_registered(&registry, em_id).await);
+
+            registry
+                .complete(em_id, task_assignment.id)
+                .await
+                .expect("complete should succeed");
+            tokio::time::sleep(REFRESH_INTERVAL).await;
+            assert!(is_registered(&registry, em_id).await);
+        }
+        assert!(reschedule_queue_receiver.try_recv().is_err());
+        wait_until_unregistered(&registry, em_id, LIVENESS_TEST_TIMEOUT).await;
+        assert!(reschedule_queue_receiver.try_recv().is_err());
+        Ok(())
     }
 }

--- a/components/spider-scheduler/src/execution_manager_registry.rs
+++ b/components/spider-scheduler/src/execution_manager_registry.rs
@@ -1,0 +1,334 @@
+//! Execution manager registry service.
+
+use std::{
+    collections::{HashMap, hash_map::Entry},
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use serde::Deserialize;
+use spider_core::types::id::{ExecutionManagerId, TaskAssignmentId};
+use tokio::{
+    select,
+    sync::{Mutex, RwLock, mpsc::UnboundedSender},
+};
+use tokio_util::sync::CancellationToken;
+
+use crate::TaskAssignment;
+
+#[derive(thiserror::Error, Debug)]
+pub enum ExecutionManagerRegistryError {
+    #[error("task assignment {1} not found for execution manager {0}")]
+    TaskAssignmentNotFound(ExecutionManagerId, TaskAssignmentId),
+
+    #[error("execution manager not found: {0}")]
+    EmNotFound(ExecutionManagerId),
+}
+
+#[derive(Clone, Deserialize)]
+pub struct ExecutionManagerRegistryConfig {
+    pub dead_em_cutoff_sec: u64,
+    pub liveness_tracking_interval_ms: u64,
+}
+
+/// Execution manager registry service.
+#[derive(Clone)]
+pub struct ExecutionManagerRegistry {
+    inner: Arc<ExecutionManagerRegistryInner>,
+}
+
+impl ExecutionManagerRegistry {
+    /// Factory function.
+    ///
+    /// # Returns
+    ///
+    /// The newly created execution manager registry.
+    #[must_use]
+    pub fn new(
+        config: &ExecutionManagerRegistryConfig,
+        cancellation_token: CancellationToken,
+        reschedule_queue_sender: UnboundedSender<TaskAssignment>,
+    ) -> Self {
+        let dead_em_cutoff = Duration::from_secs(config.dead_em_cutoff_sec);
+        let liveness_tracking_interval =
+            Duration::from_millis(config.liveness_tracking_interval_ms);
+        Self {
+            inner: Arc::new(ExecutionManagerRegistryInner {
+                em_table: RwLock::new(HashMap::new()),
+                cancellation_token,
+                dead_em_cutoff,
+                liveness_tracking_interval,
+                reschedule_queue_sender,
+            }),
+        }
+    }
+
+    /// Assigns a task to an execution manager.
+    ///
+    /// The execution manager will be added to the registry if it is not already present.
+    pub async fn assign(&self, em_id: ExecutionManagerId, task_assignment: TaskAssignment) {
+        self.upsert_em_state(
+            em_id,
+            |state| {
+                state
+                    .task_assignments
+                    .insert(task_assignment.id, task_assignment);
+                state.refresh_liveness();
+            },
+            || ExecutionManagerStateInner {
+                last_update: Instant::now(),
+                task_assignments: HashMap::from([(task_assignment.id, task_assignment)]),
+            },
+        )
+        .await;
+    }
+
+    /// Completes the task assignment.
+    ///
+    /// The registry is not aware of whether the assignment terminated on success or failure: this
+    /// is updated to the storage service only.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * [`ExecutionManagerRegistryError::EmNotFound`] if the execution manager is not registered
+    ///   or already dead.
+    /// * Forwards [`ExecutionManagerState::remove_assignment`]'s return values on failure.
+    pub async fn complete(
+        &self,
+        em_id: ExecutionManagerId,
+        task_assignment_id: TaskAssignmentId,
+    ) -> Result<(), ExecutionManagerRegistryError> {
+        if let Some(state) = self.inner.em_table.read().await.get(&em_id) {
+            state.remove_assignment(task_assignment_id).await
+        } else {
+            Err(ExecutionManagerRegistryError::EmNotFound(em_id))
+        }
+    }
+
+    /// Updates the heartbeat of the given execution manager.
+    ///
+    /// The execution manager will be added to the registry if this is its first heartbeat.
+    pub async fn update_heartbeat(&self, em_id: ExecutionManagerId) {
+        self.upsert_em_state(em_id, ExecutionManagerStateInner::refresh_liveness, || {
+            ExecutionManagerStateInner {
+                last_update: Instant::now(),
+                task_assignments: HashMap::new(),
+            }
+        })
+        .await;
+    }
+
+    /// Marks an execution manager as dead.
+    ///
+    /// This method does not remove the execution manager from the registry immediately. Instead,
+    /// it cancels the liveness tracker running in the background, which removes the registry after
+    /// receiving the cancellation signal.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * [`ExecutionManagerRegistryError::EmNotFound`] if the execution manager is not registered
+    ///   or already dead.
+    pub async fn mark_as_dead(
+        &self,
+        em_id: ExecutionManagerId,
+    ) -> Result<(), ExecutionManagerRegistryError> {
+        self.inner.em_table.read().await.get(&em_id).map_or(
+            Err(ExecutionManagerRegistryError::EmNotFound(em_id)),
+            |state| {
+                state.cancel_liveness_tracker();
+                Ok(())
+            },
+        )
+    }
+
+    /// Applies an inplace update to an execution manager's state, registering the execution manager
+    /// first if it is not yet present.
+    ///
+    /// The relevant table entry is held under a table-level lock for the entire duration of either
+    /// closure. This prevents the state from being concurrently torn down by
+    /// [`Self::track_liveness`]: an update can never land on a state that has already been removed
+    /// from the registry.
+    ///
+    /// # Type Parameters
+    ///
+    /// * `OnExisting` - A closure applied to the mutable state of an already-registered execution
+    ///   manager.
+    /// * `OnVacant` - A closure producing the initial state for a newly registered execution
+    ///   manager.
+    async fn upsert_em_state<
+        OnExisting: FnOnce(&mut ExecutionManagerStateInner),
+        OnVacant: FnOnce() -> ExecutionManagerStateInner,
+    >(
+        &self,
+        em_id: ExecutionManagerId,
+        on_existing: OnExisting,
+        on_vacant: OnVacant,
+    ) {
+        if let Some(state) = self.inner.em_table.read().await.get(&em_id) {
+            on_existing(&mut *state.inner.lock().await);
+            return;
+        }
+
+        // Register the execution manager under the write lock, double-checking for a concurrent
+        // insertion that may have happened after the read lock was released.
+        match self.inner.em_table.write().await.entry(em_id) {
+            Entry::Vacant(entry) => {
+                let liveness_tracker_cancellation_token =
+                    self.inner.cancellation_token.child_token();
+                let state = ExecutionManagerState {
+                    id: em_id,
+                    inner: Mutex::new(on_vacant()),
+                    liveness_tracker_cancellation_token: liveness_tracker_cancellation_token
+                        .clone(),
+                };
+                entry.insert(state);
+                tokio::spawn(
+                    self.clone()
+                        .track_liveness(em_id, liveness_tracker_cancellation_token),
+                );
+            }
+            Entry::Occupied(entry) => on_existing(&mut *entry.get().inner.lock().await),
+        }
+    }
+
+    /// A background task for tracking the liveness of an execution manager.
+    ///
+    /// On each tick it checks whether the execution manager identified by `em_id` is still alive,
+    /// stopping once the manager is found dead or `cancellation_token` is cancelled. On stopping,
+    /// it removes the manager from the registry and reschedules its outstanding task assignments.
+    ///
+    /// This brackground task guarantees the following:
+    ///
+    /// * The execution manager is inserted into the registry before this coroutine is spawned.
+    /// * This coroutine is the single source of the manager's removal from the registry.
+    async fn track_liveness(
+        self,
+        em_id: ExecutionManagerId,
+        cancellation_token: CancellationToken,
+    ) {
+        let mut tracking = tokio::time::interval(self.inner.liveness_tracking_interval);
+        loop {
+            select! {
+            () = cancellation_token.cancelled() => {
+                tracing::info!(em_id = % em_id, "Liveness tracker cancelled.");
+                break;
+            }
+            _ = tracking.tick() => {
+                    if let Some(state) = self.inner.em_table.read().await.get(&em_id) {
+                        if state.is_alive(self.inner.dead_em_cutoff).await {
+                            continue;
+                        }
+                        tracing::info!(
+                            em_id = % em_id,
+                            "Liveness tracker detects execution manager no longer alive."
+                        );
+                        break;
+                    }
+                    tracing::error!(
+                        em_id = % em_id,
+                        "Execution manager no longer exists. The liveness tracker is corrupted."
+                    );
+                    self.inner.cancellation_token.cancel();
+                    return;
+                }
+            }
+        }
+
+        let Some(state) = self.inner.em_table.write().await.remove(&em_id) else {
+            tracing::error!(
+                em_id = % em_id,
+                "Execution manager no longer exists. The liveness tracker is corrupted."
+            );
+            self.inner.cancellation_token.cancel();
+            return;
+        };
+        tracing::info!(em_id = % em_id, "Execution manager removed from the registry.");
+        for task_assignment in state.inner.lock().await.task_assignments.values() {
+            if self
+                .inner
+                .reschedule_queue_sender
+                .send(*task_assignment)
+                .is_err()
+            {
+                // The re-schedule queue would only be closed if the scheduler service is shutting
+                // down. Log the warning for observability purposes.
+                tracing::warn!(
+                    em_id = % em_id,
+                    "Reschedule queue has been closed. Task assignments from the dead EM ignored."
+                );
+                break;
+            }
+        }
+    }
+}
+
+/// Internal data structure for the execution manager registry.
+struct ExecutionManagerRegistryInner {
+    em_table: RwLock<HashMap<ExecutionManagerId, ExecutionManagerState>>,
+    cancellation_token: CancellationToken,
+    dead_em_cutoff: Duration,
+    liveness_tracking_interval: Duration,
+    reschedule_queue_sender: UnboundedSender<TaskAssignment>,
+}
+
+/// The state of an execution manager tracked by the registry.
+struct ExecutionManagerState {
+    id: ExecutionManagerId,
+    liveness_tracker_cancellation_token: CancellationToken,
+    inner: Mutex<ExecutionManagerStateInner>,
+}
+
+impl ExecutionManagerState {
+    /// Removes a task assignment from the execution manager's state.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * [`ExecutionManagerRegistryError::TaskAssignmentNotFound`] if the task assignment is not
+    ///   present in the state.
+    async fn remove_assignment(
+        &self,
+        task_assignment_id: TaskAssignmentId,
+    ) -> Result<(), ExecutionManagerRegistryError> {
+        let mut state = self.inner.lock().await;
+        if state.task_assignments.remove(&task_assignment_id).is_none() {
+            return Err(ExecutionManagerRegistryError::TaskAssignmentNotFound(
+                self.id,
+                task_assignment_id,
+            ));
+        }
+        state.refresh_liveness();
+        drop(state);
+        Ok(())
+    }
+
+    /// # Returns
+    ///
+    /// Whether the execution manager is considered alive with respect to the given cutoff.
+    async fn is_alive(&self, cutoff: Duration) -> bool {
+        self.inner.lock().await.last_update.elapsed() < cutoff
+    }
+
+    /// Cancels the liveness tracker for the execution manager.
+    fn cancel_liveness_tracker(&self) {
+        self.liveness_tracker_cancellation_token.cancel();
+    }
+}
+
+/// The mutable, mutex-guarded portion of an execution manager's state.
+struct ExecutionManagerStateInner {
+    last_update: Instant,
+    task_assignments: HashMap<TaskAssignmentId, TaskAssignment>,
+}
+
+impl ExecutionManagerStateInner {
+    /// Refreshes the last update time.
+    fn refresh_liveness(&mut self) {
+        self.last_update = Instant::now();
+    }
+}

--- a/components/spider-scheduler/src/lib.rs
+++ b/components/spider-scheduler/src/lib.rs
@@ -35,6 +35,7 @@ pub mod core;
 pub mod core_impl;
 pub mod dispatch_queue;
 pub mod error;
+pub mod execution_manager_registry;
 pub mod storage_client;
 pub mod types;
 

--- a/components/spider-scheduler/src/types.rs
+++ b/components/spider-scheduler/src/types.rs
@@ -1,6 +1,6 @@
 //! The data types the scheduler exchanges with the storage layer and execution managers.
 
-use spider_core::types::id::{JobId, ResourceGroupId, TaskId};
+use spider_core::types::id::{JobId, ResourceGroupId, TaskAssignmentId, TaskId};
 
 /// A ready task drained from the storage-owned inbound queue.
 ///
@@ -22,6 +22,9 @@ pub struct InboundEntry {
 /// A task placement decision written by the scheduler core to the dispatching queue.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TaskAssignment {
+    /// The unique ID of the task assignment.
+    pub id: TaskAssignmentId,
+
     /// The resource group that owns the job.
     pub resource_group_id: ResourceGroupId,
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR adds a scheduler-side mechanism for detecting execution manager (EM) failures and rescheduling affected tasks. This is needed when an EM fails after a task has been dispatched but before it registers the corresponding task instance with the storage service.

The scheduler now tags each task assignment with a globally unique assignment ID. This ID is unique within a single scheduler session and is reset when the scheduler restarts. On each task dispatch, the registry records which EM the task was assigned to.

The registry exposes the following public APIs:

- `assign`: Assigns a task to an EM, identified by the given EM ID. This is expected to be called after each task is dequeued from the dispatch queue.
- `complete`: Marks a task as received and completed by an EM. This is called as part of the EM-to-scheduler communication protocol so that the scheduler knows the task has been consumed, regardless of whether it succeeded or failed. The task result is uploaded to storage, which remains responsible for deciding whether rescheduling is required.
- `update_heartbeat`: Refreshes the EM heartbeat, keeping the EM alive from the scheduler’s perspective. EMs send heartbeats periodically, and the scheduler handles them through this method.
- `mark_as_dead`: Records a graceful-shutdown signal from an EM, indicating that the EM is intentionally shutting down and should no longer receive work.

For each EM, the scheduler runs a background liveness check. If an EM stops refreshing its heartbeat, it is considered dead. Any tasks that are still assigned to that EM are then returned for rescheduling.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Ensure all workflows pass.
* [x] Add unit tests to cover registry behavior.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public, per-assignment identifier so task assignments can be reliably tracked through their lifecycle.
  * Introduced an execution manager registry to track execution managers and the outstanding task assignments they own.
  * Added liveness/heartbeat monitoring with automatic cleanup and task rescheduling when managers become unavailable.
  * Updated the Round Robin scheduler to use the shared identifier issuance when creating task assignments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->