### PR TITLE
fix(spider-storage): Reserve `UNAVAILABLE` gRPC status code for network connection errors.

### DIFF
--- a/components/spider-execution-manager/src/client/grpc/storage.rs
+++ b/components/spider-execution-manager/src/client/grpc/storage.rs
@@ -135,15 +135,17 @@ impl StorageClient for GrpcStorageClient {
 ///
 /// The [`StorageResponseError`] for `status`'s code:
 ///
-/// * [`StorageResponseError::StaleSession`] for `UNAVAILABLE`.
+/// * [`StorageResponseError::StaleSession`] for `NOT_FOUND`.
 /// * [`StorageResponseError::CacheStale`] for `FAILED_PRECONDITION`.
 /// * [`StorageResponseError::InvalidInput`] for `INVALID_ARGUMENT`.
+/// * [`StorageResponseError::Transport`] for `UNAVAILABLE` (a lost or unestablished connection).
 /// * [`StorageResponseError::Server`] for any other code.
 fn status_to_error(status: &Status) -> StorageResponseError {
     match status.code() {
-        Code::Unavailable => StorageResponseError::StaleSession(status.message().to_owned()),
+        Code::NotFound => StorageResponseError::StaleSession(status.message().to_owned()),
         Code::FailedPrecondition => StorageResponseError::CacheStale(status.message().to_owned()),
         Code::InvalidArgument => StorageResponseError::InvalidInput(status.message().to_owned()),
+        Code::Unavailable => to_transport_error(status.message()),
         _ => StorageResponseError::Server(status.message().to_owned()),
     }
 }
@@ -162,17 +164,29 @@ mod tests {
     use super::*;
 
     #[test]
-    fn status_maps_unavailable_to_stale_session() {
-        match status_to_error(&Status::unavailable("storage session is 9")) {
+    fn status_maps_not_found_to_stale_session() {
+        match status_to_error(&Status::not_found("storage session is 9")) {
             StorageResponseError::StaleSession(message) => assert!(message.contains('9')),
             error => panic!("unexpected error: {error:?}"),
         }
     }
 
     #[test]
+    fn status_maps_unavailable_to_transport() {
+        const MESSAGE: &str = "connection lost";
+        match status_to_error(&Status::unavailable(MESSAGE)) {
+            StorageResponseError::Transport(message) => {
+                assert!(message.contains(MESSAGE));
+            }
+            error => panic!("unexpected error: {error:?}"),
+        }
+    }
+
+    #[test]
     fn status_maps_invalid_argument_to_invalid_input() {
-        match status_to_error(&Status::invalid_argument("bad task id")) {
-            StorageResponseError::InvalidInput(message) => assert!(message.contains("bad task id")),
+        const MESSAGE: &str = "bad task id";
+        match status_to_error(&Status::invalid_argument(MESSAGE)) {
+            StorageResponseError::InvalidInput(message) => assert!(message.contains(MESSAGE)),
             error => panic!("unexpected error: {error:?}"),
         }
     }

--- a/components/spider-storage/src/grpc.rs
+++ b/components/spider-storage/src/grpc.rs
@@ -75,12 +75,13 @@ impl<
     ///
     /// The [`Status`] to send to the client:
     ///
-    /// * `UNAVAILABLE` for a fatal cache-internal error (the service will restart).
+    /// * `INTERNAL` for:
+    ///   * A fatal cache-internal error (the service will restart).
+    ///   * Any other (database or otherwise unexpected) error.
     /// * `UNAUTHENTICATED` for an unknown or unauthorized resource group.
     /// * `NOT_FOUND` for a missing job.
     /// * `FAILED_PRECONDITION` for operations on an invalid job state.
     /// * `INVALID_ARGUMENT` for a malformed task graph, inputs, or request.
-    /// * `INTERNAL` for any other (database or otherwise unexpected) error.
     pub fn job_orchestration_service_error_handler(
         &self,
         error: StorageServerError,
@@ -96,7 +97,7 @@ impl<
                     "Internal error in the cache layer. Cancelling service."
                 );
                 self.cancellation_token.cancel();
-                Status::unavailable("storage service unavailable")
+                Status::internal("storage service unavailable")
             }
 
             StorageServerError::Db(db_error) => match &db_error {
@@ -182,7 +183,7 @@ impl<
     /// * `INTERNAL` for:
     ///   * A fatal cache-internal error (the service will restart).
     ///   * Any other unexpected error (the service will restart).
-    /// * `UNAVAILABLE` for a request issued from a stale session.
+    /// * `NOT_FOUND` for a request issued from a stale session.
     /// * `FAILED_PRECONDITION` for a request issued against a stale cache state.
     /// * `INVALID_ARGUMENT` for malformed inputs or a malformed request.
     pub fn task_instance_management_service_error_handler(
@@ -210,7 +211,7 @@ impl<
                     tag,
                     "The request was issued from a stale session."
                 );
-                Status::unavailable(format!(
+                Status::not_found(format!(
                     "stale session; current storage session is {storage_session}"
                 ))
             }


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

`UNAVAILABLE` was being returned by user code in two storage handlers, which made it ambiguous: a genuine transport failure (lost or unestablished connection) and an application-level error both surfaced as `UNAVAILABLE`, so the execution-manager client could not tell them apart. Per the [gRPC status-code guidance](https://grpc.io/docs/guides/status-codes/), only a small set of codes are appropriate for user code to return, and `UNAVAILABLE` is best left to the transport. This PR remaps the two offending cases onto application-appropriate codes and updates the execution-manager client to treat `UNAVAILABLE` as a transport error. It closes the follow-up flagged at the end of #354.

## Server changes (`spider-storage/src/grpc.rs`)

- `job_orchestration_service_error_handler`: a fatal cache-internal error now returns `INTERNAL` instead of `UNAVAILABLE` (it still fires the cancellation token and restarts the service).
- `task_instance_management_service_error_handler`: a request from a stale session now returns `NOT_FOUND` instead of `UNAVAILABLE`. The other mappings are unchanged.
- Updated the handler doc comments to match.

## Client changes (`spider-execution-manager/src/client/grpc/storage.rs`)

- `status_to_error` now maps `Code::Unavailable` to `StorageResponseError::Transport`, so a lost or unestablished connection is reported as a transport failure rather than as an application error.
- Stale-session detection is remapped to follow the server: `Code::NotFound` → `StorageResponseError::StaleSession`. This is required for correctness — without it, the server's new `NOT_FOUND` stale-session response would fall through to the generic `Server` case and stale-session handling would silently break.
- Updated the unit tests: replaced `status_maps_unavailable_to_stale_session` with `status_maps_not_found_to_stale_session`, and added `status_maps_unavailable_to_transport`.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Ensure all workflows pass.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gRPC error responses for storage-related issues, so some failures now return more appropriate status codes.
  * Session-related errors are now reported more consistently, helping clients distinguish missing, stale, and transport-related problems.
  * Updated error messages to better reflect the actual issue returned to callers.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->