### PR TITLE
feat(spider-huntsman): Complete storage gRPC server:

### DIFF
--- a/components/spider-execution-manager/src/client/grpc/liveness.rs
+++ b/components/spider-execution-manager/src/client/grpc/liveness.rs
@@ -99,47 +99,31 @@ fn map_liveness_status(status: &tonic::Status) -> LivenessResponseError {
 ///
 /// [`storage::RegisterExecutionManagerResponse`] converted into
 /// [`Result<RegistrationResponse, LivenessResponseError>`].
-///
-/// # Errors
-///
-/// Returns an error if:
-///
-/// * [`LivenessResponseError::Transport`] if the response omits the registration payload or carries
-///   a zero session ID. Storage assigns session IDs from a database auto-increment column, so a
-///   live session is always nonzero; a zero value indicates a malformed response.
 fn register_response_to_result(
     response: storage::RegisterExecutionManagerResponse,
 ) -> Result<RegistrationResponse, LivenessResponseError> {
-    let registration = response.registration.ok_or_else(|| {
-        LivenessResponseError::Transport(
+    match response.registration {
+        Some(registration) => {
+            if registration.session_id == 0 {
+                return Err(LivenessResponseError::Transport(
+                    "register execution manager response carried a zero session id".to_owned(),
+                ));
+            }
+            Ok(RegistrationResponse {
+                em_id: ExecutionManagerId::from(registration.execution_manager_id),
+                session_id: registration.session_id,
+            })
+        }
+        None => Err(LivenessResponseError::Transport(
             "register execution manager response missing registration".to_owned(),
-        )
-    })?;
-    if registration.session_id == 0 {
-        return Err(LivenessResponseError::Transport(
-            "register execution manager response carried a zero session id".to_owned(),
-        ));
+        )),
     }
-    Ok(RegistrationResponse {
-        em_id: ExecutionManagerId::from(registration.execution_manager_id),
-        session_id: registration.session_id,
-    })
 }
 
-/// Converts an [`storage::UpdateExecutionManagerHeartbeatResponse`] into the storage session ID
-/// it carries.
-///
 /// # Returns
 ///
-/// The session ID carried by `response` on success.
-///
-/// # Errors
-///
-/// Returns an error if:
-///
-/// * [`LivenessResponseError::Transport`] if `response` carries a zero session ID. Storage assigns
-///   session IDs from a database auto-increment column, so a live session is always nonzero; a zero
-///   value indicates a malformed response.
+/// [`storage::UpdateExecutionManagerHeartbeatResponse`] converted into
+/// [`Result<SessionId, LivenessResponseError>`].
 fn heartbeat_response_to_result(
     response: storage::UpdateExecutionManagerHeartbeatResponse,
 ) -> Result<SessionId, LivenessResponseError> {
@@ -226,7 +210,7 @@ mod tests {
         };
 
         let session_id = heartbeat_response_to_result(response)
-            .expect("heartbeat response with a nonzero session id should convert");
+            .expect("heartbeat response conversion should succeed");
 
         assert_eq!(session_id, SESSION_ID);
     }

--- a/components/spider-execution-manager/src/client/grpc/liveness.rs
+++ b/components/spider-execution-manager/src/client/grpc/liveness.rs
@@ -104,7 +104,9 @@ fn map_liveness_status(status: &tonic::Status) -> LivenessResponseError {
 ///
 /// Returns an error if:
 ///
-/// * [`LivenessResponseError::Transport`] if the response omits the registration payload.
+/// * [`LivenessResponseError::Transport`] if the response omits the registration payload or carries
+///   a zero session ID. Storage assigns session IDs from a database auto-increment column, so a
+///   live session is always nonzero; a zero value indicates a malformed response.
 fn register_response_to_result(
     response: storage::RegisterExecutionManagerResponse,
 ) -> Result<RegistrationResponse, LivenessResponseError> {
@@ -113,6 +115,11 @@ fn register_response_to_result(
             "register execution manager response missing registration".to_owned(),
         )
     })?;
+    if registration.session_id == 0 {
+        return Err(LivenessResponseError::Transport(
+            "register execution manager response carried a zero session id".to_owned(),
+        ));
+    }
     Ok(RegistrationResponse {
         em_id: ExecutionManagerId::from(registration.execution_manager_id),
         session_id: registration.session_id,
@@ -188,6 +195,21 @@ mod tests {
     #[test]
     fn register_response_to_result_rejects_missing_registration() {
         let response = storage::RegisterExecutionManagerResponse { registration: None };
+
+        assert!(matches!(
+            register_response_to_result(response),
+            Err(LivenessResponseError::Transport(_))
+        ));
+    }
+
+    #[test]
+    fn register_response_to_result_rejects_zero_session_id() {
+        let response = storage::RegisterExecutionManagerResponse {
+            registration: Some(storage::ExecutionManagerRegistration {
+                execution_manager_id: 5,
+                session_id: 0,
+            }),
+        };
 
         assert!(matches!(
             register_response_to_result(response),

--- a/components/spider-execution-manager/src/client/grpc/liveness.rs
+++ b/components/spider-execution-manager/src/client/grpc/liveness.rs
@@ -6,12 +6,12 @@ use async_trait::async_trait;
 use spider_core::types::id::{ExecutionManagerId, SessionId};
 use spider_proto_rust::storage::{
     self,
-    execution_manager_liveness_error,
     execution_manager_liveness_service_client::ExecutionManagerLivenessServiceClient,
-    register_execution_manager_response,
-    update_execution_manager_heartbeat_response,
 };
-use tonic::transport::{Channel, Endpoint};
+use tonic::{
+    Code,
+    transport::{Channel, Endpoint},
+};
 
 use crate::client::liveness::{LivenessClient, LivenessResponseError, RegistrationResponse};
 
@@ -52,7 +52,7 @@ impl LivenessClient for GrpcLivenessClient {
             .clone()
             .register_execution_manager(request)
             .await
-            .map_err(to_transport_error)?
+            .map_err(|status| map_liveness_status(&status))?
             .into_inner();
 
         register_response_to_result(response)
@@ -70,28 +70,28 @@ impl LivenessClient for GrpcLivenessClient {
             .clone()
             .update_execution_manager_heartbeat(request)
             .await
-            .map_err(to_transport_error)?
+            .map_err(|status| map_liveness_status(&status))?
             .into_inner();
 
-        heartbeat_response_to_result(response)
+        Ok(heartbeat_response_to_result(response))
     }
 }
 
-impl From<storage::ExecutionManagerLivenessError> for LivenessResponseError {
-    fn from(error: storage::ExecutionManagerLivenessError) -> Self {
-        match execution_manager_liveness_error::ErrCode::try_from(error.err_code) {
-            Ok(execution_manager_liveness_error::ErrCode::MarkedDead) => Self::MarkedDead,
-            Ok(execution_manager_liveness_error::ErrCode::InvalidInput) => {
-                Self::IllegalId(error.message)
-            }
-            Ok(
-                execution_manager_liveness_error::ErrCode::Server
-                | execution_manager_liveness_error::ErrCode::Unspecified,
-            ) => Self::Transport(error.message),
-            Err(error) => Self::Transport(format!(
-                "unknown execution manager liveness error kind: {error}"
-            )),
-        }
+/// Maps a [`tonic::Status`] returned by an execution-manager-liveness RPC into a
+/// [`LivenessResponseError`].
+///
+/// # Returns
+///
+/// * [`LivenessResponseError::MarkedDead`] when storage has already reaped the execution manager,
+///   signalled by `FAILED_PRECONDITION`.
+/// * [`LivenessResponseError::IllegalId`] when storage rejects the execution manager id, signalled
+///   by `INVALID_ARGUMENT`.
+/// * [`LivenessResponseError::Transport`] for any other failure.
+fn map_liveness_status(status: &tonic::Status) -> LivenessResponseError {
+    match status.code() {
+        Code::FailedPrecondition => LivenessResponseError::MarkedDead,
+        Code::InvalidArgument => LivenessResponseError::IllegalId(status.message().to_owned()),
+        _ => LivenessResponseError::Transport(status.message().to_owned()),
     }
 }
 
@@ -99,41 +99,34 @@ impl From<storage::ExecutionManagerLivenessError> for LivenessResponseError {
 ///
 /// [`storage::RegisterExecutionManagerResponse`] converted into
 /// [`Result<RegistrationResponse, LivenessResponseError>`].
+///
+/// # Errors
+///
+/// Returns an error if:
+///
+/// * [`LivenessResponseError::Transport`] if the response omits the registration payload.
 fn register_response_to_result(
     response: storage::RegisterExecutionManagerResponse,
 ) -> Result<RegistrationResponse, LivenessResponseError> {
-    match response.result {
-        Some(register_execution_manager_response::Result::Registration(registration)) => {
-            Ok(RegistrationResponse {
-                em_id: ExecutionManagerId::from(registration.execution_manager_id),
-                session_id: registration.session_id,
-            })
-        }
-        Some(register_execution_manager_response::Result::Error(error)) => Err(error.into()),
-        None => Err(LivenessResponseError::Transport(
-            "register execution manager response missing result".to_owned(),
-        )),
-    }
+    let registration = response.registration.ok_or_else(|| {
+        LivenessResponseError::Transport(
+            "register execution manager response missing registration".to_owned(),
+        )
+    })?;
+    Ok(RegistrationResponse {
+        em_id: ExecutionManagerId::from(registration.execution_manager_id),
+        session_id: registration.session_id,
+    })
 }
 
 /// # Returns
 ///
-/// [`storage::UpdateExecutionManagerHeartbeatResponse`] converted into
-/// [`Result<SessionId, LivenessResponseError>`].
-fn heartbeat_response_to_result(
+/// The storage session ID carried by
+/// [`storage::UpdateExecutionManagerHeartbeatResponse`].
+const fn heartbeat_response_to_result(
     response: storage::UpdateExecutionManagerHeartbeatResponse,
-) -> Result<SessionId, LivenessResponseError> {
-    match response.result {
-        Some(update_execution_manager_heartbeat_response::Result::SessionId(session_id)) => {
-            Ok(session_id)
-        }
-        Some(update_execution_manager_heartbeat_response::Result::Error(error)) => {
-            Err(error.into())
-        }
-        None => Err(LivenessResponseError::Transport(
-            "update execution manager heartbeat response missing result".to_owned(),
-        )),
-    }
+) -> SessionId {
+    response.session_id
 }
 
 /// Converts a displayable transport-layer error into [`LivenessResponseError::Transport`].
@@ -158,12 +151,10 @@ mod tests {
         const EM_ID: ExecutionManagerId = ExecutionManagerId::from(5);
 
         let response = storage::RegisterExecutionManagerResponse {
-            result: Some(register_execution_manager_response::Result::Registration(
-                storage::ExecutionManagerRegistration {
-                    execution_manager_id: EM_ID.get(),
-                    session_id: SESSION_ID,
-                },
-            )),
+            registration: Some(storage::ExecutionManagerRegistration {
+                execution_manager_id: EM_ID.get(),
+                session_id: SESSION_ID,
+            }),
         };
 
         let registration = register_response_to_result(response)
@@ -179,35 +170,56 @@ mod tests {
     }
 
     #[test]
+    fn register_response_to_result_rejects_missing_registration() {
+        let response = storage::RegisterExecutionManagerResponse { registration: None };
+
+        assert!(matches!(
+            register_response_to_result(response),
+            Err(LivenessResponseError::Transport(_))
+        ));
+    }
+
+    #[test]
     fn heartbeat_response_to_result_returns_session_id() {
         const SESSION_ID: SessionId = 9;
 
         let response = storage::UpdateExecutionManagerHeartbeatResponse {
-            result: Some(
-                update_execution_manager_heartbeat_response::Result::SessionId(SESSION_ID),
-            ),
+            session_id: SESSION_ID,
         };
 
-        let session_id = heartbeat_response_to_result(response)
-            .expect("heartbeat response conversion should succeed");
+        let session_id = heartbeat_response_to_result(response);
 
         assert_eq!(session_id, SESSION_ID);
     }
 
     #[test]
-    fn liveness_storage_error_maps_invalid_input_to_illegal_id() {
+    fn map_liveness_status_maps_failed_precondition_to_marked_dead() {
+        let status = tonic::Status::failed_precondition("already dead");
+
+        assert!(matches!(
+            map_liveness_status(&status),
+            LivenessResponseError::MarkedDead
+        ));
+    }
+
+    #[test]
+    fn map_liveness_status_maps_invalid_argument_to_illegal_id() {
         const ERROR_MSG: &str = "bad em id";
+        let status = tonic::Status::invalid_argument(ERROR_MSG);
 
-        let error = storage::ExecutionManagerLivenessError {
-            err_code: execution_manager_liveness_error::ErrCode::InvalidInput.into(),
-            message: ERROR_MSG.to_owned(),
-        };
-
-        match LivenessResponseError::from(error) {
-            LivenessResponseError::IllegalId(message) => {
-                assert_eq!(message, ERROR_MSG);
-            }
-            error => panic!("unexpected liveness response error: {error:?}"),
+        match map_liveness_status(&status) {
+            LivenessResponseError::IllegalId(message) => assert_eq!(message, ERROR_MSG),
+            error => panic!("unexpected liveness status mapping: {error:?}"),
         }
+    }
+
+    #[test]
+    fn map_liveness_status_maps_other_codes_to_transport() {
+        let status = tonic::Status::internal("boom");
+
+        assert!(matches!(
+            map_liveness_status(&status),
+            LivenessResponseError::Transport(_)
+        ));
     }
 }

--- a/components/spider-execution-manager/src/client/grpc/liveness.rs
+++ b/components/spider-execution-manager/src/client/grpc/liveness.rs
@@ -73,7 +73,7 @@ impl LivenessClient for GrpcLivenessClient {
             .map_err(|status| map_liveness_status(&status))?
             .into_inner();
 
-        Ok(heartbeat_response_to_result(response))
+        heartbeat_response_to_result(response)
     }
 }
 
@@ -119,14 +119,30 @@ fn register_response_to_result(
     })
 }
 
+/// Converts an [`storage::UpdateExecutionManagerHeartbeatResponse`] into the storage session ID
+/// it carries.
+///
 /// # Returns
 ///
-/// The storage session ID carried by
-/// [`storage::UpdateExecutionManagerHeartbeatResponse`].
-const fn heartbeat_response_to_result(
+/// The session ID carried by `response` on success.
+///
+/// # Errors
+///
+/// Returns an error if:
+///
+/// * [`LivenessResponseError::Transport`] if `response` carries a zero session ID. Storage assigns
+///   session IDs from a database auto-increment column, so a live session is always nonzero; a zero
+///   value indicates a malformed response.
+fn heartbeat_response_to_result(
     response: storage::UpdateExecutionManagerHeartbeatResponse,
-) -> SessionId {
-    response.session_id
+) -> Result<SessionId, LivenessResponseError> {
+    let session_id = response.session_id;
+    if session_id == 0 {
+        return Err(LivenessResponseError::Transport(
+            "update execution manager heartbeat response carried a zero session id".to_owned(),
+        ));
+    }
+    Ok(session_id)
 }
 
 /// Converts a displayable transport-layer error into [`LivenessResponseError::Transport`].
@@ -187,9 +203,20 @@ mod tests {
             session_id: SESSION_ID,
         };
 
-        let session_id = heartbeat_response_to_result(response);
+        let session_id = heartbeat_response_to_result(response)
+            .expect("heartbeat response with a nonzero session id should convert");
 
         assert_eq!(session_id, SESSION_ID);
+    }
+
+    #[test]
+    fn heartbeat_response_to_result_rejects_zero_session_id() {
+        let response = storage::UpdateExecutionManagerHeartbeatResponse { session_id: 0 };
+
+        assert!(matches!(
+            heartbeat_response_to_result(response),
+            Err(LivenessResponseError::Transport(_))
+        ));
     }
 
     #[test]

--- a/components/spider-execution-manager/src/client/grpc/storage.rs
+++ b/components/spider-execution-manager/src/client/grpc/storage.rs
@@ -137,12 +137,14 @@ impl StorageClient for GrpcStorageClient {
 ///
 /// * [`StorageResponseError::StaleSession`] for `UNAVAILABLE`.
 /// * [`StorageResponseError::CacheStale`] for `FAILED_PRECONDITION`.
+/// * [`StorageResponseError::JobGone`] for `NOT_FOUND`.
 /// * [`StorageResponseError::InvalidInput`] for `INVALID_ARGUMENT`.
 /// * [`StorageResponseError::Server`] for any other code.
 fn status_to_error(status: &Status) -> StorageResponseError {
     match status.code() {
         Code::Unavailable => StorageResponseError::StaleSession(status.message().to_owned()),
         Code::FailedPrecondition => StorageResponseError::CacheStale(status.message().to_owned()),
+        Code::NotFound => StorageResponseError::JobGone(status.message().to_owned()),
         Code::InvalidArgument => StorageResponseError::InvalidInput(status.message().to_owned()),
         _ => StorageResponseError::Server(status.message().to_owned()),
     }
@@ -173,6 +175,16 @@ mod tests {
     fn status_maps_invalid_argument_to_invalid_input() {
         match status_to_error(&Status::invalid_argument("bad task id")) {
             StorageResponseError::InvalidInput(message) => assert!(message.contains("bad task id")),
+            error => panic!("unexpected error: {error:?}"),
+        }
+    }
+
+    #[test]
+    fn status_maps_not_found_to_job_gone() {
+        match status_to_error(&Status::not_found("job 7 is gone")) {
+            StorageResponseError::JobGone(message) => {
+                assert!(message.contains("job 7 is gone"), "message: {message}");
+            }
             error => panic!("unexpected error: {error:?}"),
         }
     }

--- a/components/spider-execution-manager/src/client/storage.rs
+++ b/components/spider-execution-manager/src/client/storage.rs
@@ -99,6 +99,7 @@ pub trait StorageClient: Send + Sync {
     /// * [`StorageResponseError::StaleSession`] if `session_id` no longer matches storage's current
     ///   session.
     /// * [`StorageResponseError::CacheStale`] if storage's job cache rejected the report.
+    /// * [`StorageResponseError::JobGone`] if the target job no longer exists in storage.
     /// * [`StorageResponseError::Transport`] if the connection was lost or timed out.
     /// * [`StorageResponseError::Server`] if storage returned an otherwise-uncategorized error.
     /// * [`StorageResponseError::InvalidInput`] if `serialized_outputs` is `Some` for a commit or
@@ -131,6 +132,7 @@ pub trait StorageClient: Send + Sync {
     /// * [`StorageResponseError::StaleSession`] if `session_id` no longer matches storage's current
     ///   session.
     /// * [`StorageResponseError::CacheStale`] if storage's job cache rejected the report.
+    /// * [`StorageResponseError::JobGone`] if the target job no longer exists in storage.
     /// * [`StorageResponseError::Transport`] if the connection was lost or timed out.
     /// * [`StorageResponseError::Server`] if storage returned an otherwise-uncategorized error.
     async fn report_task_failure(

--- a/components/spider-execution-manager/src/client/storage.rs
+++ b/components/spider-execution-manager/src/client/storage.rs
@@ -25,6 +25,12 @@ pub enum StorageResponseError {
     #[error("cache stale: {0}")]
     CacheStale(String),
 
+    /// The target job no longer exists in storage (e.g. its resource group was deleted). The
+    /// operation is a benign no-op: callers should drop the associated task assignment and
+    /// continue, not retry or bail out.
+    #[error("job gone: {0}")]
+    JobGone(String),
+
     /// Connection lost, request timeout, or wire-format serialization failure. Callers may back off
     /// and retry.
     #[error("transport error: {0}")]
@@ -63,6 +69,7 @@ pub trait StorageClient: Send + Sync {
     /// * [`StorageResponseError::StaleSession`] if `session_id` no longer matches storage's current
     ///   session.
     /// * [`StorageResponseError::CacheStale`] if storage's job cache rejected the registration.
+    /// * [`StorageResponseError::JobGone`] if the target job no longer exists in storage.
     /// * [`StorageResponseError::Transport`] if the connection was lost or timed out.
     /// * [`StorageResponseError::Server`] if storage returned an otherwise-uncategorized error.
     async fn register_task_instance(

--- a/components/spider-execution-manager/src/runtime.rs
+++ b/components/spider-execution-manager/src/runtime.rs
@@ -569,6 +569,9 @@ impl Report {
 /// by [`Runtime::main_loop`] so reporting overlaps with the next round of task dispatching; errors
 /// are logged rather than propagated.
 ///
+/// A [`StorageResponseError::JobGone`] (the target job's resource group was deleted mid-flight) is
+/// a benign no-op logged at info level; all other errors are logged at error level.
+///
 /// # Type Parameters
 ///
 /// * `StorageClientType` - Concrete [`StorageClient`] the report is sent through.
@@ -578,15 +581,24 @@ async fn report_outcome<StorageClientType: StorageClient + 'static>(
     outcome: Outcome,
 ) {
     let report = Report::from_outcome(outcome, target);
-    let _ = report
-        .send(&storage_client, target)
-        .await
-        .inspect_err(|err| {
-            tracing::error!(
-                err = ? err,
-                job_id = ? target.job,
-                task_id = ? target.task,
-                "Failed to report task outcome to storage. Dropping the report."
-            );
-        });
+    if let Err(err) = report.send(&storage_client, target).await {
+        match &err {
+            StorageResponseError::JobGone(_) => {
+                tracing::info!(
+                    err = % err,
+                    job_id = ? target.job,
+                    task_id = ? target.task,
+                    "Storage reports the target job is gone. Dropping the outcome report."
+                );
+            }
+            _ => {
+                tracing::error!(
+                    err = ? err,
+                    job_id = ? target.job,
+                    task_id = ? target.task,
+                    "Failed to report task outcome to storage. Dropping the report."
+                );
+            }
+        }
+    }
 }

--- a/components/spider-execution-manager/src/runtime.rs
+++ b/components/spider-execution-manager/src/runtime.rs
@@ -369,6 +369,8 @@ impl<
     /// * `Ok(None)` if:
     ///   * The assignment is stale: either from a stale cache session or the task has already in a
     ///     terminal state.
+    ///   * The target job is gone (e.g. its resource group was deleted), so the assignment is
+    ///     dropped as a benign no-op.
     ///   * The runtime is cancelled.
     ///
     /// # Errors
@@ -416,6 +418,16 @@ impl<
                         job_id = ? response.task_assignment.job_id,
                         task_id = ? response.task_assignment.task_id,
                         "Storage rejected task registration. Dropping the assignment."
+                    );
+                    self.mark_consume(&response);
+                    Ok(None)
+                }
+                StorageResponseError::JobGone(_) => {
+                    tracing::info!(
+                        err = % err,
+                        job_id = ? response.task_assignment.job_id,
+                        task_id = ? response.task_assignment.task_id,
+                        "Storage reports the target job is gone. Dropping the assignment."
                     );
                     self.mark_consume(&response);
                     Ok(None)

--- a/components/spider-proto-rust/src/error.rs
+++ b/components/spider-proto-rust/src/error.rs
@@ -22,12 +22,4 @@ pub enum Error {
     /// A protobuf [`crate::storage::TimeoutPolicy`] was missing.
     #[error("timeout policy is missing")]
     TimeoutPolicyMissing,
-
-    /// A protobuf IP address string could not be parsed.
-    #[error("invalid IP address: {0}")]
-    IpAddressInvalid(String),
-
-    /// A protobuf port could not be represented as a [`u16`].
-    #[error("port does not fit in `u16`: {0}")]
-    PortOutOfRange(u32),
 }

--- a/components/spider-proto-rust/src/error.rs
+++ b/components/spider-proto-rust/src/error.rs
@@ -22,4 +22,12 @@ pub enum Error {
     /// A protobuf [`crate::storage::TimeoutPolicy`] was missing.
     #[error("timeout policy is missing")]
     TimeoutPolicyMissing,
+
+    /// A protobuf IP address string could not be parsed.
+    #[error("invalid IP address: {0}")]
+    IpAddressInvalid(String),
+
+    /// A protobuf port could not be represented as a [`u16`].
+    #[error("port does not fit in `u16`: {0}")]
+    PortOutOfRange(u32),
 }

--- a/components/spider-proto-rust/src/generated/storage.rs
+++ b/components/spider-proto-rust/src/generated/storage.rs
@@ -76,6 +76,25 @@ pub struct ReadyTask {
     #[prost(message, optional, tag = "3")]
     pub task_id: ::core::option::Option<TaskId>,
 }
+/// Request to re-enqueue the ready tasks of every cached job. Carries no parameters because the
+/// operation applies to the whole cache.
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct ResendReadyTasksRequest {}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ResendReadyTasksResponse {
+    #[prost(oneof = "resend_ready_tasks_response::Result", tags = "1, 2")]
+    pub result: ::core::option::Option<resend_ready_tasks_response::Result>,
+}
+/// Nested message and enum types in `ResendReadyTasksResponse`.
+pub mod resend_ready_tasks_response {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Result {
+        #[prost(message, tag = "1")]
+        Ok(super::Void),
+        #[prost(message, tag = "2")]
+        Error(super::InboundQueueResponseError),
+    }
+}
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct RegisterTaskInstanceRequest {
     #[prost(uint64, tag = "1")]
@@ -178,6 +197,15 @@ pub struct VerifyResourceGroupRequest {
     #[prost(bytes = "vec", tag = "2")]
     pub password: ::prost::alloc::vec::Vec<u8>,
     #[prost(uint64, tag = "3")]
+    pub session_id: u64,
+}
+/// Request to delete a resource group (and, transitively, all of its jobs). Carries the caller's
+/// storage session so the server can reject stale requests.
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct ResourceGroupIdRequest {
+    #[prost(uint64, tag = "1")]
+    pub resource_group_id: u64,
+    #[prost(uint64, tag = "2")]
     pub session_id: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1183,6 +1211,32 @@ pub mod inbound_queue_service_client {
                 );
             self.inner.unary(req, path, codec).await
         }
+        pub async fn resend_ready_tasks(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ResendReadyTasksRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::ResendReadyTasksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/storage.InboundQueueService/ResendReadyTasks",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("storage.InboundQueueService", "ResendReadyTasks"),
+                );
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated client implementations.
@@ -1332,6 +1386,35 @@ pub mod resource_group_management_service_client {
                     GrpcMethod::new(
                         "storage.ResourceGroupManagementService",
                         "VerifyResourceGroup",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn delete_resource_group(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ResourceGroupIdRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::ResourceGroupOperationResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/storage.ResourceGroupManagementService/DeleteResourceGroup",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "storage.ResourceGroupManagementService",
+                        "DeleteResourceGroup",
                     ),
                 );
             self.inner.unary(req, path, codec).await
@@ -2561,6 +2644,13 @@ pub mod inbound_queue_service_server {
             tonic::Response<super::PollReadyTasksResponse>,
             tonic::Status,
         >;
+        async fn resend_ready_tasks(
+            &self,
+            request: tonic::Request<super::ResendReadyTasksRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::ResendReadyTasksResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct InboundQueueServiceServer<T> {
@@ -2785,6 +2875,55 @@ pub mod inbound_queue_service_server {
                     };
                     Box::pin(fut)
                 }
+                "/storage.InboundQueueService/ResendReadyTasks" => {
+                    #[allow(non_camel_case_types)]
+                    struct ResendReadyTasksSvc<T: InboundQueueService>(pub Arc<T>);
+                    impl<
+                        T: InboundQueueService,
+                    > tonic::server::UnaryService<super::ResendReadyTasksRequest>
+                    for ResendReadyTasksSvc<T> {
+                        type Response = super::ResendReadyTasksResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::ResendReadyTasksRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as InboundQueueService>::resend_ready_tasks(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = ResendReadyTasksSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
                 _ => {
                     Box::pin(async move {
                         let mut response = http::Response::new(empty_body());
@@ -2846,6 +2985,13 @@ pub mod resource_group_management_service_server {
         async fn verify_resource_group(
             &self,
             request: tonic::Request<super::VerifyResourceGroupRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::ResourceGroupOperationResponse>,
+            tonic::Status,
+        >;
+        async fn delete_resource_group(
+            &self,
+            request: tonic::Request<super::ResourceGroupIdRequest>,
         ) -> std::result::Result<
             tonic::Response<super::ResourceGroupOperationResponse>,
             tonic::Status,
@@ -3015,6 +3161,57 @@ pub mod resource_group_management_service_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = VerifyResourceGroupSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/storage.ResourceGroupManagementService/DeleteResourceGroup" => {
+                    #[allow(non_camel_case_types)]
+                    struct DeleteResourceGroupSvc<T: ResourceGroupManagementService>(
+                        pub Arc<T>,
+                    );
+                    impl<
+                        T: ResourceGroupManagementService,
+                    > tonic::server::UnaryService<super::ResourceGroupIdRequest>
+                    for DeleteResourceGroupSvc<T> {
+                        type Response = super::ResourceGroupOperationResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::ResourceGroupIdRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as ResourceGroupManagementService>::delete_resource_group(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = DeleteResourceGroupSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/components/spider-proto-rust/src/generated/storage.rs
+++ b/components/spider-proto-rust/src/generated/storage.rs
@@ -47,18 +47,8 @@ pub struct PollReadyTasksRequest {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PollReadyTasksResponse {
-    #[prost(oneof = "poll_ready_tasks_response::Result", tags = "1, 2")]
-    pub result: ::core::option::Option<poll_ready_tasks_response::Result>,
-}
-/// Nested message and enum types in `PollReadyTasksResponse`.
-pub mod poll_ready_tasks_response {
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum Result {
-        #[prost(message, tag = "1")]
-        Tasks(super::ReadyTasks),
-        #[prost(message, tag = "2")]
-        Error(super::InboundQueueResponseError),
-    }
+    #[prost(message, optional, tag = "1")]
+    pub tasks: ::core::option::Option<ReadyTasks>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ReadyTasks {
@@ -80,21 +70,8 @@ pub struct ReadyTask {
 /// operation applies to the whole cache.
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct ResendReadyTasksRequest {}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ResendReadyTasksResponse {
-    #[prost(oneof = "resend_ready_tasks_response::Result", tags = "1, 2")]
-    pub result: ::core::option::Option<resend_ready_tasks_response::Result>,
-}
-/// Nested message and enum types in `ResendReadyTasksResponse`.
-pub mod resend_ready_tasks_response {
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum Result {
-        #[prost(message, tag = "1")]
-        Ok(super::Void),
-        #[prost(message, tag = "2")]
-        Error(super::InboundQueueResponseError),
-    }
-}
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct ResendReadyTasksResponse {}
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct RegisterTaskInstanceRequest {
     #[prost(uint64, tag = "1")]
@@ -172,23 +149,11 @@ pub struct AddResourceGroupRequest {
     pub external_resource_group_id: ::prost::alloc::string::String,
     #[prost(bytes = "vec", tag = "2")]
     pub password: ::prost::alloc::vec::Vec<u8>,
-    #[prost(uint64, tag = "3")]
-    pub session_id: u64,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct ResourceGroupIdResponse {
-    #[prost(oneof = "resource_group_id_response::Result", tags = "1, 2")]
-    pub result: ::core::option::Option<resource_group_id_response::Result>,
-}
-/// Nested message and enum types in `ResourceGroupIdResponse`.
-pub mod resource_group_id_response {
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum Result {
-        #[prost(uint64, tag = "1")]
-        ResourceGroupId(u64),
-        #[prost(message, tag = "2")]
-        Error(super::ResourceGroupManagementError),
-    }
+    #[prost(uint64, tag = "1")]
+    pub resource_group_id: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VerifyResourceGroupRequest {
@@ -196,17 +161,12 @@ pub struct VerifyResourceGroupRequest {
     pub resource_group_id: u64,
     #[prost(bytes = "vec", tag = "2")]
     pub password: ::prost::alloc::vec::Vec<u8>,
-    #[prost(uint64, tag = "3")]
-    pub session_id: u64,
 }
-/// Request to delete a resource group (and, transitively, all of its jobs). Carries the caller's
-/// storage session so the server can reject stale requests.
+/// Request to delete a resource group (and, transitively, all of its jobs).
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct ResourceGroupIdRequest {
     #[prost(uint64, tag = "1")]
     pub resource_group_id: u64,
-    #[prost(uint64, tag = "2")]
-    pub session_id: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RegisterExecutionManagerRequest {
@@ -225,40 +185,15 @@ pub struct ExecutionManagerRegistration {
     #[prost(uint64, tag = "2")]
     pub session_id: u64,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct RegisterExecutionManagerResponse {
-    #[prost(oneof = "register_execution_manager_response::Result", tags = "1, 2")]
-    pub result: ::core::option::Option<register_execution_manager_response::Result>,
+    #[prost(message, optional, tag = "1")]
+    pub registration: ::core::option::Option<ExecutionManagerRegistration>,
 }
-/// Nested message and enum types in `RegisterExecutionManagerResponse`.
-pub mod register_execution_manager_response {
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum Result {
-        #[prost(message, tag = "1")]
-        Registration(super::ExecutionManagerRegistration),
-        #[prost(message, tag = "2")]
-        Error(super::ExecutionManagerLivenessError),
-    }
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct UpdateExecutionManagerHeartbeatResponse {
-    #[prost(
-        oneof = "update_execution_manager_heartbeat_response::Result",
-        tags = "1, 2"
-    )]
-    pub result: ::core::option::Option<
-        update_execution_manager_heartbeat_response::Result,
-    >,
-}
-/// Nested message and enum types in `UpdateExecutionManagerHeartbeatResponse`.
-pub mod update_execution_manager_heartbeat_response {
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum Result {
-        #[prost(uint64, tag = "1")]
-        SessionId(u64),
-        #[prost(message, tag = "2")]
-        Error(super::ExecutionManagerLivenessError),
-    }
+    #[prost(uint64, tag = "1")]
+    pub session_id: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RegisterSchedulerRequest {
@@ -274,20 +209,10 @@ pub struct SchedulerRegistration {
     #[prost(uint64, tag = "2")]
     pub session_id: u64,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct RegisterSchedulerResponse {
-    #[prost(oneof = "register_scheduler_response::Result", tags = "1, 2")]
-    pub result: ::core::option::Option<register_scheduler_response::Result>,
-}
-/// Nested message and enum types in `RegisterSchedulerResponse`.
-pub mod register_scheduler_response {
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum Result {
-        #[prost(message, tag = "1")]
-        Registration(super::SchedulerRegistration),
-        #[prost(message, tag = "2")]
-        Error(super::SchedulerRegistrationError),
-    }
+    #[prost(message, optional, tag = "1")]
+    pub registration: ::core::option::Option<SchedulerRegistration>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Scheduler {
@@ -305,18 +230,8 @@ pub struct SchedulerRegistrations {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetSchedulersResponse {
-    #[prost(oneof = "get_schedulers_response::Result", tags = "1, 2")]
-    pub result: ::core::option::Option<get_schedulers_response::Result>,
-}
-/// Nested message and enum types in `GetSchedulersResponse`.
-pub mod get_schedulers_response {
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum Result {
-        #[prost(message, tag = "1")]
-        Schedulers(super::SchedulerRegistrations),
-        #[prost(message, tag = "2")]
-        Error(super::SchedulerRegistrationError),
-    }
+    #[prost(message, optional, tag = "1")]
+    pub schedulers: ::core::option::Option<SchedulerRegistrations>,
 }
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct GetSessionResponse {
@@ -342,227 +257,10 @@ pub mod task_id {
 }
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct TaskInstanceOperationResponse {}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ResourceGroupOperationResponse {
-    #[prost(oneof = "resource_group_operation_response::Result", tags = "1, 2")]
-    pub result: ::core::option::Option<resource_group_operation_response::Result>,
-}
-/// Nested message and enum types in `ResourceGroupOperationResponse`.
-pub mod resource_group_operation_response {
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum Result {
-        #[prost(message, tag = "1")]
-        Ok(super::Void),
-        #[prost(message, tag = "2")]
-        Error(super::ResourceGroupManagementError),
-    }
-}
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct ResourceGroupOperationResponse {}
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct Void {}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct InboundQueueResponseError {
-    #[prost(enumeration = "inbound_queue_response_error::ErrCode", tag = "1")]
-    pub err_code: i32,
-    #[prost(string, tag = "2")]
-    pub message: ::prost::alloc::string::String,
-}
-/// Nested message and enum types in `InboundQueueResponseError`.
-pub mod inbound_queue_response_error {
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
-    #[repr(i32)]
-    pub enum ErrCode {
-        Unspecified = 0,
-        InboundClosed = 1,
-        Server = 2,
-        InvalidInput = 3,
-    }
-    impl ErrCode {
-        /// String value of the enum field names used in the ProtoBuf definition.
-        ///
-        /// The values are not transformed in any way and thus are considered stable
-        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-        pub fn as_str_name(&self) -> &'static str {
-            match self {
-                Self::Unspecified => "ERR_CODE_UNSPECIFIED",
-                Self::InboundClosed => "INBOUND_CLOSED",
-                Self::Server => "SERVER",
-                Self::InvalidInput => "INVALID_INPUT",
-            }
-        }
-        /// Creates an enum from field names used in the ProtoBuf definition.
-        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
-            match value {
-                "ERR_CODE_UNSPECIFIED" => Some(Self::Unspecified),
-                "INBOUND_CLOSED" => Some(Self::InboundClosed),
-                "SERVER" => Some(Self::Server),
-                "INVALID_INPUT" => Some(Self::InvalidInput),
-                _ => None,
-            }
-        }
-    }
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ResourceGroupManagementError {
-    #[prost(enumeration = "resource_group_management_error::ErrCode", tag = "1")]
-    pub err_code: i32,
-    #[prost(string, tag = "2")]
-    pub message: ::prost::alloc::string::String,
-    #[prost(uint64, tag = "3")]
-    pub storage_session: u64,
-}
-/// Nested message and enum types in `ResourceGroupManagementError`.
-pub mod resource_group_management_error {
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
-    #[repr(i32)]
-    pub enum ErrCode {
-        Unspecified = 0,
-        StaleSession = 1,
-        Server = 2,
-        InvalidInput = 3,
-    }
-    impl ErrCode {
-        /// String value of the enum field names used in the ProtoBuf definition.
-        ///
-        /// The values are not transformed in any way and thus are considered stable
-        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-        pub fn as_str_name(&self) -> &'static str {
-            match self {
-                Self::Unspecified => "ERR_CODE_UNSPECIFIED",
-                Self::StaleSession => "STALE_SESSION",
-                Self::Server => "SERVER",
-                Self::InvalidInput => "INVALID_INPUT",
-            }
-        }
-        /// Creates an enum from field names used in the ProtoBuf definition.
-        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
-            match value {
-                "ERR_CODE_UNSPECIFIED" => Some(Self::Unspecified),
-                "STALE_SESSION" => Some(Self::StaleSession),
-                "SERVER" => Some(Self::Server),
-                "INVALID_INPUT" => Some(Self::InvalidInput),
-                _ => None,
-            }
-        }
-    }
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ExecutionManagerLivenessError {
-    #[prost(enumeration = "execution_manager_liveness_error::ErrCode", tag = "1")]
-    pub err_code: i32,
-    #[prost(string, tag = "2")]
-    pub message: ::prost::alloc::string::String,
-}
-/// Nested message and enum types in `ExecutionManagerLivenessError`.
-pub mod execution_manager_liveness_error {
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
-    #[repr(i32)]
-    pub enum ErrCode {
-        Unspecified = 0,
-        MarkedDead = 1,
-        InvalidInput = 2,
-        Server = 3,
-    }
-    impl ErrCode {
-        /// String value of the enum field names used in the ProtoBuf definition.
-        ///
-        /// The values are not transformed in any way and thus are considered stable
-        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-        pub fn as_str_name(&self) -> &'static str {
-            match self {
-                Self::Unspecified => "ERR_CODE_UNSPECIFIED",
-                Self::MarkedDead => "MARKED_DEAD",
-                Self::InvalidInput => "INVALID_INPUT",
-                Self::Server => "SERVER",
-            }
-        }
-        /// Creates an enum from field names used in the ProtoBuf definition.
-        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
-            match value {
-                "ERR_CODE_UNSPECIFIED" => Some(Self::Unspecified),
-                "MARKED_DEAD" => Some(Self::MarkedDead),
-                "INVALID_INPUT" => Some(Self::InvalidInput),
-                "SERVER" => Some(Self::Server),
-                _ => None,
-            }
-        }
-    }
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct SchedulerRegistrationError {
-    #[prost(enumeration = "scheduler_registration_error::ErrCode", tag = "1")]
-    pub err_code: i32,
-    #[prost(string, tag = "2")]
-    pub message: ::prost::alloc::string::String,
-}
-/// Nested message and enum types in `SchedulerRegistrationError`.
-pub mod scheduler_registration_error {
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
-    #[repr(i32)]
-    pub enum ErrCode {
-        Unspecified = 0,
-        Server = 1,
-    }
-    impl ErrCode {
-        /// String value of the enum field names used in the ProtoBuf definition.
-        ///
-        /// The values are not transformed in any way and thus are considered stable
-        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-        pub fn as_str_name(&self) -> &'static str {
-            match self {
-                Self::Unspecified => "ERR_CODE_UNSPECIFIED",
-                Self::Server => "SERVER",
-            }
-        }
-        /// Creates an enum from field names used in the ProtoBuf definition.
-        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
-            match value {
-                "ERR_CODE_UNSPECIFIED" => Some(Self::Unspecified),
-                "SERVER" => Some(Self::Server),
-                _ => None,
-            }
-        }
-    }
-}
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum JobState {

--- a/components/spider-proto-rust/src/generated/storage.rs
+++ b/components/spider-proto-rust/src/generated/storage.rs
@@ -66,8 +66,6 @@ pub struct ReadyTask {
     #[prost(message, optional, tag = "3")]
     pub task_id: ::core::option::Option<TaskId>,
 }
-/// Request to re-enqueue the ready tasks of every cached job. Carries no parameters because the
-/// operation applies to the whole cache.
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct ResendReadyTasksRequest {}
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -162,10 +160,6 @@ pub struct VerifyResourceGroupRequest {
     #[prost(bytes = "vec", tag = "2")]
     pub password: ::prost::alloc::vec::Vec<u8>,
 }
-/// Request to delete a resource group (and, transitively, all of its jobs).
-///
-/// Carries the resource group's password so the caller must prove ownership before the group and
-/// its jobs are removed, mirroring `VerifyResourceGroupRequest`.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteResourceGroupRequest {
     #[prost(uint64, tag = "1")]

--- a/components/spider-proto-rust/src/generated/storage.rs
+++ b/components/spider-proto-rust/src/generated/storage.rs
@@ -163,10 +163,15 @@ pub struct VerifyResourceGroupRequest {
     pub password: ::prost::alloc::vec::Vec<u8>,
 }
 /// Request to delete a resource group (and, transitively, all of its jobs).
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
-pub struct ResourceGroupIdRequest {
+///
+/// Carries the resource group's password so the caller must prove ownership before the group and
+/// its jobs are removed, mirroring `VerifyResourceGroupRequest`.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeleteResourceGroupRequest {
     #[prost(uint64, tag = "1")]
     pub resource_group_id: u64,
+    #[prost(bytes = "vec", tag = "2")]
+    pub password: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RegisterExecutionManagerRequest {
@@ -1090,7 +1095,7 @@ pub mod resource_group_management_service_client {
         }
         pub async fn delete_resource_group(
             &mut self,
-            request: impl tonic::IntoRequest<super::ResourceGroupIdRequest>,
+            request: impl tonic::IntoRequest<super::DeleteResourceGroupRequest>,
         ) -> std::result::Result<
             tonic::Response<super::ResourceGroupOperationResponse>,
             tonic::Status,
@@ -2689,7 +2694,7 @@ pub mod resource_group_management_service_server {
         >;
         async fn delete_resource_group(
             &self,
-            request: tonic::Request<super::ResourceGroupIdRequest>,
+            request: tonic::Request<super::DeleteResourceGroupRequest>,
         ) -> std::result::Result<
             tonic::Response<super::ResourceGroupOperationResponse>,
             tonic::Status,
@@ -2881,7 +2886,7 @@ pub mod resource_group_management_service_server {
                     );
                     impl<
                         T: ResourceGroupManagementService,
-                    > tonic::server::UnaryService<super::ResourceGroupIdRequest>
+                    > tonic::server::UnaryService<super::DeleteResourceGroupRequest>
                     for DeleteResourceGroupSvc<T> {
                         type Response = super::ResourceGroupOperationResponse;
                         type Future = BoxFuture<
@@ -2890,7 +2895,7 @@ pub mod resource_group_management_service_server {
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::ResourceGroupIdRequest>,
+                            request: tonic::Request<super::DeleteResourceGroupRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {

--- a/components/spider-proto-rust/src/lib.rs
+++ b/components/spider-proto-rust/src/lib.rs
@@ -4,6 +4,7 @@ pub mod error;
 pub mod id;
 pub mod io;
 pub mod job;
+pub mod scheduler;
 pub mod unpack;
 
 #[allow(clippy::all, clippy::nursery, clippy::pedantic)]

--- a/components/spider-proto-rust/src/scheduler.rs
+++ b/components/spider-proto-rust/src/scheduler.rs
@@ -1,10 +1,8 @@
 //! Conversions between protobuf scheduler messages and their Spider core representations.
 
-use std::net::IpAddr;
+use spider_core::types::scheduler::RegisteredScheduler;
 
-use spider_core::types::{id::SchedulerId, scheduler::RegisteredScheduler};
-
-use crate::{error::Error, storage};
+use crate::storage;
 
 impl From<RegisteredScheduler> for storage::Scheduler {
     fn from(scheduler: RegisteredScheduler) -> Self {
@@ -16,31 +14,13 @@ impl From<RegisteredScheduler> for storage::Scheduler {
     }
 }
 
-impl TryFrom<storage::Scheduler> for RegisteredScheduler {
-    type Error = Error;
-
-    fn try_from(scheduler: storage::Scheduler) -> Result<Self, Self::Error> {
-        let ip_address = scheduler
-            .ip_address
-            .parse::<IpAddr>()
-            .map_err(|error| Error::IpAddressInvalid(error.to_string()))?;
-        let port =
-            u16::try_from(scheduler.port).map_err(|_| Error::PortOutOfRange(scheduler.port))?;
-        Ok(Self {
-            id: SchedulerId::from(scheduler.scheduler_id),
-            ip_address,
-            port,
-        })
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::net::IpAddr;
 
     use spider_core::types::{id::SchedulerId, scheduler::RegisteredScheduler};
 
-    use crate::{error::Error, storage};
+    use crate::storage;
 
     #[test]
     fn registered_scheduler_to_protocol_carries_id_ip_and_port() {
@@ -56,36 +36,5 @@ mod tests {
         assert_eq!(scheduler.scheduler_id, SCHEDULER_ID.get());
         assert_eq!(scheduler.ip_address, "127.0.0.1");
         assert_eq!(scheduler.port, u32::from(PORT));
-    }
-
-    #[test]
-    fn protocol_scheduler_to_core_round_trips() {
-        const SCHEDULER_ID: SchedulerId = SchedulerId::from(42);
-
-        let proto = storage::Scheduler::from(RegisteredScheduler {
-            id: SCHEDULER_ID,
-            ip_address: IpAddr::V4("127.0.0.1".parse().expect("valid IP")),
-            port: 5678,
-        });
-
-        let scheduler = RegisteredScheduler::try_from(proto).expect("conversion should succeed");
-
-        assert_eq!(scheduler.id, SCHEDULER_ID);
-        assert_eq!(scheduler.ip_address.to_string(), "127.0.0.1");
-        assert_eq!(scheduler.port, 5678);
-    }
-
-    #[test]
-    fn protocol_scheduler_to_core_rejects_invalid_ip() {
-        let proto = storage::Scheduler {
-            scheduler_id: 1,
-            ip_address: "not an ip".to_owned(),
-            port: 8080,
-        };
-
-        assert!(matches!(
-            RegisteredScheduler::try_from(proto),
-            Err(Error::IpAddressInvalid(_))
-        ));
     }
 }

--- a/components/spider-proto-rust/src/scheduler.rs
+++ b/components/spider-proto-rust/src/scheduler.rs
@@ -1,0 +1,91 @@
+//! Conversions between protobuf scheduler messages and their Spider core representations.
+
+use std::net::IpAddr;
+
+use spider_core::types::{id::SchedulerId, scheduler::RegisteredScheduler};
+
+use crate::{error::Error, storage};
+
+impl From<RegisteredScheduler> for storage::Scheduler {
+    fn from(scheduler: RegisteredScheduler) -> Self {
+        Self {
+            scheduler_id: scheduler.id.get(),
+            ip_address: scheduler.ip_address.to_string(),
+            port: u32::from(scheduler.port),
+        }
+    }
+}
+
+impl TryFrom<storage::Scheduler> for RegisteredScheduler {
+    type Error = Error;
+
+    fn try_from(scheduler: storage::Scheduler) -> Result<Self, Self::Error> {
+        let ip_address = scheduler
+            .ip_address
+            .parse::<IpAddr>()
+            .map_err(|error| Error::IpAddressInvalid(error.to_string()))?;
+        let port =
+            u16::try_from(scheduler.port).map_err(|_| Error::PortOutOfRange(scheduler.port))?;
+        Ok(Self {
+            id: SchedulerId::from(scheduler.scheduler_id),
+            ip_address,
+            port,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::IpAddr;
+
+    use spider_core::types::{id::SchedulerId, scheduler::RegisteredScheduler};
+
+    use crate::{error::Error, storage};
+
+    #[test]
+    fn registered_scheduler_to_protocol_carries_id_ip_and_port() {
+        const SCHEDULER_ID: SchedulerId = SchedulerId::from(42);
+        const PORT: u16 = 5678;
+
+        let scheduler = storage::Scheduler::from(RegisteredScheduler {
+            id: SCHEDULER_ID,
+            ip_address: IpAddr::V4("127.0.0.1".parse().expect("valid IP")),
+            port: PORT,
+        });
+
+        assert_eq!(scheduler.scheduler_id, SCHEDULER_ID.get());
+        assert_eq!(scheduler.ip_address, "127.0.0.1");
+        assert_eq!(scheduler.port, u32::from(PORT));
+    }
+
+    #[test]
+    fn protocol_scheduler_to_core_round_trips() {
+        const SCHEDULER_ID: SchedulerId = SchedulerId::from(42);
+
+        let proto = storage::Scheduler::from(RegisteredScheduler {
+            id: SCHEDULER_ID,
+            ip_address: IpAddr::V4("127.0.0.1".parse().expect("valid IP")),
+            port: 5678,
+        });
+
+        let scheduler = RegisteredScheduler::try_from(proto).expect("conversion should succeed");
+
+        assert_eq!(scheduler.id, SCHEDULER_ID);
+        assert_eq!(scheduler.ip_address.to_string(), "127.0.0.1");
+        assert_eq!(scheduler.port, 5678);
+    }
+
+    #[test]
+    fn protocol_scheduler_to_core_rejects_invalid_ip() {
+        let proto = storage::Scheduler {
+            scheduler_id: 1,
+            ip_address: "not an ip".to_owned(),
+            port: 8080,
+        };
+
+        assert!(matches!(
+            RegisteredScheduler::try_from(proto),
+            Err(Error::IpAddressInvalid(_))
+        ));
+    }
+}

--- a/components/spider-proto-rust/src/unpack/storage.rs
+++ b/components/spider-proto-rust/src/unpack/storage.rs
@@ -16,6 +16,7 @@ use crate::{
     storage::{
         self,
         AddResourceGroupRequest,
+        DeleteResourceGroupRequest,
         ExecutionManagerIdRequest,
         JobIdRequest,
         PollReadyTasksRequest,
@@ -25,7 +26,6 @@ use crate::{
         RegisterTaskInstanceRequest,
         ReportTaskFailureRequest,
         ReportTaskSuccessRequest,
-        ResourceGroupIdRequest,
         VerifyResourceGroupRequest,
     },
     unpack::{RequestUnpack, UnpackError},
@@ -183,12 +183,15 @@ impl RequestUnpack for VerifyResourceGroupRequest {
     }
 }
 
-/// Unpacks [`ResourceGroupIdRequest`] into the resource group ID.
-impl RequestUnpack for ResourceGroupIdRequest {
-    type Unpacked = ResourceGroupId;
+/// Unpacks [`DeleteResourceGroupRequest`] into a tuple containing:
+///
+/// * The resource group ID.
+/// * The password proving ownership of the resource group.
+impl RequestUnpack for DeleteResourceGroupRequest {
+    type Unpacked = (ResourceGroupId, Vec<u8>);
 
     fn unpack(self) -> Result<Self::Unpacked, UnpackError> {
-        Ok(ResourceGroupId::from(self.resource_group_id))
+        Ok((ResourceGroupId::from(self.resource_group_id), self.password))
     }
 }
 

--- a/components/spider-proto-rust/src/unpack/storage.rs
+++ b/components/spider-proto-rust/src/unpack/storage.rs
@@ -163,16 +163,11 @@ impl RequestUnpack for ReportTaskFailureRequest {
 ///
 /// * The external resource group ID.
 /// * The password.
-/// * The caller's storage session ID.
 impl RequestUnpack for AddResourceGroupRequest {
-    type Unpacked = (String, Vec<u8>, SessionId);
+    type Unpacked = (String, Vec<u8>);
 
     fn unpack(self) -> Result<Self::Unpacked, UnpackError> {
-        Ok((
-            self.external_resource_group_id,
-            self.password,
-            self.session_id,
-        ))
+        Ok((self.external_resource_group_id, self.password))
     }
 }
 
@@ -180,31 +175,20 @@ impl RequestUnpack for AddResourceGroupRequest {
 ///
 /// * The resource group ID.
 /// * The password.
-/// * The caller's storage session ID.
 impl RequestUnpack for VerifyResourceGroupRequest {
-    type Unpacked = (ResourceGroupId, Vec<u8>, SessionId);
+    type Unpacked = (ResourceGroupId, Vec<u8>);
 
     fn unpack(self) -> Result<Self::Unpacked, UnpackError> {
-        Ok((
-            ResourceGroupId::from(self.resource_group_id),
-            self.password,
-            self.session_id,
-        ))
+        Ok((ResourceGroupId::from(self.resource_group_id), self.password))
     }
 }
 
-/// Unpacks [`ResourceGroupIdRequest`] into a tuple containing:
-///
-/// * The resource group ID.
-/// * The caller's storage session ID.
+/// Unpacks [`ResourceGroupIdRequest`] into the resource group ID.
 impl RequestUnpack for ResourceGroupIdRequest {
-    type Unpacked = (ResourceGroupId, SessionId);
+    type Unpacked = ResourceGroupId;
 
     fn unpack(self) -> Result<Self::Unpacked, UnpackError> {
-        Ok((
-            ResourceGroupId::from(self.resource_group_id),
-            self.session_id,
-        ))
+        Ok(ResourceGroupId::from(self.resource_group_id))
     }
 }
 

--- a/components/spider-proto-rust/src/unpack/storage.rs
+++ b/components/spider-proto-rust/src/unpack/storage.rs
@@ -1,5 +1,7 @@
 //! [`RequestUnpack`] implementations for `storage.proto` requests.
 
+use std::{net::IpAddr, time::Duration};
+
 use spider_core::types::id::{
     ExecutionManagerId,
     JobId,
@@ -13,11 +15,18 @@ use tonic::Code;
 use crate::{
     storage::{
         self,
+        AddResourceGroupRequest,
+        ExecutionManagerIdRequest,
         JobIdRequest,
+        PollReadyTasksRequest,
+        RegisterExecutionManagerRequest,
         RegisterJobRequest,
+        RegisterSchedulerRequest,
         RegisterTaskInstanceRequest,
         ReportTaskFailureRequest,
         ReportTaskSuccessRequest,
+        ResourceGroupIdRequest,
+        VerifyResourceGroupRequest,
     },
     unpack::{RequestUnpack, UnpackError},
 };
@@ -147,6 +156,119 @@ impl RequestUnpack for ReportTaskFailureRequest {
             self.task_instance_id,
             self.error_message,
         ))
+    }
+}
+
+/// Unpacks [`AddResourceGroupRequest`] into a tuple containing:
+///
+/// * The external resource group ID.
+/// * The password.
+/// * The caller's storage session ID.
+impl RequestUnpack for AddResourceGroupRequest {
+    type Unpacked = (String, Vec<u8>, SessionId);
+
+    fn unpack(self) -> Result<Self::Unpacked, UnpackError> {
+        Ok((
+            self.external_resource_group_id,
+            self.password,
+            self.session_id,
+        ))
+    }
+}
+
+/// Unpacks [`VerifyResourceGroupRequest`] into a tuple containing:
+///
+/// * The resource group ID.
+/// * The password.
+/// * The caller's storage session ID.
+impl RequestUnpack for VerifyResourceGroupRequest {
+    type Unpacked = (ResourceGroupId, Vec<u8>, SessionId);
+
+    fn unpack(self) -> Result<Self::Unpacked, UnpackError> {
+        Ok((
+            ResourceGroupId::from(self.resource_group_id),
+            self.password,
+            self.session_id,
+        ))
+    }
+}
+
+/// Unpacks [`ResourceGroupIdRequest`] into a tuple containing:
+///
+/// * The resource group ID.
+/// * The caller's storage session ID.
+impl RequestUnpack for ResourceGroupIdRequest {
+    type Unpacked = (ResourceGroupId, SessionId);
+
+    fn unpack(self) -> Result<Self::Unpacked, UnpackError> {
+        Ok((
+            ResourceGroupId::from(self.resource_group_id),
+            self.session_id,
+        ))
+    }
+}
+
+/// Unpacks [`RegisterExecutionManagerRequest`] into the execution manager's IP address.
+impl RequestUnpack for RegisterExecutionManagerRequest {
+    type Unpacked = IpAddr;
+
+    fn unpack(self) -> Result<Self::Unpacked, UnpackError> {
+        self.ip_address
+            .parse::<IpAddr>()
+            .map_err(|error| invalid_argument(format!("invalid IP address: {error}")))
+    }
+}
+
+/// Unpacks [`ExecutionManagerIdRequest`] into an [`ExecutionManagerId`].
+impl RequestUnpack for ExecutionManagerIdRequest {
+    type Unpacked = ExecutionManagerId;
+
+    fn unpack(self) -> Result<Self::Unpacked, UnpackError> {
+        Ok(ExecutionManagerId::from(self.execution_manager_id))
+    }
+}
+
+/// Unpacks [`RegisterSchedulerRequest`] into a tuple containing:
+///
+/// * The scheduler IP address.
+/// * The scheduler port.
+impl RequestUnpack for RegisterSchedulerRequest {
+    type Unpacked = (IpAddr, u16);
+
+    fn unpack(self) -> Result<Self::Unpacked, UnpackError> {
+        let ip_address = self
+            .ip_address
+            .parse::<IpAddr>()
+            .map_err(|error| invalid_argument(format!("invalid IP address: {error}")))?;
+        let port = u16::try_from(self.port)
+            .map_err(|_| invalid_argument(format!("port does not fit in `u16`: {}", self.port)))?;
+        Ok((ip_address, port))
+    }
+}
+
+/// Unpacks [`PollReadyTasksRequest`] into a tuple containing:
+///
+/// * The maximum number of entries to return.
+/// * The maximum duration to block waiting for entries.
+impl RequestUnpack for PollReadyTasksRequest {
+    type Unpacked = (usize, Duration);
+
+    fn unpack(self) -> Result<Self::Unpacked, UnpackError> {
+        let max_items = usize::try_from(self.max_items).map_err(|_| {
+            invalid_argument(format!(
+                "max_items does not fit in `usize`: {}",
+                self.max_items
+            ))
+        })?;
+        Ok((max_items, Duration::from_millis(self.wait_ms)))
+    }
+}
+
+/// Builds an [`UnpackError`] carrying [`Code::InvalidArgument`] and the given message.
+const fn invalid_argument(message: String) -> UnpackError {
+    UnpackError {
+        code: Code::InvalidArgument,
+        message,
     }
 }
 

--- a/components/spider-proto-rust/src/unpack/storage.rs
+++ b/components/spider-proto-rust/src/unpack/storage.rs
@@ -249,6 +249,10 @@ impl RequestUnpack for PollReadyTasksRequest {
 }
 
 /// Builds an [`UnpackError`] carrying [`Code::InvalidArgument`] and the given message.
+///
+/// # Returns
+///
+/// An [`UnpackError`] whose [`Code`] is [`Code::InvalidArgument`] and whose message is `message`.
 const fn invalid_argument(message: String) -> UnpackError {
     UnpackError {
         code: Code::InvalidArgument,

--- a/components/spider-proto/storage/storage.proto
+++ b/components/spider-proto/storage/storage.proto
@@ -96,8 +96,6 @@ message ReadyTask {
   TaskId task_id = 3;
 }
 
-// Request to re-enqueue the ready tasks of every cached job. Carries no parameters because the
-// operation applies to the whole cache.
 message ResendReadyTasksRequest {}
 
 message ResendReadyTasksResponse {}
@@ -162,10 +160,6 @@ message VerifyResourceGroupRequest {
   bytes password = 2;
 }
 
-// Request to delete a resource group (and, transitively, all of its jobs).
-//
-// Carries the resource group's password so the caller must prove ownership before the group and
-// its jobs are removed, mirroring `VerifyResourceGroupRequest`.
 message DeleteResourceGroupRequest {
   uint64 resource_group_id = 1;
   bytes password = 2;

--- a/components/spider-proto/storage/storage.proto
+++ b/components/spider-proto/storage/storage.proto
@@ -21,11 +21,13 @@ service InboundQueueService {
   rpc PollReadyTasks(PollReadyTasksRequest) returns (PollReadyTasksResponse);
   rpc PollReadyCommitTasks(PollReadyTasksRequest) returns (PollReadyTasksResponse);
   rpc PollReadyCleanupTasks(PollReadyTasksRequest) returns (PollReadyTasksResponse);
+  rpc ResendReadyTasks(ResendReadyTasksRequest) returns (ResendReadyTasksResponse);
 }
 
 service ResourceGroupManagementService {
   rpc AddResourceGroup(AddResourceGroupRequest) returns (ResourceGroupIdResponse);
   rpc VerifyResourceGroup(VerifyResourceGroupRequest) returns (ResourceGroupOperationResponse);
+  rpc DeleteResourceGroup(ResourceGroupIdRequest) returns (ResourceGroupOperationResponse);
 }
 
 service ExecutionManagerLivenessService {
@@ -97,6 +99,17 @@ message ReadyTask {
   TaskId task_id = 3;
 }
 
+// Request to re-enqueue the ready tasks of every cached job. Carries no parameters because the
+// operation applies to the whole cache.
+message ResendReadyTasksRequest {}
+
+message ResendReadyTasksResponse {
+  oneof result {
+    Void ok = 1;
+    InboundQueueResponseError error = 2;
+  }
+}
+
 message RegisterTaskInstanceRequest {
   uint64 job_id = 1;
   TaskId task_id = 2;
@@ -160,6 +173,13 @@ message VerifyResourceGroupRequest {
   uint64 resource_group_id = 1;
   bytes password = 2;
   uint64 session_id = 3;
+}
+
+// Request to delete a resource group (and, transitively, all of its jobs). Carries the caller's
+// storage session so the server can reject stale requests.
+message ResourceGroupIdRequest {
+  uint64 resource_group_id = 1;
+  uint64 session_id = 2;
 }
 
 message RegisterExecutionManagerRequest {

--- a/components/spider-proto/storage/storage.proto
+++ b/components/spider-proto/storage/storage.proto
@@ -27,7 +27,7 @@ service InboundQueueService {
 service ResourceGroupManagementService {
   rpc AddResourceGroup(AddResourceGroupRequest) returns (ResourceGroupIdResponse);
   rpc VerifyResourceGroup(VerifyResourceGroupRequest) returns (ResourceGroupOperationResponse);
-  rpc DeleteResourceGroup(ResourceGroupIdRequest) returns (ResourceGroupOperationResponse);
+  rpc DeleteResourceGroup(DeleteResourceGroupRequest) returns (ResourceGroupOperationResponse);
 }
 
 service ExecutionManagerLivenessService {
@@ -163,8 +163,12 @@ message VerifyResourceGroupRequest {
 }
 
 // Request to delete a resource group (and, transitively, all of its jobs).
-message ResourceGroupIdRequest {
+//
+// Carries the resource group's password so the caller must prove ownership before the group and
+// its jobs are removed, mirroring `VerifyResourceGroupRequest`.
+message DeleteResourceGroupRequest {
   uint64 resource_group_id = 1;
+  bytes password = 2;
 }
 
 message RegisterExecutionManagerRequest {

--- a/components/spider-proto/storage/storage.proto
+++ b/components/spider-proto/storage/storage.proto
@@ -82,10 +82,7 @@ message PollReadyTasksRequest {
 }
 
 message PollReadyTasksResponse {
-  oneof result {
-    ReadyTasks tasks = 1;
-    InboundQueueResponseError error = 2;
-  }
+  ReadyTasks tasks = 1;
 }
 
 message ReadyTasks {
@@ -103,12 +100,7 @@ message ReadyTask {
 // operation applies to the whole cache.
 message ResendReadyTasksRequest {}
 
-message ResendReadyTasksResponse {
-  oneof result {
-    Void ok = 1;
-    InboundQueueResponseError error = 2;
-  }
-}
+message ResendReadyTasksResponse {}
 
 message RegisterTaskInstanceRequest {
   uint64 job_id = 1;
@@ -159,27 +151,20 @@ message ReportTaskFailureRequest {
 message AddResourceGroupRequest {
   string external_resource_group_id = 1;
   bytes password = 2;
-  uint64 session_id = 3;
 }
 
 message ResourceGroupIdResponse {
-  oneof result {
-    uint64 resource_group_id = 1;
-    ResourceGroupManagementError error = 2;
-  }
+  uint64 resource_group_id = 1;
 }
 
 message VerifyResourceGroupRequest {
   uint64 resource_group_id = 1;
   bytes password = 2;
-  uint64 session_id = 3;
 }
 
-// Request to delete a resource group (and, transitively, all of its jobs). Carries the caller's
-// storage session so the server can reject stale requests.
+// Request to delete a resource group (and, transitively, all of its jobs).
 message ResourceGroupIdRequest {
   uint64 resource_group_id = 1;
-  uint64 session_id = 2;
 }
 
 message RegisterExecutionManagerRequest {
@@ -196,17 +181,11 @@ message ExecutionManagerRegistration {
 }
 
 message RegisterExecutionManagerResponse {
-  oneof result {
-    ExecutionManagerRegistration registration = 1;
-    ExecutionManagerLivenessError error = 2;
-  }
+  ExecutionManagerRegistration registration = 1;
 }
 
 message UpdateExecutionManagerHeartbeatResponse {
-  oneof result {
-    uint64 session_id = 1;
-    ExecutionManagerLivenessError error = 2;
-  }
+  uint64 session_id = 1;
 }
 
 message RegisterSchedulerRequest {
@@ -220,10 +199,7 @@ message SchedulerRegistration {
 }
 
 message RegisterSchedulerResponse {
-  oneof result {
-    SchedulerRegistration registration = 1;
-    SchedulerRegistrationError error = 2;
-  }
+  SchedulerRegistration registration = 1;
 }
 
 message Scheduler {
@@ -237,10 +213,7 @@ message SchedulerRegistrations {
 }
 
 message GetSchedulersResponse {
-  oneof result {
-    SchedulerRegistrations schedulers = 1;
-    SchedulerRegistrationError error = 2;
-  }
+  SchedulerRegistrations schedulers = 1;
 }
 
 message GetSessionResponse {
@@ -268,58 +241,6 @@ enum JobState {
 
 message TaskInstanceOperationResponse {}
 
-message ResourceGroupOperationResponse {
-  oneof result {
-    Void ok = 1;
-    ResourceGroupManagementError error = 2;
-  }
-}
+message ResourceGroupOperationResponse {}
 
 message Void {}
-
-message InboundQueueResponseError {
-  enum ErrCode {
-    ERR_CODE_UNSPECIFIED = 0;
-    INBOUND_CLOSED = 1;
-    SERVER = 2;
-    INVALID_INPUT = 3;
-  }
-
-  ErrCode err_code = 1;
-  string message = 2;
-}
-
-message ResourceGroupManagementError {
-  enum ErrCode {
-    ERR_CODE_UNSPECIFIED = 0;
-    STALE_SESSION = 1;
-    SERVER = 2;
-    INVALID_INPUT = 3;
-  }
-
-  ErrCode err_code = 1;
-  string message = 2;
-  uint64 storage_session = 3;
-}
-
-message ExecutionManagerLivenessError {
-  enum ErrCode {
-    ERR_CODE_UNSPECIFIED = 0;
-    MARKED_DEAD = 1;
-    INVALID_INPUT = 2;
-    SERVER = 3;
-  }
-
-  ErrCode err_code = 1;
-  string message = 2;
-}
-
-message SchedulerRegistrationError {
-  enum ErrCode {
-    ERR_CODE_UNSPECIFIED = 0;
-    SERVER = 1;
-  }
-
-  ErrCode err_code = 1;
-  string message = 2;
-}

--- a/components/spider-scheduler/src/core_impl/round_robin/tests.rs
+++ b/components/spider-scheduler/src/core_impl/round_robin/tests.rs
@@ -169,6 +169,10 @@ impl SchedulerStorageClient for MockStorageClient {
     async fn job_state(&self, _job_id: JobId) -> Result<JobState, StorageClientError> {
         Ok(JobState::Running)
     }
+
+    async fn resend_ready_tasks(&self) -> Result<(), StorageClientError> {
+        Ok(())
+    }
 }
 
 /// # Returns

--- a/components/spider-scheduler/src/error.rs
+++ b/components/spider-scheduler/src/error.rs
@@ -13,13 +13,6 @@ pub enum StorageClientError {
     #[error("job not found: {0:?}")]
     JobNotFound(JobId),
 
-    /// The scheduler's storage session is stale.
-    #[error("stale storage session: {storage_session:?}")]
-    StaleSession {
-        /// Storage's current session ID.
-        storage_session: SessionId,
-    },
-
     /// The storage server returned an invalid input error.
     #[error("invalid storage request: {0}")]
     InvalidInput(String),

--- a/components/spider-scheduler/src/storage_client/grpc.rs
+++ b/components/spider-scheduler/src/storage_client/grpc.rs
@@ -140,7 +140,7 @@ impl SchedulerStorageClient for GrpcSchedulerStorageClient {
 fn map_inbound_status(status: &tonic::Status) -> StorageClientError {
     match status.code() {
         Code::Unavailable => StorageClientError::InboundClosed,
-        Code::InvalidArgument => StorageClientError::InvalidInput(status.message().to_owned()),
+        Code::InvalidArgument => to_invalid_input_error(status.message()),
         _ => StorageClientError::Server(status.message().to_owned()),
     }
 }

--- a/components/spider-scheduler/src/storage_client/grpc.rs
+++ b/components/spider-scheduler/src/storage_client/grpc.rs
@@ -13,6 +13,7 @@ use spider_proto_rust::storage::{
     inbound_queue_service_client::InboundQueueServiceClient,
     job_orchestration_service_client::JobOrchestrationServiceClient,
     poll_ready_tasks_response,
+    resend_ready_tasks_response,
 };
 use tonic::{
     Code,
@@ -120,6 +121,17 @@ impl SchedulerStorageClient for GrpcSchedulerStorageClient {
             .into_inner();
         job_state_response_to_result(response)
     }
+
+    async fn resend_ready_tasks(&self) -> Result<(), StorageClientError> {
+        let response = self
+            .scheduler_client
+            .clone()
+            .resend_ready_tasks(storage::ResendReadyTasksRequest {})
+            .await
+            .map_err(to_transport_error)?
+            .into_inner();
+        resend_ready_tasks_response_to_result(response)
+    }
 }
 
 impl From<storage::InboundQueueResponseError> for StorageClientError {
@@ -169,6 +181,21 @@ fn poll_ready_tasks_response_to_result(
         Some(poll_ready_tasks_response::Result::Error(error)) => Err(error.into()),
         None => Err(StorageClientError::Transport(
             "poll ready tasks response missing `result` message".to_owned(),
+        )),
+    }
+}
+
+/// # Returns
+///
+/// [`storage::ResendReadyTasksResponse`] converted into [`Result<(), StorageClientError>`].
+fn resend_ready_tasks_response_to_result(
+    response: storage::ResendReadyTasksResponse,
+) -> Result<(), StorageClientError> {
+    match response.result {
+        Some(resend_ready_tasks_response::Result::Ok(_)) => Ok(()),
+        Some(resend_ready_tasks_response::Result::Error(error)) => Err(error.into()),
+        None => Err(StorageClientError::Transport(
+            "resend ready tasks response missing `result` message".to_owned(),
         )),
     }
 }
@@ -333,6 +360,42 @@ mod tests {
         assert!(matches!(
             StorageClientError::from(error),
             StorageClientError::InboundClosed
+        ));
+    }
+
+    #[test]
+    fn resend_ready_tasks_response_accepts_ok() {
+        let response = storage::ResendReadyTasksResponse {
+            result: Some(resend_ready_tasks_response::Result::Ok(storage::Void {})),
+        };
+
+        assert!(resend_ready_tasks_response_to_result(response).is_ok());
+    }
+
+    #[test]
+    fn resend_ready_tasks_response_maps_error() {
+        let response = storage::ResendReadyTasksResponse {
+            result: Some(resend_ready_tasks_response::Result::Error(
+                storage::InboundQueueResponseError {
+                    err_code: inbound_queue_response_error::ErrCode::InboundClosed.into(),
+                    message: "closed".to_owned(),
+                },
+            )),
+        };
+
+        assert!(matches!(
+            resend_ready_tasks_response_to_result(response),
+            Err(StorageClientError::InboundClosed)
+        ));
+    }
+
+    #[test]
+    fn resend_ready_tasks_response_rejects_missing_result() {
+        let response = storage::ResendReadyTasksResponse { result: None };
+
+        assert!(matches!(
+            resend_ready_tasks_response_to_result(response),
+            Err(StorageClientError::Transport(_))
         ));
     }
 }

--- a/components/spider-scheduler/src/storage_client/grpc.rs
+++ b/components/spider-scheduler/src/storage_client/grpc.rs
@@ -168,17 +168,13 @@ fn poll_ready_tasks_request(
 ///
 /// [`storage::PollReadyTasksResponse`] converted into
 /// [`Result<(SessionId, Vec<InboundEntry>), StorageClientError>`].
-///
-/// # Errors
-///
-/// Returns an error if:
-///
-/// * [`StorageClientError::Transport`] if the response omits the `tasks` payload.
 fn poll_ready_tasks_response_to_result(
     response: storage::PollReadyTasksResponse,
 ) -> Result<(SessionId, Vec<InboundEntry>), StorageClientError> {
     let tasks = response.tasks.ok_or_else(|| {
-        StorageClientError::Transport("poll ready tasks response missing `tasks`".to_owned())
+        StorageClientError::Transport(
+            "poll ready tasks response missing `tasks` message".to_owned(),
+        )
     })?;
     ready_tasks_to_result(tasks)
 }

--- a/components/spider-scheduler/src/storage_client/grpc.rs
+++ b/components/spider-scheduler/src/storage_client/grpc.rs
@@ -9,11 +9,8 @@ use spider_core::{
 };
 use spider_proto_rust::storage::{
     self,
-    inbound_queue_response_error,
     inbound_queue_service_client::InboundQueueServiceClient,
     job_orchestration_service_client::JobOrchestrationServiceClient,
-    poll_ready_tasks_response,
-    resend_ready_tasks_response,
 };
 use tonic::{
     Code,
@@ -68,7 +65,7 @@ impl SchedulerStorageClient for GrpcSchedulerStorageClient {
             .clone()
             .poll_ready_tasks(request)
             .await
-            .map_err(to_transport_error)?
+            .map_err(|status| map_inbound_status(&status))?
             .into_inner();
         poll_ready_tasks_response_to_result(response)
     }
@@ -84,7 +81,7 @@ impl SchedulerStorageClient for GrpcSchedulerStorageClient {
             .clone()
             .poll_ready_commit_tasks(request)
             .await
-            .map_err(to_transport_error)?
+            .map_err(|status| map_inbound_status(&status))?
             .into_inner();
         poll_ready_tasks_response_to_result(response)
     }
@@ -100,7 +97,7 @@ impl SchedulerStorageClient for GrpcSchedulerStorageClient {
             .clone()
             .poll_ready_cleanup_tasks(request)
             .await
-            .map_err(to_transport_error)?
+            .map_err(|status| map_inbound_status(&status))?
             .into_inner();
         poll_ready_tasks_response_to_result(response)
     }
@@ -123,30 +120,28 @@ impl SchedulerStorageClient for GrpcSchedulerStorageClient {
     }
 
     async fn resend_ready_tasks(&self) -> Result<(), StorageClientError> {
-        let response = self
-            .scheduler_client
+        self.scheduler_client
             .clone()
             .resend_ready_tasks(storage::ResendReadyTasksRequest {})
             .await
-            .map_err(to_transport_error)?
-            .into_inner();
-        resend_ready_tasks_response_to_result(response)
+            .map_err(|status| map_inbound_status(&status))?;
+        Ok(())
     }
 }
 
-impl From<storage::InboundQueueResponseError> for StorageClientError {
-    fn from(error: storage::InboundQueueResponseError) -> Self {
-        match inbound_queue_response_error::ErrCode::try_from(error.err_code) {
-            Ok(inbound_queue_response_error::ErrCode::InboundClosed) => Self::InboundClosed,
-            Ok(inbound_queue_response_error::ErrCode::InvalidInput) => {
-                Self::InvalidInput(error.message)
-            }
-            Ok(
-                inbound_queue_response_error::ErrCode::Server
-                | inbound_queue_response_error::ErrCode::Unspecified,
-            ) => Self::Server(error.message),
-            Err(error) => Self::Transport(format!("unknown scheduler storage error kind: {error}")),
-        }
+/// Maps a [`tonic::Status`] returned by an inbound-queue RPC into a [`StorageClientError`].
+///
+/// # Returns
+///
+/// * [`StorageClientError::InboundClosed`] when the inbound queue is closed (or the request was
+///   issued from a stale session), signalled by `UNAVAILABLE`.
+/// * [`StorageClientError::InvalidInput`] for a malformed request, signalled by `INVALID_ARGUMENT`.
+/// * [`StorageClientError::Server`] for any other failure.
+fn map_inbound_status(status: &tonic::Status) -> StorageClientError {
+    match status.code() {
+        Code::Unavailable => StorageClientError::InboundClosed,
+        Code::InvalidArgument => StorageClientError::InvalidInput(status.message().to_owned()),
+        _ => StorageClientError::Server(status.message().to_owned()),
     }
 }
 
@@ -173,31 +168,19 @@ fn poll_ready_tasks_request(
 ///
 /// [`storage::PollReadyTasksResponse`] converted into
 /// [`Result<(SessionId, Vec<InboundEntry>), StorageClientError>`].
+///
+/// # Errors
+///
+/// Returns an error if:
+///
+/// * [`StorageClientError::Transport`] if the response omits the `tasks` payload.
 fn poll_ready_tasks_response_to_result(
     response: storage::PollReadyTasksResponse,
 ) -> Result<(SessionId, Vec<InboundEntry>), StorageClientError> {
-    match response.result {
-        Some(poll_ready_tasks_response::Result::Tasks(tasks)) => ready_tasks_to_result(tasks),
-        Some(poll_ready_tasks_response::Result::Error(error)) => Err(error.into()),
-        None => Err(StorageClientError::Transport(
-            "poll ready tasks response missing `result` message".to_owned(),
-        )),
-    }
-}
-
-/// # Returns
-///
-/// [`storage::ResendReadyTasksResponse`] converted into [`Result<(), StorageClientError>`].
-fn resend_ready_tasks_response_to_result(
-    response: storage::ResendReadyTasksResponse,
-) -> Result<(), StorageClientError> {
-    match response.result {
-        Some(resend_ready_tasks_response::Result::Ok(_)) => Ok(()),
-        Some(resend_ready_tasks_response::Result::Error(error)) => Err(error.into()),
-        None => Err(StorageClientError::Transport(
-            "resend ready tasks response missing `result` message".to_owned(),
-        )),
-    }
+    let tasks = response.tasks.ok_or_else(|| {
+        StorageClientError::Transport("poll ready tasks response missing `tasks`".to_owned())
+    })?;
+    ready_tasks_to_result(tasks)
 }
 
 /// # Returns
@@ -281,11 +264,7 @@ fn to_invalid_input_error(error: impl std::fmt::Display) -> StorageClientError {
 #[cfg(test)]
 mod tests {
     use spider_core::types::id::{JobId, ResourceGroupId, TaskId};
-    use spider_proto_rust::storage::{
-        self,
-        inbound_queue_response_error,
-        poll_ready_tasks_response,
-    };
+    use spider_proto_rust::storage;
 
     use super::*;
 
@@ -297,16 +276,14 @@ mod tests {
     #[test]
     fn poll_ready_tasks_response_converts_entries() {
         let response = storage::PollReadyTasksResponse {
-            result: Some(poll_ready_tasks_response::Result::Tasks(
-                storage::ReadyTasks {
-                    session_id: SESSION_ID,
-                    tasks: vec![storage::ReadyTask {
-                        resource_group_id: RESOURCE_GROUP_ID,
-                        job_id: JOB_ID,
-                        task_id: Some(storage::TaskId::from(TaskId::Index(TASK_INDEX))),
-                    }],
-                },
-            )),
+            tasks: Some(storage::ReadyTasks {
+                session_id: SESSION_ID,
+                tasks: vec![storage::ReadyTask {
+                    resource_group_id: RESOURCE_GROUP_ID,
+                    job_id: JOB_ID,
+                    task_id: Some(storage::TaskId::from(TaskId::Index(TASK_INDEX))),
+                }],
+            }),
         };
 
         let (session_id, entries) = poll_ready_tasks_response_to_result(response)
@@ -328,16 +305,14 @@ mod tests {
         const MISSING_TASK_ID_MESSAGE: &str = "missing task ID";
 
         let response = storage::PollReadyTasksResponse {
-            result: Some(poll_ready_tasks_response::Result::Tasks(
-                storage::ReadyTasks {
-                    session_id: SESSION_ID,
-                    tasks: vec![storage::ReadyTask {
-                        resource_group_id: RESOURCE_GROUP_ID,
-                        job_id: JOB_ID,
-                        task_id: None,
-                    }],
-                },
-            )),
+            tasks: Some(storage::ReadyTasks {
+                session_id: SESSION_ID,
+                tasks: vec![storage::ReadyTask {
+                    resource_group_id: RESOURCE_GROUP_ID,
+                    job_id: JOB_ID,
+                    task_id: None,
+                }],
+            }),
         };
 
         match poll_ready_tasks_response_to_result(response) {
@@ -349,53 +324,43 @@ mod tests {
     }
 
     #[test]
-    fn inbound_queue_response_error_maps_inbound_closed() {
-        const ERROR_MESSAGE: &str = "closed";
-
-        let error = storage::InboundQueueResponseError {
-            err_code: inbound_queue_response_error::ErrCode::InboundClosed.into(),
-            message: ERROR_MESSAGE.to_owned(),
-        };
+    fn poll_ready_tasks_response_rejects_missing_tasks() {
+        let response = storage::PollReadyTasksResponse { tasks: None };
 
         assert!(matches!(
-            StorageClientError::from(error),
+            poll_ready_tasks_response_to_result(response),
+            Err(StorageClientError::Transport(_))
+        ));
+    }
+
+    #[test]
+    fn map_inbound_status_maps_unavailable_to_inbound_closed() {
+        let status = tonic::Status::unavailable("inbound queue is closed");
+
+        assert!(matches!(
+            map_inbound_status(&status),
             StorageClientError::InboundClosed
         ));
     }
 
     #[test]
-    fn resend_ready_tasks_response_accepts_ok() {
-        let response = storage::ResendReadyTasksResponse {
-            result: Some(resend_ready_tasks_response::Result::Ok(storage::Void {})),
-        };
+    fn map_inbound_status_maps_invalid_argument_to_invalid_input() {
+        const MESSAGE: &str = "bad max_items";
+        let status = tonic::Status::invalid_argument(MESSAGE);
 
-        assert!(resend_ready_tasks_response_to_result(response).is_ok());
+        match map_inbound_status(&status) {
+            StorageClientError::InvalidInput(message) => assert_eq!(message, MESSAGE),
+            error => panic!("unexpected inbound status mapping: {error:?}"),
+        }
     }
 
     #[test]
-    fn resend_ready_tasks_response_maps_error() {
-        let response = storage::ResendReadyTasksResponse {
-            result: Some(resend_ready_tasks_response::Result::Error(
-                storage::InboundQueueResponseError {
-                    err_code: inbound_queue_response_error::ErrCode::InboundClosed.into(),
-                    message: "closed".to_owned(),
-                },
-            )),
-        };
+    fn map_inbound_status_maps_other_codes_to_server() {
+        let status = tonic::Status::internal("boom");
 
         assert!(matches!(
-            resend_ready_tasks_response_to_result(response),
-            Err(StorageClientError::InboundClosed)
-        ));
-    }
-
-    #[test]
-    fn resend_ready_tasks_response_rejects_missing_result() {
-        let response = storage::ResendReadyTasksResponse { result: None };
-
-        assert!(matches!(
-            resend_ready_tasks_response_to_result(response),
-            Err(StorageClientError::Transport(_))
+            map_inbound_status(&status),
+            StorageClientError::Server(_)
         ));
     }
 }

--- a/components/spider-scheduler/src/storage_client/grpc.rs
+++ b/components/spider-scheduler/src/storage_client/grpc.rs
@@ -133,8 +133,8 @@ impl SchedulerStorageClient for GrpcSchedulerStorageClient {
 ///
 /// # Returns
 ///
-/// * [`StorageClientError::InboundClosed`] when the inbound queue is closed (or the request was
-///   issued from a stale session), signalled by `UNAVAILABLE`.
+/// * [`StorageClientError::InboundClosed`] when the inbound queue is closed, signalled by
+///   `UNAVAILABLE`.
 /// * [`StorageClientError::InvalidInput`] for a malformed request, signalled by `INVALID_ARGUMENT`.
 /// * [`StorageClientError::Server`] for any other failure.
 fn map_inbound_status(status: &tonic::Status) -> StorageClientError {

--- a/components/spider-scheduler/src/storage_client/mod.rs
+++ b/components/spider-scheduler/src/storage_client/mod.rs
@@ -117,4 +117,20 @@ pub trait SchedulerStorageClient: Send + Sync + Clone {
     /// * [`StorageClientError::Server`] if the storage server returns an error.
     /// * [`StorageClientError::Transport`] if the storage server returns malformed data.
     async fn job_state(&self, job_id: JobId) -> Result<JobState, StorageClientError>;
+
+    /// Asks storage to re-enqueue the ready tasks of every cached job back onto the inbound queue.
+    ///
+    /// Used after a storage session change (e.g. a scheduler reconnect) to recover tasks that were
+    /// drained but not yet placed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * [`StorageClientError::InboundClosed`] if the inbound queue is closed and can no longer
+    ///   yield entries.
+    /// * [`StorageClientError::Server`] if the storage server returns an error.
+    /// * [`StorageClientError::Transport`] if the storage transport failed or returned malformed
+    ///   data.
+    async fn resend_ready_tasks(&self) -> Result<(), StorageClientError>;
 }

--- a/components/spider-storage/src/cache/job.rs
+++ b/components/spider-storage/src/cache/job.rs
@@ -200,6 +200,12 @@ impl<
         self.inner.id
     }
 
+    /// Returns the resource group that owns this job.
+    #[must_use]
+    pub fn resource_group_id(&self) -> ResourceGroupId {
+        self.inner.owner_id
+    }
+
     /// # Returns
     ///
     /// The current job state.

--- a/components/spider-storage/src/db/mariadb.rs
+++ b/components/spider-storage/src/db/mariadb.rs
@@ -482,13 +482,13 @@ impl ResourceGroupManagement for MariaDbStorageConnector {
 
         let mut tx = self.pool.begin().await?;
 
-        let existing_id: Option<ResourceGroupId> = sqlx::query_scalar(SELECT_FOR_UPDATE_QUERY)
+        let Some(_): Option<ResourceGroupId> = sqlx::query_scalar(SELECT_FOR_UPDATE_QUERY)
             .bind(resource_group_id)
             .fetch_optional(&mut *tx)
-            .await?;
-        if existing_id.is_none() {
+            .await?
+        else {
             return Err(DbError::ResourceGroupNotFound(resource_group_id));
-        }
+        };
 
         sqlx::query(DELETE_JOBS_QUERY)
             .bind(resource_group_id)

--- a/components/spider-storage/src/db/mariadb.rs
+++ b/components/spider-storage/src/db/mariadb.rs
@@ -466,8 +466,41 @@ impl ResourceGroupManagement for MariaDbStorageConnector {
         }
     }
 
-    async fn delete(&self, _resource_group_id: ResourceGroupId) -> Result<(), DbError> {
-        todo!("not implemented")
+    async fn delete(&self, resource_group_id: ResourceGroupId) -> Result<(), DbError> {
+        const SELECT_FOR_UPDATE_QUERY: &str = formatcp!(
+            "SELECT `id` FROM `{table}` WHERE `id` = ? FOR UPDATE;",
+            table = RESOURCE_GROUPS_TABLE_NAME,
+        );
+        const DELETE_JOBS_QUERY: &str = formatcp!(
+            "DELETE FROM `{table}` WHERE `resource_group_id` = ?;",
+            table = JOBS_TABLE_NAME,
+        );
+        const DELETE_RESOURCE_GROUP_QUERY: &str = formatcp!(
+            "DELETE FROM `{table}` WHERE `id` = ?;",
+            table = RESOURCE_GROUPS_TABLE_NAME,
+        );
+
+        let mut tx = self.pool.begin().await?;
+
+        let existing_id: Option<ResourceGroupId> = sqlx::query_scalar(SELECT_FOR_UPDATE_QUERY)
+            .bind(resource_group_id)
+            .fetch_optional(&mut *tx)
+            .await?;
+        if existing_id.is_none() {
+            return Err(DbError::ResourceGroupNotFound(resource_group_id));
+        }
+
+        sqlx::query(DELETE_JOBS_QUERY)
+            .bind(resource_group_id)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query(DELETE_RESOURCE_GROUP_QUERY)
+            .bind(resource_group_id)
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+        Ok(())
     }
 }
 

--- a/components/spider-storage/src/grpc.rs
+++ b/components/spider-storage/src/grpc.rs
@@ -227,6 +227,8 @@ impl<
     ///   * A fatal cache-internal error (the service will restart).
     ///   * Any other unexpected error (the service will restart).
     /// * `UNAVAILABLE` for a request issued from a stale session.
+    /// * `NOT_FOUND` for a request targeting a job that no longer exists in the cache (e.g. its
+    ///   resource group was deleted). Clients treat this as a benign no-op and drop the request.
     /// * `FAILED_PRECONDITION` for a request issued against a stale cache state.
     /// * `INVALID_ARGUMENT` for malformed inputs or a malformed request.
     pub fn task_instance_management_service_error_handler(
@@ -267,10 +269,12 @@ impl<
                     job_id = job_id.get(),
                     service = SERVICE_NAME,
                     tag,
-                    "The request attempts to access a job that does not exist in the cache."
+                    "The request targets a job that no longer exists in the cache."
                 );
-                // The absence of the job is considered a stale cache state.
-                Status::failed_precondition(format!("cache stale: {error}"))
+                // The job is gone (deleted or evicted), not transiently stale. Report it as
+                // NOT_FOUND so clients can drop the request as a benign no-op instead of retrying
+                // against a permanently missing job.
+                Status::not_found(error.to_string())
             }
 
             error @ (StorageServerError::Tdl(_) | StorageServerError::BadRequest(_)) => {
@@ -803,15 +807,15 @@ impl<
 
     async fn delete_resource_group(
         &self,
-        request: Request<storage::ResourceGroupIdRequest>,
+        request: Request<storage::DeleteResourceGroupRequest>,
     ) -> Result<Response<storage::ResourceGroupOperationResponse>, Status> {
-        let rg_id = request.into_inner().unpack()?;
+        let (rg_id, password) = request.into_inner().unpack()?;
         tracing::info!(
             rg_id = rg_id.get(),
             "Delete resource group request received."
         );
         self.inner
-            .delete_resource_group(rg_id)
+            .delete_resource_group(rg_id, &password)
             .await
             .map_err(|error| {
                 self.resource_group_management_service_error_handler(error, "delete_resource_group")
@@ -1117,8 +1121,9 @@ mod tests {
             .await?;
 
         service
-            .delete_resource_group(Request::new(storage::ResourceGroupIdRequest {
+            .delete_resource_group(Request::new(storage::DeleteResourceGroupRequest {
                 resource_group_id: rg_id,
+                password: password.clone(),
             }))
             .await?;
 
@@ -1130,6 +1135,31 @@ mod tests {
             .await;
         let status = verify_after_delete.expect_err("verify should fail after delete");
         assert_eq!(status.code(), Code::NotFound);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn delete_resource_group_rejects_wrong_password_as_unauthenticated() -> anyhow::Result<()>
+    {
+        let service = create_grpc_service();
+        let password = b"secret".to_vec();
+        let rg_id = service
+            .add_resource_group(Request::new(storage::AddResourceGroupRequest {
+                external_resource_group_id: "external-rg".to_owned(),
+                password: password.clone(),
+            }))
+            .await?
+            .into_inner()
+            .resource_group_id;
+
+        let result = service
+            .delete_resource_group(Request::new(storage::DeleteResourceGroupRequest {
+                resource_group_id: rg_id,
+                password: b"wrong".to_vec(),
+            }))
+            .await;
+        let status = result.expect_err("a wrong password should be rejected");
+        assert_eq!(status.code(), Code::Unauthenticated);
         Ok(())
     }
 
@@ -1155,6 +1185,22 @@ mod tests {
             .await;
         let status = result.expect_err("a wrong password should be rejected");
         assert_eq!(status.code(), Code::Unauthenticated);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn register_task_instance_reports_missing_job_as_not_found() -> anyhow::Result<()> {
+        let service = create_grpc_service();
+        let result = service
+            .register_task_instance(Request::new(storage::RegisterTaskInstanceRequest {
+                job_id: JobId::random().get(),
+                task_id: Some(storage::TaskId::from(TaskId::Index(0))),
+                execution_manager_id: ExecutionManagerId::from(1).get(),
+                session_id: TEST_SESSION_ID,
+            }))
+            .await;
+        let status = result.expect_err("an unknown job should be rejected");
+        assert_eq!(status.code(), Code::NotFound);
         Ok(())
     }
 

--- a/components/spider-storage/src/grpc.rs
+++ b/components/spider-storage/src/grpc.rs
@@ -75,8 +75,8 @@ impl<
     /// The [`Status`] to send to the client:
     ///
     /// * `UNAVAILABLE` for a fatal cache-internal error (the service will restart).
-    /// * `UNAUTHENTICATED` for an unknown or unauthorized resource group.
-    /// * `NOT_FOUND` for a missing job.
+    /// * `UNAUTHENTICATED` for a wrong resource-group password.
+    /// * `NOT_FOUND` for an unknown resource group or a missing job.
     /// * `FAILED_PRECONDITION` for operations on an invalid job state.
     /// * `INVALID_ARGUMENT` for a malformed task graph, inputs, or request.
     /// * `INTERNAL` for any other (database or otherwise unexpected) error.
@@ -99,14 +99,23 @@ impl<
             }
 
             StorageServerError::Db(db_error) => match &db_error {
-                DbError::ResourceGroupNotFound(_) | DbError::InvalidPassword(_) => {
+                DbError::ResourceGroupNotFound(_) => {
                     tracing::warn!(
                         error = % db_error,
                         service = SERVICE_NAME,
                         tag,
-                        "Invalid resource group."
+                        "Resource group not found."
                     );
-                    Status::unauthenticated("invalid resource group")
+                    Status::not_found(db_error.to_string())
+                }
+                DbError::InvalidPassword(_) => {
+                    tracing::warn!(
+                        error = % db_error,
+                        service = SERVICE_NAME,
+                        tag,
+                        "Invalid resource group password."
+                    );
+                    Status::unauthenticated(db_error.to_string())
                 }
                 DbError::JobNotFound(_) => {
                     tracing::warn!(
@@ -270,7 +279,7 @@ impl<
     /// The [`Status`] to send to the client:
     ///
     /// * `UNAVAILABLE` when the ready-queue channel is closed (the inbound queue can no longer
-    ///   yield entries) or the request was issued from a stale session.
+    ///   yield entries).
     /// * `INTERNAL` for a fatal cache-internal error (the service will restart) or any other
     ///   unexpected failure.
     pub fn inbound_queue_service_error_handler(
@@ -302,18 +311,6 @@ impl<
                 Status::internal("storage service unavailable")
             }
 
-            StorageServerError::StaleSession(storage_session) => {
-                tracing::warn!(
-                    storage_session,
-                    service = SERVICE_NAME,
-                    tag,
-                    "The request was issued from a stale session."
-                );
-                Status::unavailable(format!(
-                    "stale session; current storage session is {storage_session}"
-                ))
-            }
-
             error => {
                 tracing::error!(
                     error = % error,
@@ -337,7 +334,7 @@ impl<
     /// The [`Status`] to send to the client:
     ///
     /// * `NOT_FOUND` for an unknown resource group.
-    /// * `INVALID_ARGUMENT` for a wrong password.
+    /// * `UNAUTHENTICATED` for a wrong password.
     /// * `ALREADY_EXISTS` for a duplicate external resource group ID.
     /// * `INTERNAL` for a fatal cache-internal error (the service will restart) or any other
     ///   unexpected failure.
@@ -365,7 +362,7 @@ impl<
                     tag,
                     "Invalid resource group password."
                 );
-                Status::invalid_argument(error.to_string())
+                Status::unauthenticated(error.to_string())
             }
 
             error @ StorageServerError::Db(DbError::ResourceGroupAlreadyExists(_)) => {
@@ -501,8 +498,9 @@ impl<
                     error = % error,
                     service = SERVICE_NAME,
                     tag,
-                    "Unexpected internal error."
+                    "Unexpected internal error. Cancelling service to avoid cache corruption."
                 );
+                self.cancellation_token.cancel();
                 Status::internal("internal error")
             }
         }
@@ -1162,6 +1160,31 @@ mod tests {
             .await;
         let status = verify_after_delete.expect_err("verify should fail after delete");
         assert_eq!(status.code(), Code::NotFound);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn verify_resource_group_rejects_wrong_password_as_unauthenticated() -> anyhow::Result<()>
+    {
+        let service = create_grpc_service();
+        let password = b"secret".to_vec();
+        let rg_id = service
+            .add_resource_group(Request::new(storage::AddResourceGroupRequest {
+                external_resource_group_id: "external-rg".to_owned(),
+                password: password.clone(),
+            }))
+            .await?
+            .into_inner()
+            .resource_group_id;
+
+        let result = service
+            .verify_resource_group(Request::new(storage::VerifyResourceGroupRequest {
+                resource_group_id: rg_id,
+                password: b"wrong".to_vec(),
+            }))
+            .await;
+        let status = result.expect_err("a wrong password should be rejected");
+        assert_eq!(status.code(), Code::Unauthenticated);
         Ok(())
     }
 

--- a/components/spider-storage/src/grpc.rs
+++ b/components/spider-storage/src/grpc.rs
@@ -1,17 +1,25 @@
 //! gRPC service adapters for the storage runtime.
 
 use async_trait::async_trait;
-use spider_core::types::id::TaskId;
+use spider_core::types::id::{SessionId, TaskId};
 use spider_proto_rust::{
     storage::{
         self,
         execution_manager_liveness_service_server::ExecutionManagerLivenessService,
+        get_schedulers_response,
         inbound_queue_service_server::InboundQueueService,
         job_orchestration_service_server::JobOrchestrationService,
+        poll_ready_tasks_response,
+        register_execution_manager_response,
+        register_scheduler_response,
+        resend_ready_tasks_response,
+        resource_group_id_response,
         resource_group_management_service_server::ResourceGroupManagementService,
+        resource_group_operation_response,
         scheduler_registration_service_server::SchedulerRegistrationService,
         session_management_service_server::SessionManagementService,
         task_instance_management_service_server::TaskInstanceManagementService,
+        update_execution_manager_heartbeat_response,
     },
     unpack::RequestUnpack,
 };
@@ -19,9 +27,9 @@ use tokio_util::sync::CancellationToken;
 use tonic::{Request, Response, Status};
 
 use crate::{
-    cache::error::CacheError,
+    cache::error::{CacheError, InternalError},
     db::{DbError, DbStorage},
-    ready_queue::ReadyQueueSender,
+    ready_queue::{CleanupTaskMarker, CommitTaskMarker, ReadyQueueEntry, ReadyQueueSender},
     state::{ServiceState, StorageServerError},
     task_instance_pool::TaskInstancePoolConnector,
 };
@@ -486,23 +494,78 @@ impl<
 {
     async fn poll_ready_tasks(
         &self,
-        _request: Request<storage::PollReadyTasksRequest>,
+        request: Request<storage::PollReadyTasksRequest>,
     ) -> Result<Response<storage::PollReadyTasksResponse>, Status> {
-        todo!("Not implemented")
+        let (max_items, wait) = request.into_inner().unpack()?;
+        tracing::debug!(max_items, ?wait, "Poll ready tasks request received.");
+        let result = match self.inner.poll_ready_tasks(max_items, wait).await {
+            Ok(entries) => poll_ready_tasks_response::Result::Tasks(ready_tasks(
+                self.inner.session_id(),
+                entries,
+            )),
+            Err(error) => poll_ready_tasks_response::Result::Error(to_inbound_error(&error)),
+        };
+        Ok(Response::new(storage::PollReadyTasksResponse {
+            result: Some(result),
+        }))
     }
 
     async fn poll_ready_commit_tasks(
         &self,
-        _request: Request<storage::PollReadyTasksRequest>,
+        request: Request<storage::PollReadyTasksRequest>,
     ) -> Result<Response<storage::PollReadyTasksResponse>, Status> {
-        todo!("Not implemented")
+        let (max_items, wait) = request.into_inner().unpack()?;
+        tracing::debug!(
+            max_items,
+            ?wait,
+            "Poll ready commit tasks request received."
+        );
+        let result = match self.inner.poll_commit_ready_tasks(max_items, wait).await {
+            Ok(entries) => poll_ready_tasks_response::Result::Tasks(ready_tasks(
+                self.inner.session_id(),
+                entries,
+            )),
+            Err(error) => poll_ready_tasks_response::Result::Error(to_inbound_error(&error)),
+        };
+        Ok(Response::new(storage::PollReadyTasksResponse {
+            result: Some(result),
+        }))
     }
 
     async fn poll_ready_cleanup_tasks(
         &self,
-        _request: Request<storage::PollReadyTasksRequest>,
+        request: Request<storage::PollReadyTasksRequest>,
     ) -> Result<Response<storage::PollReadyTasksResponse>, Status> {
-        todo!("Not implemented")
+        let (max_items, wait) = request.into_inner().unpack()?;
+        tracing::debug!(
+            max_items,
+            ?wait,
+            "Poll ready cleanup tasks request received."
+        );
+        let result = match self.inner.poll_cleanup_ready_tasks(max_items, wait).await {
+            Ok(entries) => poll_ready_tasks_response::Result::Tasks(ready_tasks(
+                self.inner.session_id(),
+                entries,
+            )),
+            Err(error) => poll_ready_tasks_response::Result::Error(to_inbound_error(&error)),
+        };
+        Ok(Response::new(storage::PollReadyTasksResponse {
+            result: Some(result),
+        }))
+    }
+
+    async fn resend_ready_tasks(
+        &self,
+        _request: Request<storage::ResendReadyTasksRequest>,
+    ) -> Result<Response<storage::ResendReadyTasksResponse>, Status> {
+        tracing::info!("Resend ready tasks request received.");
+        let result = match self.inner.resend_ready_tasks().await {
+            Ok(()) => resend_ready_tasks_response::Result::Ok(storage::Void {}),
+            Err(error) => resend_ready_tasks_response::Result::Error(to_inbound_error(&error)),
+        };
+        Ok(Response::new(storage::ResendReadyTasksResponse {
+            result: Some(result),
+        }))
     }
 }
 
@@ -516,16 +579,84 @@ impl<
 {
     async fn add_resource_group(
         &self,
-        _request: Request<storage::AddResourceGroupRequest>,
+        request: Request<storage::AddResourceGroupRequest>,
     ) -> Result<Response<storage::ResourceGroupIdResponse>, Status> {
-        todo!("Not implemented")
+        let (external_id, password, request_session_id) = request.into_inner().unpack()?;
+        tracing::info!(external_id = % external_id, "Add resource group request received.");
+        let current_session = self.inner.session_id();
+        let result = if request_session_id == current_session {
+            match self.inner.add_resource_group(external_id, password).await {
+                Ok(rg_id) => resource_group_id_response::Result::ResourceGroupId(rg_id.get()),
+                Err(error) => resource_group_id_response::Result::Error(to_resource_group_error(
+                    &error,
+                    current_session,
+                )),
+            }
+        } else {
+            resource_group_id_response::Result::Error(to_resource_group_error(
+                &StorageServerError::StaleSession(current_session),
+                current_session,
+            ))
+        };
+        Ok(Response::new(storage::ResourceGroupIdResponse {
+            result: Some(result),
+        }))
     }
 
     async fn verify_resource_group(
         &self,
-        _request: Request<storage::VerifyResourceGroupRequest>,
+        request: Request<storage::VerifyResourceGroupRequest>,
     ) -> Result<Response<storage::ResourceGroupOperationResponse>, Status> {
-        todo!("Not implemented")
+        let (rg_id, password, request_session_id) = request.into_inner().unpack()?;
+        tracing::info!(
+            rg_id = rg_id.get(),
+            "Verify resource group request received."
+        );
+        let current_session = self.inner.session_id();
+        let result = if request_session_id == current_session {
+            match self.inner.verify_resource_group(rg_id, &password).await {
+                Ok(()) => resource_group_operation_response::Result::Ok(storage::Void {}),
+                Err(error) => resource_group_operation_response::Result::Error(
+                    to_resource_group_error(&error, current_session),
+                ),
+            }
+        } else {
+            resource_group_operation_response::Result::Error(to_resource_group_error(
+                &StorageServerError::StaleSession(current_session),
+                current_session,
+            ))
+        };
+        Ok(Response::new(storage::ResourceGroupOperationResponse {
+            result: Some(result),
+        }))
+    }
+
+    async fn delete_resource_group(
+        &self,
+        request: Request<storage::ResourceGroupIdRequest>,
+    ) -> Result<Response<storage::ResourceGroupOperationResponse>, Status> {
+        let (rg_id, request_session_id) = request.into_inner().unpack()?;
+        tracing::info!(
+            rg_id = rg_id.get(),
+            "Delete resource group request received."
+        );
+        let current_session = self.inner.session_id();
+        let result = if request_session_id == current_session {
+            match self.inner.delete_resource_group(rg_id).await {
+                Ok(()) => resource_group_operation_response::Result::Ok(storage::Void {}),
+                Err(error) => resource_group_operation_response::Result::Error(
+                    to_resource_group_error(&error, current_session),
+                ),
+            }
+        } else {
+            resource_group_operation_response::Result::Error(to_resource_group_error(
+                &StorageServerError::StaleSession(current_session),
+                current_session,
+            ))
+        };
+        Ok(Response::new(storage::ResourceGroupOperationResponse {
+            result: Some(result),
+        }))
     }
 }
 
@@ -539,16 +670,48 @@ impl<
 {
     async fn register_execution_manager(
         &self,
-        _request: Request<storage::RegisterExecutionManagerRequest>,
+        request: Request<storage::RegisterExecutionManagerRequest>,
     ) -> Result<Response<storage::RegisterExecutionManagerResponse>, Status> {
-        todo!("Not implemented")
+        let ip_address = request.into_inner().unpack()?;
+        tracing::info!(% ip_address, "Execution manager registration request received.");
+        let result = match self.inner.register_execution_manager(ip_address).await {
+            Ok(em_id) => register_execution_manager_response::Result::Registration(
+                storage::ExecutionManagerRegistration {
+                    execution_manager_id: em_id.get(),
+                    session_id: self.inner.session_id(),
+                },
+            ),
+            Err(error) => {
+                register_execution_manager_response::Result::Error(to_liveness_error(&error))
+            }
+        };
+        Ok(Response::new(storage::RegisterExecutionManagerResponse {
+            result: Some(result),
+        }))
     }
 
     async fn update_execution_manager_heartbeat(
         &self,
-        _request: Request<storage::ExecutionManagerIdRequest>,
+        request: Request<storage::ExecutionManagerIdRequest>,
     ) -> Result<Response<storage::UpdateExecutionManagerHeartbeatResponse>, Status> {
-        todo!("Not implemented")
+        let em_id = request.into_inner().unpack()?;
+        tracing::info!(
+            em_id = em_id.get(),
+            "Execution manager heartbeat request received."
+        );
+        let result = match self.inner.update_execution_manager_heartbeat(em_id).await {
+            Ok(()) => update_execution_manager_heartbeat_response::Result::SessionId(
+                self.inner.session_id(),
+            ),
+            Err(error) => update_execution_manager_heartbeat_response::Result::Error(
+                to_liveness_error(&error),
+            ),
+        };
+        Ok(Response::new(
+            storage::UpdateExecutionManagerHeartbeatResponse {
+                result: Some(result),
+            },
+        ))
     }
 }
 
@@ -562,16 +725,43 @@ impl<
 {
     async fn register_scheduler(
         &self,
-        _request: Request<storage::RegisterSchedulerRequest>,
+        request: Request<storage::RegisterSchedulerRequest>,
     ) -> Result<Response<storage::RegisterSchedulerResponse>, Status> {
-        todo!("Not implemented")
+        let (ip_address, port) = request.into_inner().unpack()?;
+        tracing::info!(% ip_address, port, "Scheduler registration request received.");
+        let result = match self.inner.register_scheduler(ip_address, port).await {
+            Ok(scheduler_id) => {
+                register_scheduler_response::Result::Registration(storage::SchedulerRegistration {
+                    scheduler_id: scheduler_id.get(),
+                    session_id: self.inner.session_id(),
+                })
+            }
+            Err(error) => register_scheduler_response::Result::Error(to_scheduler_error(&error)),
+        };
+        Ok(Response::new(storage::RegisterSchedulerResponse {
+            result: Some(result),
+        }))
     }
 
     async fn get_schedulers(
         &self,
         _request: Request<storage::Void>,
     ) -> Result<Response<storage::GetSchedulersResponse>, Status> {
-        todo!("Not implemented")
+        tracing::info!("Get schedulers request received.");
+        let result = match self.inner.get_schedulers().await {
+            Ok(schedulers) => {
+                get_schedulers_response::Result::Schedulers(storage::SchedulerRegistrations {
+                    schedulers: schedulers
+                        .into_iter()
+                        .map(storage::Scheduler::from)
+                        .collect(),
+                })
+            }
+            Err(error) => get_schedulers_response::Result::Error(to_scheduler_error(&error)),
+        };
+        Ok(Response::new(storage::GetSchedulersResponse {
+            result: Some(result),
+        }))
     }
 }
 
@@ -587,7 +777,145 @@ impl<
         &self,
         _request: Request<storage::Void>,
     ) -> Result<Response<storage::GetSessionResponse>, Status> {
-        todo!("Not implemented")
+        let session_id = self.inner.session_id();
+        tracing::info!(session_id, "Get session request received.");
+        Ok(Response::new(storage::GetSessionResponse { session_id }))
+    }
+}
+
+/// Converts a ready-queue task kind into its protobuf [`storage::TaskId`] form.
+trait ToProtoTaskId {
+    /// # Returns
+    ///
+    /// The protobuf task ID for this ready-queue lane marker.
+    fn to_proto_task_id(self) -> storage::TaskId;
+}
+
+impl ToProtoTaskId for spider_core::task::TaskIndex {
+    fn to_proto_task_id(self) -> storage::TaskId {
+        storage::TaskId::from(TaskId::Index(self))
+    }
+}
+
+impl ToProtoTaskId for CommitTaskMarker {
+    fn to_proto_task_id(self) -> storage::TaskId {
+        storage::TaskId::from(TaskId::Commit)
+    }
+}
+
+impl ToProtoTaskId for CleanupTaskMarker {
+    fn to_proto_task_id(self) -> storage::TaskId {
+        storage::TaskId::from(TaskId::Cleanup)
+    }
+}
+
+/// Builds a [`storage::ReadyTasks`] message from a batch of ready-queue entries.
+///
+/// # Returns
+///
+/// A [`storage::ReadyTasks`] carrying the storage session and the flattened ready tasks.
+fn ready_tasks<TaskKind: ToProtoTaskId>(
+    session_id: SessionId,
+    entries: Vec<ReadyQueueEntry<TaskKind>>,
+) -> storage::ReadyTasks {
+    let tasks = entries
+        .into_iter()
+        .map(|entry| {
+            let resource_group_id = entry.resource_group_id.get();
+            let job_id = entry.job_id.get();
+            let task_id = entry.task_kind.to_proto_task_id();
+            storage::ReadyTask {
+                resource_group_id,
+                job_id,
+                task_id: Some(task_id),
+            }
+        })
+        .collect();
+    storage::ReadyTasks { session_id, tasks }
+}
+
+/// Maps an inbound-queue [`StorageServerError`] to a protobuf
+/// [`storage::InboundQueueResponseError`].
+///
+/// # Returns
+///
+/// * `INBOUND_CLOSED` when the ready-queue channel is closed.
+/// * `SERVER` for any other failure.
+fn to_inbound_error(error: &StorageServerError) -> storage::InboundQueueResponseError {
+    use storage::inbound_queue_response_error::ErrCode;
+    let err_code = match error {
+        StorageServerError::Cache(CacheError::Internal(InternalError::ReadyQueueChannelClosed)) => {
+            ErrCode::InboundClosed
+        }
+        _ => ErrCode::Server,
+    };
+    storage::InboundQueueResponseError {
+        err_code: err_code.into(),
+        message: error.to_string(),
+    }
+}
+
+/// Maps a resource-group [`StorageServerError`] to a protobuf
+/// [`storage::ResourceGroupManagementError`].
+///
+/// # Returns
+///
+/// * `STALE_SESSION` when the request was issued against a stale storage session.
+/// * `INVALID_INPUT` for an unknown resource group, a wrong password, or a duplicate external ID.
+/// * `SERVER` for any other failure.
+fn to_resource_group_error(
+    error: &StorageServerError,
+    current_session: SessionId,
+) -> storage::ResourceGroupManagementError {
+    use storage::resource_group_management_error::ErrCode;
+    let err_code = match error {
+        StorageServerError::StaleSession(_) => ErrCode::StaleSession,
+        StorageServerError::Db(
+            DbError::ResourceGroupNotFound(_)
+            | DbError::InvalidPassword(_)
+            | DbError::ResourceGroupAlreadyExists(_),
+        ) => ErrCode::InvalidInput,
+        _ => ErrCode::Server,
+    };
+    storage::ResourceGroupManagementError {
+        err_code: err_code.into(),
+        message: error.to_string(),
+        storage_session: current_session,
+    }
+}
+
+/// Maps an execution-manager-liveness [`StorageServerError`] to a protobuf
+/// [`storage::ExecutionManagerLivenessError`].
+///
+/// # Returns
+///
+/// * `MARKED_DEAD` when the execution manager has already been reaped.
+/// * `INVALID_INPUT` for an illegal execution manager ID.
+/// * `SERVER` for any other failure.
+fn to_liveness_error(error: &StorageServerError) -> storage::ExecutionManagerLivenessError {
+    use storage::execution_manager_liveness_error::ErrCode;
+    let err_code = match error {
+        StorageServerError::Db(DbError::ExecutionManagerAlreadyDead(_)) => ErrCode::MarkedDead,
+        StorageServerError::Db(DbError::IllegalExecutionManagerId(_)) => ErrCode::InvalidInput,
+        _ => ErrCode::Server,
+    };
+    storage::ExecutionManagerLivenessError {
+        err_code: err_code.into(),
+        message: error.to_string(),
+    }
+}
+
+/// Maps a scheduler-registration [`StorageServerError`] to a protobuf
+/// [`storage::SchedulerRegistrationError`].
+///
+/// # Returns
+///
+/// `SERVER` for any failure; scheduler registration currently has no caller-visible error
+/// classification beyond a generic server error.
+fn to_scheduler_error(error: &StorageServerError) -> storage::SchedulerRegistrationError {
+    storage::SchedulerRegistrationError {
+        err_code: storage::scheduler_registration_error::ErrCode::Server.into(),
+        message: error.to_string(),
     }
 }
 
@@ -600,4 +928,320 @@ fn make_job_state_response(
     Response::new(storage::JobStateResponse {
         state: storage::JobState::from(state).into(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use spider_core::types::id::{ExecutionManagerId, JobId, ResourceGroupId, SessionId};
+    use tokio_util::sync::CancellationToken;
+    use tonic::Request;
+
+    use super::*;
+    use crate::{
+        ready_queue::{ReadyQueueConfig, ReadyQueueSenderHandle, create_ready_queue},
+        state::{
+            JobCache,
+            JobCacheGcHandle,
+            test_utils::{MockDbConnector, MockReadyQueueSender, MockTaskInstancePoolConnector},
+        },
+    };
+
+    type TestGrpcState =
+        GrpcServiceState<MockReadyQueueSender, MockDbConnector, MockTaskInstancePoolConnector>;
+
+    type TestGrpcStateWithReadyQueue =
+        GrpcServiceState<ReadyQueueSenderHandle, MockDbConnector, MockTaskInstancePoolConnector>;
+
+    const TEST_SESSION_ID: SessionId = 0;
+
+    fn create_grpc_service() -> TestGrpcState {
+        create_grpc_service_with_db(MockDbConnector::default())
+    }
+
+    fn create_grpc_service_with_db(db: MockDbConnector) -> TestGrpcState {
+        let (_sender, receiver) =
+            create_ready_queue(&ReadyQueueConfig::default()).expect("ready queue creation");
+        let service = ServiceState::new(
+            db,
+            TEST_SESSION_ID,
+            JobCache::new(),
+            MockReadyQueueSender,
+            receiver,
+            MockTaskInstancePoolConnector,
+            JobCacheGcHandle::new(tokio::sync::mpsc::unbounded_channel().0),
+        );
+        GrpcServiceState::new(service, CancellationToken::new())
+    }
+
+    fn create_grpc_service_with_ready_queue(
+        db: MockDbConnector,
+    ) -> (TestGrpcStateWithReadyQueue, ReadyQueueSenderHandle) {
+        let (sender, receiver) =
+            create_ready_queue(&ReadyQueueConfig::default()).expect("ready queue creation");
+        let service = ServiceState::new(
+            db,
+            TEST_SESSION_ID,
+            JobCache::new(),
+            sender.clone(),
+            receiver,
+            MockTaskInstancePoolConnector,
+            JobCacheGcHandle::new(tokio::sync::mpsc::unbounded_channel().0),
+        );
+        (
+            GrpcServiceState::new(service, CancellationToken::new()),
+            sender,
+        )
+    }
+
+    #[tokio::test]
+    async fn get_session_returns_service_session_id() -> anyhow::Result<()> {
+        let service = create_grpc_service();
+        let response = service
+            .get_session(Request::new(storage::Void {}))
+            .await?
+            .into_inner();
+        assert_eq!(response.session_id, TEST_SESSION_ID);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn add_verify_delete_resource_group_round_trip() -> anyhow::Result<()> {
+        let service = create_grpc_service();
+        let password = b"secret".to_vec();
+
+        let add_response = service
+            .add_resource_group(Request::new(storage::AddResourceGroupRequest {
+                external_resource_group_id: "external-rg".to_owned(),
+                password: password.clone(),
+                session_id: TEST_SESSION_ID,
+            }))
+            .await?
+            .into_inner();
+        let rg_id = match add_response.result {
+            Some(resource_group_id_response::Result::ResourceGroupId(rg_id)) => rg_id,
+            other => panic!("expected a resource group id, got {other:?}"),
+        };
+
+        let verify_response = service
+            .verify_resource_group(Request::new(storage::VerifyResourceGroupRequest {
+                resource_group_id: rg_id,
+                password: password.clone(),
+                session_id: TEST_SESSION_ID,
+            }))
+            .await?
+            .into_inner();
+        assert!(matches!(
+            verify_response.result,
+            Some(resource_group_operation_response::Result::Ok(_))
+        ));
+
+        let delete_response = service
+            .delete_resource_group(Request::new(storage::ResourceGroupIdRequest {
+                resource_group_id: rg_id,
+                session_id: TEST_SESSION_ID,
+            }))
+            .await?
+            .into_inner();
+        assert!(matches!(
+            delete_response.result,
+            Some(resource_group_operation_response::Result::Ok(_))
+        ));
+
+        let verify_after_delete = service
+            .verify_resource_group(Request::new(storage::VerifyResourceGroupRequest {
+                resource_group_id: rg_id,
+                password,
+                session_id: TEST_SESSION_ID,
+            }))
+            .await?
+            .into_inner();
+        assert!(matches!(
+            verify_after_delete.result,
+            Some(resource_group_operation_response::Result::Error(_))
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn add_resource_group_rejects_stale_session() -> anyhow::Result<()> {
+        let service = create_grpc_service();
+        let response = service
+            .add_resource_group(Request::new(storage::AddResourceGroupRequest {
+                external_resource_group_id: "external-rg".to_owned(),
+                password: b"secret".to_vec(),
+                session_id: TEST_SESSION_ID + 1,
+            }))
+            .await?
+            .into_inner();
+        match response.result {
+            Some(resource_group_id_response::Result::Error(error)) => {
+                assert_eq!(
+                    storage::resource_group_management_error::ErrCode::try_from(error.err_code)
+                        .expect("valid err code"),
+                    storage::resource_group_management_error::ErrCode::StaleSession
+                );
+                assert_eq!(error.storage_session, TEST_SESSION_ID);
+            }
+            other => panic!("expected a stale-session error, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn register_execution_manager_returns_id_and_session() -> anyhow::Result<()> {
+        let service = create_grpc_service();
+        let response = service
+            .register_execution_manager(Request::new(storage::RegisterExecutionManagerRequest {
+                ip_address: "127.0.0.1".to_owned(),
+            }))
+            .await?
+            .into_inner();
+        let registration = match response.result {
+            Some(register_execution_manager_response::Result::Registration(registration)) => {
+                registration
+            }
+            other => panic!("expected a registration, got {other:?}"),
+        };
+        assert_eq!(registration.session_id, TEST_SESSION_ID);
+        assert_ne!(registration.execution_manager_id, 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn heartbeat_returns_session_for_registered_em() -> anyhow::Result<()> {
+        let service = create_grpc_service();
+        let em_id = service
+            .register_execution_manager(Request::new(storage::RegisterExecutionManagerRequest {
+                ip_address: "127.0.0.1".to_owned(),
+            }))
+            .await?
+            .into_inner()
+            .result
+            .and_then(|result| match result {
+                register_execution_manager_response::Result::Registration(registration) => {
+                    Some(registration.execution_manager_id)
+                }
+                register_execution_manager_response::Result::Error(_) => None,
+            })
+            .expect("registration should succeed");
+
+        let response = service
+            .update_execution_manager_heartbeat(Request::new(storage::ExecutionManagerIdRequest {
+                execution_manager_id: em_id,
+            }))
+            .await?
+            .into_inner();
+        assert!(matches!(
+            response.result,
+            Some(update_execution_manager_heartbeat_response::Result::SessionId(TEST_SESSION_ID))
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn heartbeat_rejects_unknown_em() -> anyhow::Result<()> {
+        let service = create_grpc_service();
+        let response = service
+            .update_execution_manager_heartbeat(Request::new(storage::ExecutionManagerIdRequest {
+                execution_manager_id: ExecutionManagerId::from(999).get(),
+            }))
+            .await?
+            .into_inner();
+        match response.result {
+            Some(update_execution_manager_heartbeat_response::Result::Error(error)) => {
+                assert_eq!(
+                    storage::execution_manager_liveness_error::ErrCode::try_from(error.err_code)
+                        .expect("valid err code"),
+                    storage::execution_manager_liveness_error::ErrCode::InvalidInput
+                );
+            }
+            other => panic!("expected an invalid-input error, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn register_and_get_schedulers() -> anyhow::Result<()> {
+        let service = create_grpc_service();
+        let register_response = service
+            .register_scheduler(Request::new(storage::RegisterSchedulerRequest {
+                ip_address: "127.0.0.1".to_owned(),
+                port: 5678,
+            }))
+            .await?
+            .into_inner();
+        let scheduler_id = match register_response.result {
+            Some(register_scheduler_response::Result::Registration(registration)) => {
+                registration.scheduler_id
+            }
+            other => panic!("expected a registration, got {other:?}"),
+        };
+        assert_eq!(
+            register_response
+                .result
+                .and_then(|result| match result {
+                    register_scheduler_response::Result::Registration(registration) => {
+                        Some(registration.session_id)
+                    }
+                    register_scheduler_response::Result::Error(_) => None,
+                })
+                .expect("session id should be present"),
+            TEST_SESSION_ID
+        );
+
+        let get_response = service
+            .get_schedulers(Request::new(storage::Void {}))
+            .await?
+            .into_inner();
+        let schedulers = match get_response.result {
+            Some(get_schedulers_response::Result::Schedulers(registrations)) => registrations,
+            other => panic!("expected schedulers, got {other:?}"),
+        };
+        assert_eq!(schedulers.schedulers.len(), 1);
+        assert_eq!(schedulers.schedulers[0].scheduler_id, scheduler_id);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn resend_ready_tasks_succeeds() -> anyhow::Result<()> {
+        let service = create_grpc_service();
+        let response = service
+            .resend_ready_tasks(Request::new(storage::ResendReadyTasksRequest {}))
+            .await?
+            .into_inner();
+        assert!(matches!(
+            response.result,
+            Some(resend_ready_tasks_response::Result::Ok(_))
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn poll_ready_tasks_returns_entries() -> anyhow::Result<()> {
+        const TASK_INDEX: usize = 3;
+        let (service, sender) = create_grpc_service_with_ready_queue(MockDbConnector::default());
+        let rg_id = ResourceGroupId::from(7);
+        let job_id = JobId::from(11);
+        sender
+            .send_task_ready(rg_id, job_id, vec![TASK_INDEX])
+            .await
+            .expect("send_task_ready should succeed");
+
+        let response = service
+            .poll_ready_tasks(Request::new(storage::PollReadyTasksRequest {
+                max_items: 10,
+                wait_ms: 100,
+            }))
+            .await?
+            .into_inner();
+        let tasks = match response.result {
+            Some(poll_ready_tasks_response::Result::Tasks(tasks)) => tasks,
+            other => panic!("expected ready tasks, got {other:?}"),
+        };
+        assert_eq!(tasks.session_id, TEST_SESSION_ID);
+        assert_eq!(tasks.tasks.len(), 1);
+        assert_eq!(tasks.tasks[0].resource_group_id, rg_id.get());
+        assert_eq!(tasks.tasks[0].job_id, job_id.get());
+        Ok(())
+    }
 }

--- a/components/spider-storage/src/grpc.rs
+++ b/components/spider-storage/src/grpc.rs
@@ -65,6 +65,55 @@ impl<
         }
     }
 
+    /// Logs a fatal cache-internal error, cancels the service, and returns an `INTERNAL` status.
+    ///
+    /// Shared by every service error handler for the `Cache(CacheError::Internal)` arm. The error
+    /// is unrecoverable, so the whole storage service is cancelled to avoid cache corruption.
+    ///
+    /// # Returns
+    ///
+    /// `Status::internal("storage service unavailable")`.
+    fn fatal_internal_status(
+        &self,
+        service_name: &'static str,
+        tag: &'static str,
+        error: &InternalError,
+    ) -> Status {
+        tracing::error!(
+            error = % error,
+            service = service_name,
+            tag,
+            "Internal error in the cache layer. Cancelling service."
+        );
+        self.cancellation_token.cancel();
+        Status::internal("storage service unavailable")
+    }
+
+    /// Logs an unexpected error, cancels the service, and returns an `INTERNAL` status.
+    ///
+    /// Shared by every service error handler for the catch-all fallback arm. An unmapped error is
+    /// treated as unrecoverable, so the whole storage service is cancelled to avoid cache
+    /// corruption.
+    ///
+    /// # Returns
+    ///
+    /// `Status::internal("internal error")`.
+    fn unexpected_internal_status(
+        &self,
+        service_name: &'static str,
+        tag: &'static str,
+        error: &StorageServerError,
+    ) -> Status {
+        tracing::error!(
+            error = % error,
+            service = service_name,
+            tag,
+            "Unexpected internal error. Cancelling service to avoid cache corruption."
+        );
+        self.cancellation_token.cancel();
+        Status::internal("internal error")
+    }
+
     /// Error handler for job orchestration service errors.
     ///
     /// This function maps the given [`StorageServerError`] to a [`Status`] that can be sent to the
@@ -88,14 +137,7 @@ impl<
         const SERVICE_NAME: &str = "JobOrchestration";
         match error {
             StorageServerError::Cache(CacheError::Internal(e)) => {
-                tracing::error!(
-                    error = % e,
-                    service = SERVICE_NAME,
-                    tag,
-                    "Internal error in the cache layer. Cancelling service."
-                );
-                self.cancellation_token.cancel();
-                Status::internal("storage service unavailable")
+                self.fatal_internal_status(SERVICE_NAME, tag, &e)
             }
 
             StorageServerError::Db(db_error) => match &db_error {
@@ -168,16 +210,7 @@ impl<
                 Status::invalid_argument(error.to_string())
             }
 
-            _ => {
-                tracing::error!(
-                    error = % error,
-                    service = SERVICE_NAME,
-                    tag,
-                    "Unexpected internal error. Cancelling service to avoid cache corruption."
-                );
-                self.cancellation_token.cancel();
-                Status::internal("internal error")
-            }
+            _ => self.unexpected_internal_status(SERVICE_NAME, tag, &error),
         }
     }
 
@@ -204,14 +237,7 @@ impl<
         const SERVICE_NAME: &str = "TaskInstanceManagement";
         match error {
             StorageServerError::Cache(CacheError::Internal(e)) => {
-                tracing::error!(
-                    error = % e,
-                    service = SERVICE_NAME,
-                    tag,
-                    "Internal error in the cache layer. Cancelling service."
-                );
-                self.cancellation_token.cancel();
-                Status::internal("storage service unavailable")
+                self.fatal_internal_status(SERVICE_NAME, tag, &e)
             }
 
             StorageServerError::StaleSession(storage_session) => {
@@ -257,16 +283,7 @@ impl<
                 Status::invalid_argument(error.to_string())
             }
 
-            _ => {
-                tracing::error!(
-                    error = % error,
-                    service = SERVICE_NAME,
-                    tag,
-                    "Unexpected internal error. Cancelling service to avoid cache corruption."
-                );
-                self.cancellation_token.cancel();
-                Status::internal("internal error")
-            }
+            _ => self.unexpected_internal_status(SERVICE_NAME, tag, &error),
         }
     }
 
@@ -302,26 +319,10 @@ impl<
             }
 
             StorageServerError::Cache(CacheError::Internal(e)) => {
-                tracing::error!(
-                    error = % e,
-                    service = SERVICE_NAME,
-                    tag,
-                    "Internal error in the cache layer. Cancelling service."
-                );
-                self.cancellation_token.cancel();
-                Status::internal("storage service unavailable")
+                self.fatal_internal_status(SERVICE_NAME, tag, &e)
             }
 
-            error => {
-                tracing::error!(
-                    error = % error,
-                    service = SERVICE_NAME,
-                    tag,
-                    "Unexpected internal error. Cancelling service to avoid cache corruption."
-                );
-                self.cancellation_token.cancel();
-                Status::internal("internal error")
-            }
+            error => self.unexpected_internal_status(SERVICE_NAME, tag, &error),
         }
     }
 
@@ -377,26 +378,10 @@ impl<
             }
 
             StorageServerError::Cache(CacheError::Internal(e)) => {
-                tracing::error!(
-                    error = % e,
-                    service = SERVICE_NAME,
-                    tag,
-                    "Internal error in the cache layer. Cancelling service."
-                );
-                self.cancellation_token.cancel();
-                Status::internal("storage service unavailable")
+                self.fatal_internal_status(SERVICE_NAME, tag, &e)
             }
 
-            error => {
-                tracing::error!(
-                    error = % error,
-                    service = SERVICE_NAME,
-                    tag,
-                    "Unexpected internal error. Cancelling service to avoid cache corruption."
-                );
-                self.cancellation_token.cancel();
-                Status::internal("internal error")
-            }
+            error => self.unexpected_internal_status(SERVICE_NAME, tag, &error),
         }
     }
 
@@ -441,26 +426,10 @@ impl<
             }
 
             StorageServerError::Cache(CacheError::Internal(e)) => {
-                tracing::error!(
-                    error = % e,
-                    service = SERVICE_NAME,
-                    tag,
-                    "Internal error in the cache layer. Cancelling service."
-                );
-                self.cancellation_token.cancel();
-                Status::internal("storage service unavailable")
+                self.fatal_internal_status(SERVICE_NAME, tag, &e)
             }
 
-            error => {
-                tracing::error!(
-                    error = % error,
-                    service = SERVICE_NAME,
-                    tag,
-                    "Unexpected internal error. Cancelling service to avoid cache corruption."
-                );
-                self.cancellation_token.cancel();
-                Status::internal("internal error")
-            }
+            error => self.unexpected_internal_status(SERVICE_NAME, tag, &error),
         }
     }
 
@@ -476,6 +445,7 @@ impl<
     /// * `INTERNAL` for a fatal cache-internal error (the service will restart) or any other
     ///   failure; scheduler registration currently has no caller-visible error classification
     ///   beyond a generic server error.
+    #[must_use]
     pub fn scheduler_registration_service_error_handler(
         &self,
         error: StorageServerError,
@@ -484,26 +454,10 @@ impl<
         const SERVICE_NAME: &str = "SchedulerRegistration";
         match error {
             StorageServerError::Cache(CacheError::Internal(e)) => {
-                tracing::error!(
-                    error = % e,
-                    service = SERVICE_NAME,
-                    tag,
-                    "Internal error in the cache layer. Cancelling service."
-                );
-                self.cancellation_token.cancel();
-                Status::internal("storage service unavailable")
+                self.fatal_internal_status(SERVICE_NAME, tag, &e)
             }
 
-            error => {
-                tracing::error!(
-                    error = % error,
-                    service = SERVICE_NAME,
-                    tag,
-                    "Unexpected internal error. Cancelling service to avoid cache corruption."
-                );
-                self.cancellation_token.cancel();
-                Status::internal("internal error")
-            }
+            error => self.unexpected_internal_status(SERVICE_NAME, tag, &error),
         }
     }
 }
@@ -1081,10 +1035,16 @@ mod tests {
 
     const TEST_SESSION_ID: SessionId = 0;
 
+    /// # Returns
+    ///
+    /// A [`TestGrpcState`] backed by a default mock DB connector.
     fn create_grpc_service() -> TestGrpcState {
         create_grpc_service_with_db(MockDbConnector::default())
     }
 
+    /// # Returns
+    ///
+    /// A [`TestGrpcState`] backed by `db` and a [`MockReadyQueueSender`].
     fn create_grpc_service_with_db(db: MockDbConnector) -> TestGrpcState {
         let (_sender, receiver) =
             create_ready_queue(&ReadyQueueConfig::default()).expect("ready queue creation");
@@ -1100,6 +1060,10 @@ mod tests {
         GrpcServiceState::new(service, CancellationToken::new())
     }
 
+    /// # Returns
+    ///
+    /// A [`TestGrpcStateWithReadyQueue`] wired to a real ready queue, plus the queue's sender
+    /// handle so tests can enqueue entries.
     fn create_grpc_service_with_ready_queue(
         db: MockDbConnector,
     ) -> (TestGrpcStateWithReadyQueue, ReadyQueueSenderHandle) {

--- a/components/spider-storage/src/grpc.rs
+++ b/components/spider-storage/src/grpc.rs
@@ -1047,7 +1047,7 @@ mod tests {
     type TestGrpcStateWithReadyQueue =
         GrpcServiceState<ReadyQueueSenderHandle, MockDbConnector, MockTaskInstancePoolConnector>;
 
-    const TEST_SESSION_ID: SessionId = 0;
+    const TEST_SESSION_ID: SessionId = 1;
 
     /// # Returns
     ///

--- a/components/spider-storage/src/grpc.rs
+++ b/components/spider-storage/src/grpc.rs
@@ -65,55 +65,6 @@ impl<
         }
     }
 
-    /// Logs a fatal cache-internal error, cancels the service, and returns an `INTERNAL` status.
-    ///
-    /// Shared by every service error handler for the `Cache(CacheError::Internal)` arm. The error
-    /// is unrecoverable, so the whole storage service is cancelled to avoid cache corruption.
-    ///
-    /// # Returns
-    ///
-    /// `Status::internal("storage service unavailable")`.
-    fn fatal_internal_status(
-        &self,
-        service_name: &'static str,
-        tag: &'static str,
-        error: &InternalError,
-    ) -> Status {
-        tracing::error!(
-            error = % error,
-            service = service_name,
-            tag,
-            "Internal error in the cache layer. Cancelling service."
-        );
-        self.cancellation_token.cancel();
-        Status::internal("storage service unavailable")
-    }
-
-    /// Logs an unexpected error, cancels the service, and returns an `INTERNAL` status.
-    ///
-    /// Shared by every service error handler for the catch-all fallback arm. An unmapped error is
-    /// treated as unrecoverable, so the whole storage service is cancelled to avoid cache
-    /// corruption.
-    ///
-    /// # Returns
-    ///
-    /// `Status::internal("internal error")`.
-    fn unexpected_internal_status(
-        &self,
-        service_name: &'static str,
-        tag: &'static str,
-        error: &StorageServerError,
-    ) -> Status {
-        tracing::error!(
-            error = % error,
-            service = service_name,
-            tag,
-            "Unexpected internal error. Cancelling service to avoid cache corruption."
-        );
-        self.cancellation_token.cancel();
-        Status::internal("internal error")
-    }
-
     /// Error handler for job orchestration service errors.
     ///
     /// This function maps the given [`StorageServerError`] to a [`Status`] that can be sent to the
@@ -123,9 +74,9 @@ impl<
     ///
     /// The [`Status`] to send to the client:
     ///
-    /// * `INTERNAL` for a fatal cache-internal error (the service will restart).
-    /// * `UNAUTHENTICATED` for a wrong resource-group password.
-    /// * `NOT_FOUND` for an unknown resource group or a missing job.
+    /// * `UNAVAILABLE` for a fatal cache-internal error (the service will restart).
+    /// * `UNAUTHENTICATED` for an unknown or unauthorized resource group, or a wrong password.
+    /// * `NOT_FOUND` for a missing job.
     /// * `FAILED_PRECONDITION` for operations on an invalid job state.
     /// * `INVALID_ARGUMENT` for a malformed task graph, inputs, or request.
     /// * `INTERNAL` for any other (database or otherwise unexpected) error.
@@ -137,27 +88,18 @@ impl<
         const SERVICE_NAME: &str = "JobOrchestration";
         match error {
             StorageServerError::Cache(CacheError::Internal(e)) => {
-                self.fatal_internal_status(SERVICE_NAME, tag, &e)
+                self.fatal_unavailable_status(SERVICE_NAME, tag, &e)
             }
 
             StorageServerError::Db(db_error) => match &db_error {
-                DbError::ResourceGroupNotFound(_) => {
+                DbError::ResourceGroupNotFound(_) | DbError::InvalidPassword(_) => {
                     tracing::warn!(
                         error = % db_error,
                         service = SERVICE_NAME,
                         tag,
-                        "Resource group not found."
+                        "Invalid resource group."
                     );
-                    Status::not_found(db_error.to_string())
-                }
-                DbError::InvalidPassword(_) => {
-                    tracing::warn!(
-                        error = % db_error,
-                        service = SERVICE_NAME,
-                        tag,
-                        "Invalid resource group password."
-                    );
-                    Status::unauthenticated(db_error.to_string())
+                    Status::unauthenticated("invalid resource group")
                 }
                 DbError::JobNotFound(_) => {
                     tracing::warn!(
@@ -339,11 +281,10 @@ impl<
     ///
     /// The [`Status`] to send to the client:
     ///
-    /// * `NOT_FOUND` for an unknown resource group.
-    /// * `UNAUTHENTICATED` for a wrong password.
+    /// * `UNAUTHENTICATED` for an unknown resource group or a wrong password.
     /// * `ALREADY_EXISTS` for a duplicate external resource group ID.
-    /// * `INTERNAL` for a fatal cache-internal error (the service will restart) or any other
-    ///   unexpected failure.
+    /// * `UNAVAILABLE` for a fatal cache-internal error (the service will restart).
+    /// * `INTERNAL` for any other unexpected failure.
     pub fn resource_group_management_service_error_handler(
         &self,
         error: StorageServerError,
@@ -351,24 +292,16 @@ impl<
     ) -> Status {
         const SERVICE_NAME: &str = "ResourceGroupManagement";
         match error {
-            error @ StorageServerError::Db(DbError::ResourceGroupNotFound(_)) => {
+            error @ StorageServerError::Db(
+                DbError::ResourceGroupNotFound(_) | DbError::InvalidPassword(_),
+            ) => {
                 tracing::warn!(
                     error = % error,
                     service = SERVICE_NAME,
                     tag,
-                    "Resource group not found."
+                    "Invalid resource group."
                 );
-                Status::not_found(error.to_string())
-            }
-
-            error @ StorageServerError::Db(DbError::InvalidPassword(_)) => {
-                tracing::warn!(
-                    error = % error,
-                    service = SERVICE_NAME,
-                    tag,
-                    "Invalid resource group password."
-                );
-                Status::unauthenticated(error.to_string())
+                Status::unauthenticated("invalid resource group")
             }
 
             error @ StorageServerError::Db(DbError::ResourceGroupAlreadyExists(_)) => {
@@ -382,7 +315,7 @@ impl<
             }
 
             StorageServerError::Cache(CacheError::Internal(e)) => {
-                self.fatal_internal_status(SERVICE_NAME, tag, &e)
+                self.fatal_unavailable_status(SERVICE_NAME, tag, &e)
             }
 
             error => self.unexpected_internal_status(SERVICE_NAME, tag, &error),
@@ -400,8 +333,8 @@ impl<
     ///
     /// * `FAILED_PRECONDITION` when the execution manager has already been reaped.
     /// * `INVALID_ARGUMENT` for an illegal execution manager ID.
-    /// * `INTERNAL` for a fatal cache-internal error (the service will restart) or any other
-    ///   unexpected failure.
+    /// * `UNAVAILABLE` for a fatal cache-internal error (the service will restart).
+    /// * `INTERNAL` for any other unexpected failure.
     pub fn execution_manager_liveness_service_error_handler(
         &self,
         error: StorageServerError,
@@ -430,7 +363,7 @@ impl<
             }
 
             StorageServerError::Cache(CacheError::Internal(e)) => {
-                self.fatal_internal_status(SERVICE_NAME, tag, &e)
+                self.fatal_unavailable_status(SERVICE_NAME, tag, &e)
             }
 
             error => self.unexpected_internal_status(SERVICE_NAME, tag, &error),
@@ -446,9 +379,9 @@ impl<
     ///
     /// The [`Status`] to send to the client:
     ///
-    /// * `INTERNAL` for a fatal cache-internal error (the service will restart) or any other
-    ///   failure; scheduler registration currently has no caller-visible error classification
-    ///   beyond a generic server error.
+    /// * `UNAVAILABLE` for a fatal cache-internal error (the service will restart).
+    /// * `INTERNAL` for any other failure; scheduler registration currently has no caller-visible
+    ///   error classification beyond a generic server error.
     #[must_use]
     pub fn scheduler_registration_service_error_handler(
         &self,
@@ -458,11 +391,88 @@ impl<
         const SERVICE_NAME: &str = "SchedulerRegistration";
         match error {
             StorageServerError::Cache(CacheError::Internal(e)) => {
-                self.fatal_internal_status(SERVICE_NAME, tag, &e)
+                self.fatal_unavailable_status(SERVICE_NAME, tag, &e)
             }
 
             error => self.unexpected_internal_status(SERVICE_NAME, tag, &error),
         }
+    }
+
+    /// Logs a fatal cache-internal error, cancels the service, and returns an `UNAVAILABLE` status.
+    ///
+    /// Shared by the service error handlers whose `Cache(CacheError::Internal)` arm must read as a
+    /// transient "service restarting" signal (job orchestration, resource-group management,
+    /// liveness, and scheduler registration). The error is unrecoverable, so the whole storage
+    /// service is cancelled to avoid cache corruption.
+    ///
+    /// # Returns
+    ///
+    /// `Status::unavailable("storage service unavailable")`.
+    fn fatal_unavailable_status(
+        &self,
+        service_name: &'static str,
+        tag: &'static str,
+        error: &InternalError,
+    ) -> Status {
+        tracing::error!(
+            error = % error,
+            service = service_name,
+            tag,
+            "Internal error in the cache layer. Cancelling service."
+        );
+        self.cancellation_token.cancel();
+        Status::unavailable("storage service unavailable")
+    }
+
+    /// Logs a fatal cache-internal error, cancels the service, and returns an `INTERNAL` status.
+    ///
+    /// Shared by the service error handlers whose `UNAVAILABLE` code is already reserved for a
+    /// caller-facing semantic (task-instance `StaleSession`, inbound `InboundClosed`), so the fatal
+    /// cache-internal arm falls back to `INTERNAL`. The error is unrecoverable, so the whole
+    /// storage service is cancelled to avoid cache corruption.
+    ///
+    /// # Returns
+    ///
+    /// `Status::internal("storage service unavailable")`.
+    fn fatal_internal_status(
+        &self,
+        service_name: &'static str,
+        tag: &'static str,
+        error: &InternalError,
+    ) -> Status {
+        tracing::error!(
+            error = % error,
+            service = service_name,
+            tag,
+            "Internal error in the cache layer. Cancelling service."
+        );
+        self.cancellation_token.cancel();
+        Status::internal("storage service unavailable")
+    }
+
+    /// Logs an unexpected error, cancels the service, and returns an `INTERNAL` status.
+    ///
+    /// Shared by every service error handler for the catch-all fallback arm. An unmapped error is
+    /// treated as unrecoverable, so the whole storage service is cancelled to avoid cache
+    /// corruption.
+    ///
+    /// # Returns
+    ///
+    /// `Status::internal("internal error")`.
+    fn unexpected_internal_status(
+        &self,
+        service_name: &'static str,
+        tag: &'static str,
+        error: &StorageServerError,
+    ) -> Status {
+        tracing::error!(
+            error = % error,
+            service = service_name,
+            tag,
+            "Unexpected internal error. Cancelling service to avoid cache corruption."
+        );
+        self.cancellation_token.cancel();
+        Status::internal("internal error")
     }
 }
 
@@ -1134,7 +1144,7 @@ mod tests {
             }))
             .await;
         let status = verify_after_delete.expect_err("verify should fail after delete");
-        assert_eq!(status.code(), Code::NotFound);
+        assert_eq!(status.code(), Code::Unauthenticated);
         Ok(())
     }
 
@@ -1202,6 +1212,56 @@ mod tests {
         let status = result.expect_err("an unknown job should be rejected");
         assert_eq!(status.code(), Code::NotFound);
         Ok(())
+    }
+
+    #[test]
+    fn job_orchestration_maps_unknown_resource_group_to_unauthenticated() {
+        let service = create_grpc_service();
+        let status = service.job_orchestration_service_error_handler(
+            StorageServerError::Db(DbError::ResourceGroupNotFound(ResourceGroupId::from(7))),
+            "test",
+        );
+        assert_eq!(status.code(), Code::Unauthenticated);
+    }
+
+    #[test]
+    fn job_orchestration_maps_wrong_password_to_unauthenticated() {
+        let service = create_grpc_service();
+        let status = service.job_orchestration_service_error_handler(
+            StorageServerError::Db(DbError::InvalidPassword(ResourceGroupId::from(7))),
+            "test",
+        );
+        assert_eq!(status.code(), Code::Unauthenticated);
+    }
+
+    #[test]
+    fn job_orchestration_maps_fatal_cache_internal_to_unavailable() {
+        let service = create_grpc_service();
+        let status = service.job_orchestration_service_error_handler(
+            StorageServerError::Cache(CacheError::Internal(InternalError::TaskGraphEmpty)),
+            "test",
+        );
+        assert_eq!(status.code(), Code::Unavailable);
+    }
+
+    #[test]
+    fn resource_group_management_maps_unknown_resource_group_to_unauthenticated() {
+        let service = create_grpc_service();
+        let status = service.resource_group_management_service_error_handler(
+            StorageServerError::Db(DbError::ResourceGroupNotFound(ResourceGroupId::from(7))),
+            "test",
+        );
+        assert_eq!(status.code(), Code::Unauthenticated);
+    }
+
+    #[test]
+    fn resource_group_management_maps_fatal_cache_internal_to_unavailable() {
+        let service = create_grpc_service();
+        let status = service.resource_group_management_service_error_handler(
+            StorageServerError::Cache(CacheError::Internal(InternalError::TaskGraphEmpty)),
+            "test",
+        );
+        assert_eq!(status.code(), Code::Unavailable);
     }
 
     #[tokio::test]

--- a/components/spider-storage/src/grpc.rs
+++ b/components/spider-storage/src/grpc.rs
@@ -6,20 +6,12 @@ use spider_proto_rust::{
     storage::{
         self,
         execution_manager_liveness_service_server::ExecutionManagerLivenessService,
-        get_schedulers_response,
         inbound_queue_service_server::InboundQueueService,
         job_orchestration_service_server::JobOrchestrationService,
-        poll_ready_tasks_response,
-        register_execution_manager_response,
-        register_scheduler_response,
-        resend_ready_tasks_response,
-        resource_group_id_response,
         resource_group_management_service_server::ResourceGroupManagementService,
-        resource_group_operation_response,
         scheduler_registration_service_server::SchedulerRegistrationService,
         session_management_service_server::SessionManagementService,
         task_instance_management_service_server::TaskInstanceManagementService,
-        update_execution_manager_heartbeat_response,
     },
     unpack::RequestUnpack,
 };
@@ -267,6 +259,254 @@ impl<
             }
         }
     }
+
+    /// Error handler for inbound queue service errors.
+    ///
+    /// This function maps the given [`StorageServerError`] to a [`Status`] that can be sent to the
+    /// client. The errors are logged for observability.
+    ///
+    /// # Returns
+    ///
+    /// The [`Status`] to send to the client:
+    ///
+    /// * `UNAVAILABLE` when the ready-queue channel is closed (the inbound queue can no longer
+    ///   yield entries) or the request was issued from a stale session.
+    /// * `INTERNAL` for a fatal cache-internal error (the service will restart) or any other
+    ///   unexpected failure.
+    pub fn inbound_queue_service_error_handler(
+        &self,
+        error: StorageServerError,
+        tag: &'static str,
+    ) -> Status {
+        const SERVICE_NAME: &str = "InboundQueue";
+        match error {
+            StorageServerError::Cache(CacheError::Internal(
+                InternalError::ReadyQueueChannelClosed,
+            )) => {
+                tracing::warn!(
+                    service = SERVICE_NAME,
+                    tag,
+                    "Inbound queue channel is closed."
+                );
+                Status::unavailable("inbound queue is closed")
+            }
+
+            StorageServerError::Cache(CacheError::Internal(e)) => {
+                tracing::error!(
+                    error = % e,
+                    service = SERVICE_NAME,
+                    tag,
+                    "Internal error in the cache layer. Cancelling service."
+                );
+                self.cancellation_token.cancel();
+                Status::internal("storage service unavailable")
+            }
+
+            StorageServerError::StaleSession(storage_session) => {
+                tracing::warn!(
+                    storage_session,
+                    service = SERVICE_NAME,
+                    tag,
+                    "The request was issued from a stale session."
+                );
+                Status::unavailable(format!(
+                    "stale session; current storage session is {storage_session}"
+                ))
+            }
+
+            error => {
+                tracing::error!(
+                    error = % error,
+                    service = SERVICE_NAME,
+                    tag,
+                    "Unexpected internal error. Cancelling service to avoid cache corruption."
+                );
+                self.cancellation_token.cancel();
+                Status::internal("internal error")
+            }
+        }
+    }
+
+    /// Error handler for resource group management service errors.
+    ///
+    /// This function maps the given [`StorageServerError`] to a [`Status`] that can be sent to the
+    /// client. The errors are logged for observability.
+    ///
+    /// # Returns
+    ///
+    /// The [`Status`] to send to the client:
+    ///
+    /// * `NOT_FOUND` for an unknown resource group.
+    /// * `INVALID_ARGUMENT` for a wrong password.
+    /// * `ALREADY_EXISTS` for a duplicate external resource group ID.
+    /// * `INTERNAL` for a fatal cache-internal error (the service will restart) or any other
+    ///   unexpected failure.
+    pub fn resource_group_management_service_error_handler(
+        &self,
+        error: StorageServerError,
+        tag: &'static str,
+    ) -> Status {
+        const SERVICE_NAME: &str = "ResourceGroupManagement";
+        match error {
+            error @ StorageServerError::Db(DbError::ResourceGroupNotFound(_)) => {
+                tracing::warn!(
+                    error = % error,
+                    service = SERVICE_NAME,
+                    tag,
+                    "Resource group not found."
+                );
+                Status::not_found(error.to_string())
+            }
+
+            error @ StorageServerError::Db(DbError::InvalidPassword(_)) => {
+                tracing::warn!(
+                    error = % error,
+                    service = SERVICE_NAME,
+                    tag,
+                    "Invalid resource group password."
+                );
+                Status::invalid_argument(error.to_string())
+            }
+
+            error @ StorageServerError::Db(DbError::ResourceGroupAlreadyExists(_)) => {
+                tracing::warn!(
+                    error = % error,
+                    service = SERVICE_NAME,
+                    tag,
+                    "Resource group already exists."
+                );
+                Status::already_exists(error.to_string())
+            }
+
+            StorageServerError::Cache(CacheError::Internal(e)) => {
+                tracing::error!(
+                    error = % e,
+                    service = SERVICE_NAME,
+                    tag,
+                    "Internal error in the cache layer. Cancelling service."
+                );
+                self.cancellation_token.cancel();
+                Status::internal("storage service unavailable")
+            }
+
+            error => {
+                tracing::error!(
+                    error = % error,
+                    service = SERVICE_NAME,
+                    tag,
+                    "Unexpected internal error. Cancelling service to avoid cache corruption."
+                );
+                self.cancellation_token.cancel();
+                Status::internal("internal error")
+            }
+        }
+    }
+
+    /// Error handler for execution manager liveness service errors.
+    ///
+    /// This function maps the given [`StorageServerError`] to a [`Status`] that can be sent to the
+    /// client. The errors are logged for observability.
+    ///
+    /// # Returns
+    ///
+    /// The [`Status`] to send to the client:
+    ///
+    /// * `FAILED_PRECONDITION` when the execution manager has already been reaped.
+    /// * `INVALID_ARGUMENT` for an illegal execution manager ID.
+    /// * `INTERNAL` for a fatal cache-internal error (the service will restart) or any other
+    ///   unexpected failure.
+    pub fn execution_manager_liveness_service_error_handler(
+        &self,
+        error: StorageServerError,
+        tag: &'static str,
+    ) -> Status {
+        const SERVICE_NAME: &str = "ExecutionManagerLiveness";
+        match error {
+            error @ StorageServerError::Db(DbError::ExecutionManagerAlreadyDead(_)) => {
+                tracing::warn!(
+                    error = % error,
+                    service = SERVICE_NAME,
+                    tag,
+                    "Execution manager already marked dead."
+                );
+                Status::failed_precondition(error.to_string())
+            }
+
+            error @ StorageServerError::Db(DbError::IllegalExecutionManagerId(_)) => {
+                tracing::warn!(
+                    error = % error,
+                    service = SERVICE_NAME,
+                    tag,
+                    "Illegal execution manager id."
+                );
+                Status::invalid_argument(error.to_string())
+            }
+
+            StorageServerError::Cache(CacheError::Internal(e)) => {
+                tracing::error!(
+                    error = % e,
+                    service = SERVICE_NAME,
+                    tag,
+                    "Internal error in the cache layer. Cancelling service."
+                );
+                self.cancellation_token.cancel();
+                Status::internal("storage service unavailable")
+            }
+
+            error => {
+                tracing::error!(
+                    error = % error,
+                    service = SERVICE_NAME,
+                    tag,
+                    "Unexpected internal error. Cancelling service to avoid cache corruption."
+                );
+                self.cancellation_token.cancel();
+                Status::internal("internal error")
+            }
+        }
+    }
+
+    /// Error handler for scheduler registration service errors.
+    ///
+    /// This function maps the given [`StorageServerError`] to a [`Status`] that can be sent to the
+    /// client. The errors are logged for observability.
+    ///
+    /// # Returns
+    ///
+    /// The [`Status`] to send to the client:
+    ///
+    /// * `INTERNAL` for a fatal cache-internal error (the service will restart) or any other
+    ///   failure; scheduler registration currently has no caller-visible error classification
+    ///   beyond a generic server error.
+    pub fn scheduler_registration_service_error_handler(
+        &self,
+        error: StorageServerError,
+        tag: &'static str,
+    ) -> Status {
+        const SERVICE_NAME: &str = "SchedulerRegistration";
+        match error {
+            StorageServerError::Cache(CacheError::Internal(e)) => {
+                tracing::error!(
+                    error = % e,
+                    service = SERVICE_NAME,
+                    tag,
+                    "Internal error in the cache layer. Cancelling service."
+                );
+                self.cancellation_token.cancel();
+                Status::internal("storage service unavailable")
+            }
+
+            error => {
+                tracing::error!(
+                    error = % error,
+                    service = SERVICE_NAME,
+                    tag,
+                    "Unexpected internal error."
+                );
+                Status::internal("internal error")
+            }
+        }
+    }
 }
 
 /// Implementation of [`JobOrchestrationService`].
@@ -498,15 +738,13 @@ impl<
     ) -> Result<Response<storage::PollReadyTasksResponse>, Status> {
         let (max_items, wait) = request.into_inner().unpack()?;
         tracing::debug!(max_items, ?wait, "Poll ready tasks request received.");
-        let result = match self.inner.poll_ready_tasks(max_items, wait).await {
-            Ok(entries) => poll_ready_tasks_response::Result::Tasks(ready_tasks(
-                self.inner.session_id(),
-                entries,
-            )),
-            Err(error) => poll_ready_tasks_response::Result::Error(to_inbound_error(&error)),
-        };
+        let entries = self
+            .inner
+            .poll_ready_tasks(max_items, wait)
+            .await
+            .map_err(|error| self.inbound_queue_service_error_handler(error, "poll_ready_tasks"))?;
         Ok(Response::new(storage::PollReadyTasksResponse {
-            result: Some(result),
+            tasks: Some(ready_tasks(self.inner.session_id(), entries)),
         }))
     }
 
@@ -520,15 +758,15 @@ impl<
             ?wait,
             "Poll ready commit tasks request received."
         );
-        let result = match self.inner.poll_commit_ready_tasks(max_items, wait).await {
-            Ok(entries) => poll_ready_tasks_response::Result::Tasks(ready_tasks(
-                self.inner.session_id(),
-                entries,
-            )),
-            Err(error) => poll_ready_tasks_response::Result::Error(to_inbound_error(&error)),
-        };
+        let entries = self
+            .inner
+            .poll_commit_ready_tasks(max_items, wait)
+            .await
+            .map_err(|error| {
+                self.inbound_queue_service_error_handler(error, "poll_ready_commit_tasks")
+            })?;
         Ok(Response::new(storage::PollReadyTasksResponse {
-            result: Some(result),
+            tasks: Some(ready_tasks(self.inner.session_id(), entries)),
         }))
     }
 
@@ -542,15 +780,15 @@ impl<
             ?wait,
             "Poll ready cleanup tasks request received."
         );
-        let result = match self.inner.poll_cleanup_ready_tasks(max_items, wait).await {
-            Ok(entries) => poll_ready_tasks_response::Result::Tasks(ready_tasks(
-                self.inner.session_id(),
-                entries,
-            )),
-            Err(error) => poll_ready_tasks_response::Result::Error(to_inbound_error(&error)),
-        };
+        let entries = self
+            .inner
+            .poll_cleanup_ready_tasks(max_items, wait)
+            .await
+            .map_err(|error| {
+                self.inbound_queue_service_error_handler(error, "poll_ready_cleanup_tasks")
+            })?;
         Ok(Response::new(storage::PollReadyTasksResponse {
-            result: Some(result),
+            tasks: Some(ready_tasks(self.inner.session_id(), entries)),
         }))
     }
 
@@ -559,13 +797,10 @@ impl<
         _request: Request<storage::ResendReadyTasksRequest>,
     ) -> Result<Response<storage::ResendReadyTasksResponse>, Status> {
         tracing::info!("Resend ready tasks request received.");
-        let result = match self.inner.resend_ready_tasks().await {
-            Ok(()) => resend_ready_tasks_response::Result::Ok(storage::Void {}),
-            Err(error) => resend_ready_tasks_response::Result::Error(to_inbound_error(&error)),
-        };
-        Ok(Response::new(storage::ResendReadyTasksResponse {
-            result: Some(result),
-        }))
+        self.inner.resend_ready_tasks().await.map_err(|error| {
+            self.inbound_queue_service_error_handler(error, "resend_ready_tasks")
+        })?;
+        Ok(Response::new(storage::ResendReadyTasksResponse {}))
     }
 }
 
@@ -581,25 +816,17 @@ impl<
         &self,
         request: Request<storage::AddResourceGroupRequest>,
     ) -> Result<Response<storage::ResourceGroupIdResponse>, Status> {
-        let (external_id, password, request_session_id) = request.into_inner().unpack()?;
+        let (external_id, password) = request.into_inner().unpack()?;
         tracing::info!(external_id = % external_id, "Add resource group request received.");
-        let current_session = self.inner.session_id();
-        let result = if request_session_id == current_session {
-            match self.inner.add_resource_group(external_id, password).await {
-                Ok(rg_id) => resource_group_id_response::Result::ResourceGroupId(rg_id.get()),
-                Err(error) => resource_group_id_response::Result::Error(to_resource_group_error(
-                    &error,
-                    current_session,
-                )),
-            }
-        } else {
-            resource_group_id_response::Result::Error(to_resource_group_error(
-                &StorageServerError::StaleSession(current_session),
-                current_session,
-            ))
-        };
+        let rg_id = self
+            .inner
+            .add_resource_group(external_id, password)
+            .await
+            .map_err(|error| {
+                self.resource_group_management_service_error_handler(error, "add_resource_group")
+            })?;
         Ok(Response::new(storage::ResourceGroupIdResponse {
-            result: Some(result),
+            resource_group_id: rg_id.get(),
         }))
     }
 
@@ -607,56 +834,36 @@ impl<
         &self,
         request: Request<storage::VerifyResourceGroupRequest>,
     ) -> Result<Response<storage::ResourceGroupOperationResponse>, Status> {
-        let (rg_id, password, request_session_id) = request.into_inner().unpack()?;
+        let (rg_id, password) = request.into_inner().unpack()?;
         tracing::info!(
             rg_id = rg_id.get(),
             "Verify resource group request received."
         );
-        let current_session = self.inner.session_id();
-        let result = if request_session_id == current_session {
-            match self.inner.verify_resource_group(rg_id, &password).await {
-                Ok(()) => resource_group_operation_response::Result::Ok(storage::Void {}),
-                Err(error) => resource_group_operation_response::Result::Error(
-                    to_resource_group_error(&error, current_session),
-                ),
-            }
-        } else {
-            resource_group_operation_response::Result::Error(to_resource_group_error(
-                &StorageServerError::StaleSession(current_session),
-                current_session,
-            ))
-        };
-        Ok(Response::new(storage::ResourceGroupOperationResponse {
-            result: Some(result),
-        }))
+        self.inner
+            .verify_resource_group(rg_id, &password)
+            .await
+            .map_err(|error| {
+                self.resource_group_management_service_error_handler(error, "verify_resource_group")
+            })?;
+        Ok(Response::new(storage::ResourceGroupOperationResponse {}))
     }
 
     async fn delete_resource_group(
         &self,
         request: Request<storage::ResourceGroupIdRequest>,
     ) -> Result<Response<storage::ResourceGroupOperationResponse>, Status> {
-        let (rg_id, request_session_id) = request.into_inner().unpack()?;
+        let rg_id = request.into_inner().unpack()?;
         tracing::info!(
             rg_id = rg_id.get(),
             "Delete resource group request received."
         );
-        let current_session = self.inner.session_id();
-        let result = if request_session_id == current_session {
-            match self.inner.delete_resource_group(rg_id).await {
-                Ok(()) => resource_group_operation_response::Result::Ok(storage::Void {}),
-                Err(error) => resource_group_operation_response::Result::Error(
-                    to_resource_group_error(&error, current_session),
-                ),
-            }
-        } else {
-            resource_group_operation_response::Result::Error(to_resource_group_error(
-                &StorageServerError::StaleSession(current_session),
-                current_session,
-            ))
-        };
-        Ok(Response::new(storage::ResourceGroupOperationResponse {
-            result: Some(result),
-        }))
+        self.inner
+            .delete_resource_group(rg_id)
+            .await
+            .map_err(|error| {
+                self.resource_group_management_service_error_handler(error, "delete_resource_group")
+            })?;
+        Ok(Response::new(storage::ResourceGroupOperationResponse {}))
     }
 }
 
@@ -674,19 +881,21 @@ impl<
     ) -> Result<Response<storage::RegisterExecutionManagerResponse>, Status> {
         let ip_address = request.into_inner().unpack()?;
         tracing::info!(% ip_address, "Execution manager registration request received.");
-        let result = match self.inner.register_execution_manager(ip_address).await {
-            Ok(em_id) => register_execution_manager_response::Result::Registration(
-                storage::ExecutionManagerRegistration {
-                    execution_manager_id: em_id.get(),
-                    session_id: self.inner.session_id(),
-                },
-            ),
-            Err(error) => {
-                register_execution_manager_response::Result::Error(to_liveness_error(&error))
-            }
-        };
+        let em_id = self
+            .inner
+            .register_execution_manager(ip_address)
+            .await
+            .map_err(|error| {
+                self.execution_manager_liveness_service_error_handler(
+                    error,
+                    "register_execution_manager",
+                )
+            })?;
         Ok(Response::new(storage::RegisterExecutionManagerResponse {
-            result: Some(result),
+            registration: Some(storage::ExecutionManagerRegistration {
+                execution_manager_id: em_id.get(),
+                session_id: self.inner.session_id(),
+            }),
         }))
     }
 
@@ -699,17 +908,18 @@ impl<
             em_id = em_id.get(),
             "Execution manager heartbeat request received."
         );
-        let result = match self.inner.update_execution_manager_heartbeat(em_id).await {
-            Ok(()) => update_execution_manager_heartbeat_response::Result::SessionId(
-                self.inner.session_id(),
-            ),
-            Err(error) => update_execution_manager_heartbeat_response::Result::Error(
-                to_liveness_error(&error),
-            ),
-        };
+        self.inner
+            .update_execution_manager_heartbeat(em_id)
+            .await
+            .map_err(|error| {
+                self.execution_manager_liveness_service_error_handler(
+                    error,
+                    "update_execution_manager_heartbeat",
+                )
+            })?;
         Ok(Response::new(
             storage::UpdateExecutionManagerHeartbeatResponse {
-                result: Some(result),
+                session_id: self.inner.session_id(),
             },
         ))
     }
@@ -729,17 +939,18 @@ impl<
     ) -> Result<Response<storage::RegisterSchedulerResponse>, Status> {
         let (ip_address, port) = request.into_inner().unpack()?;
         tracing::info!(% ip_address, port, "Scheduler registration request received.");
-        let result = match self.inner.register_scheduler(ip_address, port).await {
-            Ok(scheduler_id) => {
-                register_scheduler_response::Result::Registration(storage::SchedulerRegistration {
-                    scheduler_id: scheduler_id.get(),
-                    session_id: self.inner.session_id(),
-                })
-            }
-            Err(error) => register_scheduler_response::Result::Error(to_scheduler_error(&error)),
-        };
+        let scheduler_id = self
+            .inner
+            .register_scheduler(ip_address, port)
+            .await
+            .map_err(|error| {
+                self.scheduler_registration_service_error_handler(error, "register_scheduler")
+            })?;
         Ok(Response::new(storage::RegisterSchedulerResponse {
-            result: Some(result),
+            registration: Some(storage::SchedulerRegistration {
+                scheduler_id: scheduler_id.get(),
+                session_id: self.inner.session_id(),
+            }),
         }))
     }
 
@@ -748,19 +959,16 @@ impl<
         _request: Request<storage::Void>,
     ) -> Result<Response<storage::GetSchedulersResponse>, Status> {
         tracing::info!("Get schedulers request received.");
-        let result = match self.inner.get_schedulers().await {
-            Ok(schedulers) => {
-                get_schedulers_response::Result::Schedulers(storage::SchedulerRegistrations {
-                    schedulers: schedulers
-                        .into_iter()
-                        .map(storage::Scheduler::from)
-                        .collect(),
-                })
-            }
-            Err(error) => get_schedulers_response::Result::Error(to_scheduler_error(&error)),
-        };
+        let schedulers = self.inner.get_schedulers().await.map_err(|error| {
+            self.scheduler_registration_service_error_handler(error, "get_schedulers")
+        })?;
         Ok(Response::new(storage::GetSchedulersResponse {
-            result: Some(result),
+            schedulers: Some(storage::SchedulerRegistrations {
+                schedulers: schedulers
+                    .into_iter()
+                    .map(storage::Scheduler::from)
+                    .collect(),
+            }),
         }))
     }
 }
@@ -834,91 +1042,6 @@ fn ready_tasks<TaskKind: ToProtoTaskId>(
     storage::ReadyTasks { session_id, tasks }
 }
 
-/// Maps an inbound-queue [`StorageServerError`] to a protobuf
-/// [`storage::InboundQueueResponseError`].
-///
-/// # Returns
-///
-/// * `INBOUND_CLOSED` when the ready-queue channel is closed.
-/// * `SERVER` for any other failure.
-fn to_inbound_error(error: &StorageServerError) -> storage::InboundQueueResponseError {
-    use storage::inbound_queue_response_error::ErrCode;
-    let err_code = match error {
-        StorageServerError::Cache(CacheError::Internal(InternalError::ReadyQueueChannelClosed)) => {
-            ErrCode::InboundClosed
-        }
-        _ => ErrCode::Server,
-    };
-    storage::InboundQueueResponseError {
-        err_code: err_code.into(),
-        message: error.to_string(),
-    }
-}
-
-/// Maps a resource-group [`StorageServerError`] to a protobuf
-/// [`storage::ResourceGroupManagementError`].
-///
-/// # Returns
-///
-/// * `STALE_SESSION` when the request was issued against a stale storage session.
-/// * `INVALID_INPUT` for an unknown resource group, a wrong password, or a duplicate external ID.
-/// * `SERVER` for any other failure.
-fn to_resource_group_error(
-    error: &StorageServerError,
-    current_session: SessionId,
-) -> storage::ResourceGroupManagementError {
-    use storage::resource_group_management_error::ErrCode;
-    let err_code = match error {
-        StorageServerError::StaleSession(_) => ErrCode::StaleSession,
-        StorageServerError::Db(
-            DbError::ResourceGroupNotFound(_)
-            | DbError::InvalidPassword(_)
-            | DbError::ResourceGroupAlreadyExists(_),
-        ) => ErrCode::InvalidInput,
-        _ => ErrCode::Server,
-    };
-    storage::ResourceGroupManagementError {
-        err_code: err_code.into(),
-        message: error.to_string(),
-        storage_session: current_session,
-    }
-}
-
-/// Maps an execution-manager-liveness [`StorageServerError`] to a protobuf
-/// [`storage::ExecutionManagerLivenessError`].
-///
-/// # Returns
-///
-/// * `MARKED_DEAD` when the execution manager has already been reaped.
-/// * `INVALID_INPUT` for an illegal execution manager ID.
-/// * `SERVER` for any other failure.
-fn to_liveness_error(error: &StorageServerError) -> storage::ExecutionManagerLivenessError {
-    use storage::execution_manager_liveness_error::ErrCode;
-    let err_code = match error {
-        StorageServerError::Db(DbError::ExecutionManagerAlreadyDead(_)) => ErrCode::MarkedDead,
-        StorageServerError::Db(DbError::IllegalExecutionManagerId(_)) => ErrCode::InvalidInput,
-        _ => ErrCode::Server,
-    };
-    storage::ExecutionManagerLivenessError {
-        err_code: err_code.into(),
-        message: error.to_string(),
-    }
-}
-
-/// Maps a scheduler-registration [`StorageServerError`] to a protobuf
-/// [`storage::SchedulerRegistrationError`].
-///
-/// # Returns
-///
-/// `SERVER` for any failure; scheduler registration currently has no caller-visible error
-/// classification beyond a generic server error.
-fn to_scheduler_error(error: &StorageServerError) -> storage::SchedulerRegistrationError {
-    storage::SchedulerRegistrationError {
-        err_code: storage::scheduler_registration_error::ErrCode::Server.into(),
-        message: error.to_string(),
-    }
-}
-
 /// # Returns
 ///
 /// A [`storage::JobStateResponse`] carrying the given job state.
@@ -934,7 +1057,7 @@ fn make_job_state_response(
 mod tests {
     use spider_core::types::id::{ExecutionManagerId, JobId, ResourceGroupId, SessionId};
     use tokio_util::sync::CancellationToken;
-    use tonic::Request;
+    use tonic::{Code, Request};
 
     use super::*;
     use crate::{
@@ -1013,77 +1136,32 @@ mod tests {
             .add_resource_group(Request::new(storage::AddResourceGroupRequest {
                 external_resource_group_id: "external-rg".to_owned(),
                 password: password.clone(),
-                session_id: TEST_SESSION_ID,
             }))
             .await?
             .into_inner();
-        let rg_id = match add_response.result {
-            Some(resource_group_id_response::Result::ResourceGroupId(rg_id)) => rg_id,
-            other => panic!("expected a resource group id, got {other:?}"),
-        };
+        let rg_id = add_response.resource_group_id;
 
-        let verify_response = service
+        service
             .verify_resource_group(Request::new(storage::VerifyResourceGroupRequest {
                 resource_group_id: rg_id,
                 password: password.clone(),
-                session_id: TEST_SESSION_ID,
             }))
-            .await?
-            .into_inner();
-        assert!(matches!(
-            verify_response.result,
-            Some(resource_group_operation_response::Result::Ok(_))
-        ));
+            .await?;
 
-        let delete_response = service
+        service
             .delete_resource_group(Request::new(storage::ResourceGroupIdRequest {
                 resource_group_id: rg_id,
-                session_id: TEST_SESSION_ID,
             }))
-            .await?
-            .into_inner();
-        assert!(matches!(
-            delete_response.result,
-            Some(resource_group_operation_response::Result::Ok(_))
-        ));
+            .await?;
 
         let verify_after_delete = service
             .verify_resource_group(Request::new(storage::VerifyResourceGroupRequest {
                 resource_group_id: rg_id,
                 password,
-                session_id: TEST_SESSION_ID,
             }))
-            .await?
-            .into_inner();
-        assert!(matches!(
-            verify_after_delete.result,
-            Some(resource_group_operation_response::Result::Error(_))
-        ));
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn add_resource_group_rejects_stale_session() -> anyhow::Result<()> {
-        let service = create_grpc_service();
-        let response = service
-            .add_resource_group(Request::new(storage::AddResourceGroupRequest {
-                external_resource_group_id: "external-rg".to_owned(),
-                password: b"secret".to_vec(),
-                session_id: TEST_SESSION_ID + 1,
-            }))
-            .await?
-            .into_inner();
-        match response.result {
-            Some(resource_group_id_response::Result::Error(error)) => {
-                assert_eq!(
-                    storage::resource_group_management_error::ErrCode::try_from(error.err_code)
-                        .expect("valid err code"),
-                    storage::resource_group_management_error::ErrCode::StaleSession
-                );
-                assert_eq!(error.storage_session, TEST_SESSION_ID);
-            }
-            other => panic!("expected a stale-session error, got {other:?}"),
-        }
+            .await;
+        let status = verify_after_delete.expect_err("verify should fail after delete");
+        assert_eq!(status.code(), Code::NotFound);
         Ok(())
     }
 
@@ -1096,12 +1174,9 @@ mod tests {
             }))
             .await?
             .into_inner();
-        let registration = match response.result {
-            Some(register_execution_manager_response::Result::Registration(registration)) => {
-                registration
-            }
-            other => panic!("expected a registration, got {other:?}"),
-        };
+        let registration = response
+            .registration
+            .expect("registration should be present");
         assert_eq!(registration.session_id, TEST_SESSION_ID);
         assert_ne!(registration.execution_manager_id, 0);
         Ok(())
@@ -1116,14 +1191,9 @@ mod tests {
             }))
             .await?
             .into_inner()
-            .result
-            .and_then(|result| match result {
-                register_execution_manager_response::Result::Registration(registration) => {
-                    Some(registration.execution_manager_id)
-                }
-                register_execution_manager_response::Result::Error(_) => None,
-            })
-            .expect("registration should succeed");
+            .registration
+            .expect("registration should be present")
+            .execution_manager_id;
 
         let response = service
             .update_execution_manager_heartbeat(Request::new(storage::ExecutionManagerIdRequest {
@@ -1131,32 +1201,20 @@ mod tests {
             }))
             .await?
             .into_inner();
-        assert!(matches!(
-            response.result,
-            Some(update_execution_manager_heartbeat_response::Result::SessionId(TEST_SESSION_ID))
-        ));
+        assert_eq!(response.session_id, TEST_SESSION_ID);
         Ok(())
     }
 
     #[tokio::test]
     async fn heartbeat_rejects_unknown_em() -> anyhow::Result<()> {
         let service = create_grpc_service();
-        let response = service
+        let result = service
             .update_execution_manager_heartbeat(Request::new(storage::ExecutionManagerIdRequest {
                 execution_manager_id: ExecutionManagerId::from(999).get(),
             }))
-            .await?
-            .into_inner();
-        match response.result {
-            Some(update_execution_manager_heartbeat_response::Result::Error(error)) => {
-                assert_eq!(
-                    storage::execution_manager_liveness_error::ErrCode::try_from(error.err_code)
-                        .expect("valid err code"),
-                    storage::execution_manager_liveness_error::ErrCode::InvalidInput
-                );
-            }
-            other => panic!("expected an invalid-input error, got {other:?}"),
-        }
+            .await;
+        let status = result.expect_err("an unknown em id should be rejected");
+        assert_eq!(status.code(), Code::InvalidArgument);
         Ok(())
     }
 
@@ -1170,33 +1228,19 @@ mod tests {
             }))
             .await?
             .into_inner();
-        let scheduler_id = match register_response.result {
-            Some(register_scheduler_response::Result::Registration(registration)) => {
-                registration.scheduler_id
-            }
-            other => panic!("expected a registration, got {other:?}"),
-        };
-        assert_eq!(
-            register_response
-                .result
-                .and_then(|result| match result {
-                    register_scheduler_response::Result::Registration(registration) => {
-                        Some(registration.session_id)
-                    }
-                    register_scheduler_response::Result::Error(_) => None,
-                })
-                .expect("session id should be present"),
-            TEST_SESSION_ID
-        );
+        let registration = register_response
+            .registration
+            .expect("registration should be present");
+        let scheduler_id = registration.scheduler_id;
+        assert_eq!(registration.session_id, TEST_SESSION_ID);
 
         let get_response = service
             .get_schedulers(Request::new(storage::Void {}))
             .await?
             .into_inner();
-        let schedulers = match get_response.result {
-            Some(get_schedulers_response::Result::Schedulers(registrations)) => registrations,
-            other => panic!("expected schedulers, got {other:?}"),
-        };
+        let schedulers = get_response
+            .schedulers
+            .expect("schedulers should be present");
         assert_eq!(schedulers.schedulers.len(), 1);
         assert_eq!(schedulers.schedulers[0].scheduler_id, scheduler_id);
         Ok(())
@@ -1205,14 +1249,9 @@ mod tests {
     #[tokio::test]
     async fn resend_ready_tasks_succeeds() -> anyhow::Result<()> {
         let service = create_grpc_service();
-        let response = service
+        service
             .resend_ready_tasks(Request::new(storage::ResendReadyTasksRequest {}))
-            .await?
-            .into_inner();
-        assert!(matches!(
-            response.result,
-            Some(resend_ready_tasks_response::Result::Ok(_))
-        ));
+            .await?;
         Ok(())
     }
 
@@ -1234,10 +1273,7 @@ mod tests {
             }))
             .await?
             .into_inner();
-        let tasks = match response.result {
-            Some(poll_ready_tasks_response::Result::Tasks(tasks)) => tasks,
-            other => panic!("expected ready tasks, got {other:?}"),
-        };
+        let tasks = response.tasks.expect("ready tasks should be present");
         assert_eq!(tasks.session_id, TEST_SESSION_ID);
         assert_eq!(tasks.tasks.len(), 1);
         assert_eq!(tasks.tasks[0].resource_group_id, rg_id.get());

--- a/components/spider-storage/src/grpc.rs
+++ b/components/spider-storage/src/grpc.rs
@@ -74,7 +74,7 @@ impl<
     ///
     /// The [`Status`] to send to the client:
     ///
-    /// * `UNAVAILABLE` for a fatal cache-internal error (the service will restart).
+    /// * `INTERNAL` for a fatal cache-internal error (the service will restart).
     /// * `UNAUTHENTICATED` for a wrong resource-group password.
     /// * `NOT_FOUND` for an unknown resource group or a missing job.
     /// * `FAILED_PRECONDITION` for operations on an invalid job state.
@@ -95,7 +95,7 @@ impl<
                     "Internal error in the cache layer. Cancelling service."
                 );
                 self.cancellation_token.cancel();
-                Status::unavailable("storage service unavailable")
+                Status::internal("storage service unavailable")
             }
 
             StorageServerError::Db(db_error) => match &db_error {
@@ -173,8 +173,9 @@ impl<
                     error = % error,
                     service = SERVICE_NAME,
                     tag,
-                    "Unexpected internal error."
+                    "Unexpected internal error. Cancelling service to avoid cache corruption."
                 );
+                self.cancellation_token.cancel();
                 Status::internal("internal error")
             }
         }
@@ -1017,12 +1018,17 @@ impl ToProtoTaskId for CleanupTaskMarker {
 
 /// Builds a [`storage::ReadyTasks`] message from a batch of ready-queue entries.
 ///
+/// # Type Parameters
+///
+/// * `TaskKindType` - The kind of ready-queue task (`ReadyTask`, `CommitTask`, or `CleanupTask`)
+///   carried by each entry; must be convertible to a protobuf task ID.
+///
 /// # Returns
 ///
 /// A [`storage::ReadyTasks`] carrying the storage session and the flattened ready tasks.
-fn ready_tasks<TaskKind: ToProtoTaskId>(
+fn ready_tasks<TaskKindType: ToProtoTaskId>(
     session_id: SessionId,
-    entries: Vec<ReadyQueueEntry<TaskKind>>,
+    entries: Vec<ReadyQueueEntry<TaskKindType>>,
 ) -> storage::ReadyTasks {
     let tasks = entries
         .into_iter()

--- a/components/spider-storage/src/state.rs
+++ b/components/spider-storage/src/state.rs
@@ -11,4 +11,4 @@ pub use runtime::{Runtime, create_runtime};
 pub use service::ServiceState;
 
 #[cfg(test)]
-mod test_utils;
+pub(crate) mod test_utils;

--- a/components/spider-storage/src/state/job_cache.rs
+++ b/components/spider-storage/src/state/job_cache.rs
@@ -3,7 +3,7 @@ use std::{
     sync::Arc,
 };
 
-use spider_core::types::id::JobId;
+use spider_core::types::id::{JobId, ResourceGroupId};
 use tokio::sync::RwLock;
 
 use crate::{
@@ -119,6 +119,27 @@ impl<
             .count()
     }
 
+    /// Removes every job control block belonging to the given resource group from the cache.
+    ///
+    /// # Returns
+    ///
+    /// The number of job control blocks that existed and were removed.
+    pub async fn remove_by_resource_group(&self, resource_group_id: ResourceGroupId) -> usize {
+        let victim_ids: Vec<JobId> = self
+            .jobs
+            .read()
+            .await
+            .iter()
+            .filter(|(_, jcb)| jcb.resource_group_id() == resource_group_id)
+            .map(|(job_id, _)| *job_id)
+            .collect();
+        let mut jobs = self.jobs.write().await;
+        victim_ids
+            .iter()
+            .filter(|job_id| jobs.remove(job_id).is_some())
+            .count()
+    }
+
     /// Resends all ready tasks for every job in the cache to the ready queue.
     ///
     /// # Errors
@@ -184,6 +205,14 @@ mod tests {
         job_id: JobId,
     ) -> SharedJobControlBlock<MockReadyQueueSender, MockDbConnector, MockTaskInstancePoolConnector>
     {
+        create_test_jcb_with_resource_group(job_id, ResourceGroupId::random()).await
+    }
+
+    async fn create_test_jcb_with_resource_group(
+        job_id: JobId,
+        resource_group_id: ResourceGroupId,
+    ) -> SharedJobControlBlock<MockReadyQueueSender, MockDbConnector, MockTaskInstancePoolConnector>
+    {
         let bytes_type = DataTypeDescriptor::Value(ValueTypeDescriptor::bytes());
         let mut submitted =
             SubmittedTaskGraph::new(None, None).expect("task graph creation should succeed");
@@ -205,7 +234,7 @@ mod tests {
                 .expect("job submission should be valid");
         SharedJobControlBlock::create(
             job_id,
-            spider_core::types::id::ResourceGroupId::random(),
+            resource_group_id,
             job_submission,
             MockReadyQueueSender,
             MockDbConnector::default(),
@@ -272,6 +301,47 @@ mod tests {
         assert!(
             cache.get(second_job_id).await.is_none(),
             "second job should be removed"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn job_cache_remove_by_resource_group_evicts_only_owned_jobs() -> anyhow::Result<()> {
+        let cache: JobCache<MockReadyQueueSender, MockDbConnector, MockTaskInstancePoolConnector> =
+            JobCache::new();
+        let target_group = ResourceGroupId::from(42);
+        let other_group = ResourceGroupId::from(7);
+        let first_job_id = JobId::random();
+        let second_job_id = JobId::random();
+        let unrelated_job_id = JobId::random();
+
+        cache
+            .insert(create_test_jcb_with_resource_group(first_job_id, target_group).await)
+            .await?;
+        cache
+            .insert(create_test_jcb_with_resource_group(second_job_id, target_group).await)
+            .await?;
+        cache
+            .insert(create_test_jcb_with_resource_group(unrelated_job_id, other_group).await)
+            .await?;
+
+        let num_removed_jobs = cache.remove_by_resource_group(target_group).await;
+
+        assert_eq!(
+            num_removed_jobs, 2,
+            "only the resource group's jobs should be removed"
+        );
+        assert!(
+            cache.get(first_job_id).await.is_none(),
+            "first owned job should be removed"
+        );
+        assert!(
+            cache.get(second_job_id).await.is_none(),
+            "second owned job should be removed"
+        );
+        assert!(
+            cache.get(unrelated_job_id).await.is_some(),
+            "unrelated job should remain"
         );
         Ok(())
     }

--- a/components/spider-storage/src/state/job_cache.rs
+++ b/components/spider-storage/src/state/job_cache.rs
@@ -201,6 +201,9 @@ mod tests {
         state::test_utils::{MockDbConnector, MockReadyQueueSender, MockTaskInstancePoolConnector},
     };
 
+    /// # Returns
+    ///
+    /// A test job control block owned by a random resource group.
     async fn create_test_jcb(
         job_id: JobId,
     ) -> SharedJobControlBlock<MockReadyQueueSender, MockDbConnector, MockTaskInstancePoolConnector>
@@ -208,6 +211,9 @@ mod tests {
         create_test_jcb_with_resource_group(job_id, ResourceGroupId::random()).await
     }
 
+    /// # Returns
+    ///
+    /// A test job control block owned by `resource_group_id`.
     async fn create_test_jcb_with_resource_group(
         job_id: JobId,
         resource_group_id: ResourceGroupId,

--- a/components/spider-storage/src/state/job_cache.rs
+++ b/components/spider-storage/src/state/job_cache.rs
@@ -331,12 +331,14 @@ mod tests {
             num_removed_jobs, 2,
             "only the resource group's jobs should be removed"
         );
-        assert!(
-            cache.get(first_job_id).await.is_none(),
+        assert_eq!(
+            cache.get(first_job_id).await.map(|_| ()),
+            None,
             "first owned job should be removed"
         );
-        assert!(
-            cache.get(second_job_id).await.is_none(),
+        assert_eq!(
+            cache.get(second_job_id).await.map(|_| ()),
+            None,
             "second owned job should be removed"
         );
         assert!(

--- a/components/spider-storage/src/state/service.rs
+++ b/components/spider-storage/src/state/service.rs
@@ -542,7 +542,7 @@ impl<
             .map_err(StorageServerError::from)
     }
 
-    /// Deletes a resource group and, transitively, all of its jobs.
+    /// Deletes a resource group and all of its jobs from database and cache.
     ///
     /// # Errors
     ///
@@ -554,8 +554,14 @@ impl<
         resource_group_id: ResourceGroupId,
     ) -> Result<(), StorageServerError> {
         self.inner.db.delete(resource_group_id).await?;
+        let evicted_jobs = self
+            .inner
+            .job_cache
+            .remove_by_resource_group(resource_group_id)
+            .await;
         tracing::info!(
             rg_id = ? resource_group_id,
+            evicted_jobs,
             "Resource group deleted.",
         );
         Ok(())

--- a/components/spider-storage/src/state/service.rs
+++ b/components/spider-storage/src/state/service.rs
@@ -544,15 +544,22 @@ impl<
 
     /// Deletes a resource group and all of its jobs from database and cache.
     ///
+    /// The caller must supply the resource group's password, which is verified before any deletion
+    /// occurs so that only an authenticated owner can remove a group and its jobs.
+    ///
     /// # Errors
     ///
     /// Returns an error if:
     ///
+    /// * Forwards [`ResourceGroupManagement::verify`]'s return values on failure (wrong password or
+    ///   unknown resource group).
     /// * Forwards [`ResourceGroupManagement::delete`]'s return values on failure.
     pub async fn delete_resource_group(
         &self,
         resource_group_id: ResourceGroupId,
+        password: &[u8],
     ) -> Result<(), StorageServerError> {
+        self.inner.db.verify(resource_group_id, password).await?;
         self.inner.db.delete(resource_group_id).await?;
         let evicted_jobs = self
             .inner
@@ -1616,10 +1623,11 @@ mod tests {
     #[tokio::test]
     async fn delete_resource_group_succeeds_for_existing() -> anyhow::Result<()> {
         let service = create_test_service();
+        let password = vec![1, 2, 3];
         let rg_id = service
-            .add_resource_group("external_123".to_owned(), vec![1, 2, 3])
+            .add_resource_group("external_123".to_owned(), password.clone())
             .await?;
-        service.delete_resource_group(rg_id).await?;
+        service.delete_resource_group(rg_id, &password).await?;
         let result = service.verify_resource_group(rg_id, &[1, 2, 3]).await;
         assert!(
             result.is_err(),
@@ -1629,10 +1637,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn delete_resource_group_rejects_wrong_password() -> anyhow::Result<()> {
+        let service = create_test_service();
+        let rg_id = service
+            .add_resource_group("external_123".to_owned(), vec![1, 2, 3])
+            .await?;
+        let result = service.delete_resource_group(rg_id, &[4, 5, 6]).await;
+        assert!(
+            matches!(
+                result,
+                Err(StorageServerError::Db(DbError::InvalidPassword(_)))
+            ),
+            "delete_resource_group should return InvalidPassword for a wrong password"
+        );
+        assert!(
+            service
+                .verify_resource_group(rg_id, &[1, 2, 3])
+                .await
+                .is_ok(),
+            "resource group should still exist when the password is wrong"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn delete_resource_group_returns_error_for_unknown() -> anyhow::Result<()> {
         let service = create_test_service();
         let result = service
-            .delete_resource_group(ResourceGroupId::random())
+            .delete_resource_group(ResourceGroupId::random(), &[1, 2, 3])
             .await;
         assert!(
             matches!(

--- a/components/spider-storage/src/state/service.rs
+++ b/components/spider-storage/src/state/service.rs
@@ -542,6 +542,25 @@ impl<
             .map_err(StorageServerError::from)
     }
 
+    /// Deletes a resource group and, transitively, all of its jobs.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * Forwards [`ResourceGroupManagement::delete`]'s return values on failure.
+    pub async fn delete_resource_group(
+        &self,
+        resource_group_id: ResourceGroupId,
+    ) -> Result<(), StorageServerError> {
+        self.inner.db.delete(resource_group_id).await?;
+        tracing::info!(
+            rg_id = ? resource_group_id,
+            "Resource group deleted.",
+        );
+        Ok(())
+    }
+
     /// Polls the ready queue for task entries.
     ///
     /// # Returns
@@ -1585,6 +1604,37 @@ mod tests {
             .await?;
         let result = service.verify_resource_group(rg_id, &[4, 5, 6]).await;
         assert!(result.is_err(), "verify should fail for wrong password");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn delete_resource_group_succeeds_for_existing() -> anyhow::Result<()> {
+        let service = create_test_service();
+        let rg_id = service
+            .add_resource_group("external_123".to_owned(), vec![1, 2, 3])
+            .await?;
+        service.delete_resource_group(rg_id).await?;
+        let result = service.verify_resource_group(rg_id, &[1, 2, 3]).await;
+        assert!(
+            result.is_err(),
+            "verify should fail after the resource group is deleted"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn delete_resource_group_returns_error_for_unknown() -> anyhow::Result<()> {
+        let service = create_test_service();
+        let result = service
+            .delete_resource_group(ResourceGroupId::random())
+            .await;
+        assert!(
+            matches!(
+                result,
+                Err(StorageServerError::Db(DbError::ResourceGroupNotFound(_)))
+            ),
+            "delete_resource_group should return ResourceGroupNotFound for an unknown id"
+        );
         Ok(())
     }
 

--- a/components/spider-storage/src/state/test_utils.rs
+++ b/components/spider-storage/src/state/test_utils.rs
@@ -79,6 +79,8 @@ pub struct MockDbConnector {
     pub next_resource_group_id: Arc<AtomicUsize>,
     pub execution_managers: Arc<DashMap<ExecutionManagerId, IpAddr>>,
     pub next_execution_manager_id: Arc<AtomicUsize>,
+    pub schedulers: Arc<DashMap<SchedulerId, RegisteredScheduler>>,
+    pub next_scheduler_id: Arc<AtomicUsize>,
     pub session_id: SessionId,
 }
 
@@ -92,6 +94,8 @@ impl Default for MockDbConnector {
             next_resource_group_id: Arc::new(AtomicUsize::new(1)),
             execution_managers: Arc::new(DashMap::new()),
             next_execution_manager_id: Arc::new(AtomicUsize::new(1)),
+            schedulers: Arc::new(DashMap::new()),
+            next_scheduler_id: Arc::new(AtomicUsize::new(1)),
             session_id: 0,
         }
     }
@@ -257,18 +261,30 @@ impl ExecutionManagerLivenessManagement for MockDbConnector {
 impl SchedulerRegistrationManagement for MockDbConnector {
     async fn register_scheduler(
         &self,
-        _ip_address: IpAddr,
-        _port: u16,
+        ip_address: IpAddr,
+        port: u16,
     ) -> Result<SchedulerId, DbError> {
-        unreachable!("not implemented for mock connector")
+        // Mirror the production semantics: only one scheduler is registered at a time.
+        self.schedulers.clear();
+        let counter = self.next_scheduler_id.fetch_add(1, Ordering::Relaxed);
+        let scheduler_id = SchedulerId::from(counter as u64);
+        self.schedulers.insert(
+            scheduler_id,
+            RegisteredScheduler {
+                id: scheduler_id,
+                ip_address,
+                port,
+            },
+        );
+        Ok(scheduler_id)
     }
 
     async fn get_schedulers(&self) -> Result<Vec<RegisteredScheduler>, DbError> {
-        unreachable!("not implemented for mock connector")
+        Ok(self.schedulers.iter().map(|entry| *entry).collect())
     }
 
-    async fn is_scheduler_registered(&self, _scheduler_id: SchedulerId) -> Result<bool, DbError> {
-        unreachable!("not implemented for mock connector")
+    async fn is_scheduler_registered(&self, scheduler_id: SchedulerId) -> Result<bool, DbError> {
+        Ok(self.schedulers.contains_key(&scheduler_id))
     }
 }
 

--- a/components/spider-storage/tests/mariadb_test.rs
+++ b/components/spider-storage/tests/mariadb_test.rs
@@ -639,6 +639,47 @@ async fn test_verify_nonexistent_resource_group() {
 
 #[tokio::test]
 #[ignore = "requires MariaDB"]
+async fn test_delete_resource_group_removes_group_and_its_jobs() {
+    let storage = create_mariadb_connector().await;
+    let rg_id = create_test_resource_group(&storage).await;
+    let (graph, inputs) = single_task_graph();
+    let job_submission =
+        ValidatedJobSubmission::create(graph, inputs).expect("job submission should be valid");
+    let job_id = storage
+        .register(rg_id, &job_submission)
+        .await
+        .expect("register should succeed");
+
+    storage.delete(rg_id).await.expect("delete should succeed");
+
+    let verify_result = storage.verify(rg_id, b"test-password").await;
+    assert!(
+        matches!(verify_result, Err(DbError::ResourceGroupNotFound(_))),
+        "verify should fail after the resource group is deleted, got {verify_result:?}"
+    );
+
+    let job_state_result = storage.get_state(job_id).await;
+    assert!(
+        matches!(job_state_result, Err(DbError::JobNotFound(_))),
+        "the resource group's jobs should be removed, got {job_state_result:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires MariaDB"]
+async fn test_delete_nonexistent_resource_group() {
+    let storage = create_mariadb_connector().await;
+    let fake_rg_id = ResourceGroupId::random();
+
+    let result = storage.delete(fake_rg_id).await;
+    assert!(
+        matches!(result, Err(DbError::ResourceGroupNotFound(_))),
+        "expected ResourceGroupNotFound, got {result:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires MariaDB"]
 async fn test_start_job_not_found() {
     let storage = create_mariadb_connector().await;
     let fake_job_id = JobId::random();


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

- Use gRPC status instead of custom error code.
- Add delete resource group implementation.
- Fix #352 by adding back `ResendReadyTasks` and `DeleteResourceGroup`.

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

## Use gRPC status instead of custom error code

Replace remaining error codes in gRPC protocol (`InboundQueueResponseError`, `ResourceGroupManagementError`, `ExecutionManagerLivenessError`, `SchedulerRegistrationError`) with status.

Update scheduler and execution manager clients to parse gRPC status into local error type.


## Add delete resource group implementation

Adds resource group deletion in database and in cache. This also removes all jobs belonging to this resource group from both database and cache.

> [!Warning]
> Because of the limitation in the scheduler queue implementation, enqueued tasks owned by the resource group are not removed. However, the scheduled task should later fail at task instance creation.
> There is known possible race condition between the deletion and another task instance creation. However, the task should fail later when reporting result, with no extra action needed by storage.

## Add `ResendReadyTasks`

As pointed out in #352, `ResendReadyTasks` is now put into `InboundQueueService`.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
- [ ] GitHub workflows pass.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for deleting resource groups, including removing associated cached jobs.
  * Added an inbound-queue RPC to resend ready tasks (and scheduler client support for it).
  * Expanded scheduler support with registration and listing of schedulers.
* **Bug Fixes**
  * Treat “job gone” and missing-job scenarios as benign no-ops during task registration and outcome reporting.
  * Improved gRPC status/error mapping and updated response parsing for simplified service responses.
* **Tests**
  * Updated and extended unit/integration coverage for new response shapes, mappings, and resend/delete behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->