### PR TITLE
feat(spider-utils): Add a gRPC connection pool and route the execution-manager and scheduler gRPC clients through it.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2056,6 +2056,7 @@ dependencies = [
  "serde",
  "spider-core",
  "spider-proto-rust",
+ "spider-utils",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -2142,6 +2143,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "thiserror",
+ "tonic",
  "tracing-appender",
  "tracing-subscriber",
 ]

--- a/components/spider-execution-manager/src/client/grpc/liveness.rs
+++ b/components/spider-execution-manager/src/client/grpc/liveness.rs
@@ -1,6 +1,6 @@
 //! gRPC-backed [`LivenessClient`] implementation.
 
-use std::net::IpAddr;
+use std::{net::IpAddr, num::NonZeroUsize};
 
 use async_trait::async_trait;
 use spider_core::types::id::{ExecutionManagerId, SessionId};
@@ -11,6 +11,7 @@ use spider_proto_rust::storage::{
     register_execution_manager_response,
     update_execution_manager_heartbeat_response,
 };
+use spider_utils::grpc::client::ConnectionPool;
 use tonic::transport::{Channel, Endpoint};
 
 use crate::client::liveness::{LivenessClient, LivenessResponseError, RegistrationResponse};
@@ -18,11 +19,11 @@ use crate::client::liveness::{LivenessClient, LivenessResponseError, Registratio
 /// gRPC-backed [`LivenessClient`] implementation.
 #[derive(Debug, Clone)]
 pub struct GrpcLivenessClient {
-    client: ExecutionManagerLivenessServiceClient<Channel>,
+    connection_pool: ConnectionPool<ExecutionManagerLivenessServiceClient<Channel>>,
 }
 
 impl GrpcLivenessClient {
-    /// Connects to the storage gRPC endpoint.
+    /// Connects a pool of `pool_size` connections to the storage gRPC endpoint.
     ///
     /// # Returns
     ///
@@ -33,11 +34,17 @@ impl GrpcLivenessClient {
     /// Returns an error if:
     ///
     /// * [`LivenessResponseError::Transport`] if tonic cannot create or connect to the endpoint.
-    pub async fn connect(endpoint: Endpoint) -> Result<Self, LivenessResponseError> {
-        ExecutionManagerLivenessServiceClient::connect(endpoint)
-            .await
-            .map(|client| Self { client })
-            .map_err(to_transport_error)
+    pub async fn connect(
+        endpoint: Endpoint,
+        pool_size: NonZeroUsize,
+    ) -> Result<Self, LivenessResponseError> {
+        let connection_pool = ConnectionPool::connect(endpoint, pool_size, |channel| {
+            Ok(ExecutionManagerLivenessServiceClient::new(channel))
+        })
+        .await
+        .map_err(to_transport_error)?;
+
+        Ok(Self { connection_pool })
     }
 }
 
@@ -48,8 +55,8 @@ impl LivenessClient for GrpcLivenessClient {
             ip_address: ip.to_string(),
         };
         let response = self
-            .client
-            .clone()
+            .connection_pool
+            .get_client()
             .register_execution_manager(request)
             .await
             .map_err(to_transport_error)?
@@ -66,8 +73,8 @@ impl LivenessClient for GrpcLivenessClient {
             execution_manager_id: em_id.get(),
         };
         let response = self
-            .client
-            .clone()
+            .connection_pool
+            .get_client()
             .update_execution_manager_heartbeat(request)
             .await
             .map_err(to_transport_error)?

--- a/components/spider-execution-manager/src/client/grpc/liveness.rs
+++ b/components/spider-execution-manager/src/client/grpc/liveness.rs
@@ -39,7 +39,7 @@ impl GrpcLivenessClient {
         pool_size: NonZeroUsize,
     ) -> Result<Self, LivenessResponseError> {
         let connection_pool = ConnectionPool::connect(endpoint, pool_size, |channel| {
-            Ok(ExecutionManagerLivenessServiceClient::new(channel))
+            ExecutionManagerLivenessServiceClient::new(channel)
         })
         .await
         .map_err(to_transport_error)?;

--- a/components/spider-execution-manager/src/client/grpc/liveness.rs
+++ b/components/spider-execution-manager/src/client/grpc/liveness.rs
@@ -23,7 +23,7 @@ pub struct GrpcLivenessClient {
 }
 
 impl GrpcLivenessClient {
-    /// Connects a pool of `pool_size` connections to the storage gRPC endpoint.
+    /// Connects a pool of `pool_size` connections to the liveness gRPC endpoint.
     ///
     /// # Returns
     ///

--- a/components/spider-execution-manager/src/client/grpc/scheduler.rs
+++ b/components/spider-execution-manager/src/client/grpc/scheduler.rs
@@ -33,7 +33,7 @@ impl GrpcSchedulerClient {
         pool_size: NonZeroUsize,
     ) -> Result<Self, SchedulerError> {
         let connection_pool = ConnectionPool::connect(endpoint, pool_size, |channel| {
-            Ok(SchedulerServiceClient::new(channel))
+            SchedulerServiceClient::new(channel)
         })
         .await
         .map_err(to_transport_error)?;

--- a/components/spider-execution-manager/src/client/grpc/scheduler.rs
+++ b/components/spider-execution-manager/src/client/grpc/scheduler.rs
@@ -1,8 +1,11 @@
 //! gRPC-backed [`SchedulerClient`] implementation.
 
+use std::num::NonZeroUsize;
+
 use async_trait::async_trait;
 use spider_core::types::{id::ExecutionManagerId, scheduler::TaskAssignmentRecord};
 use spider_proto_rust::scheduler::{self, scheduler_service_client::SchedulerServiceClient};
+use spider_utils::grpc::client::ConnectionPool;
 use tonic::transport::{Channel, Endpoint};
 
 use crate::client::{SchedulerClient, SchedulerError, SchedulerResponse};
@@ -10,11 +13,11 @@ use crate::client::{SchedulerClient, SchedulerError, SchedulerResponse};
 /// gRPC-backed [`SchedulerClient`] implementation.
 #[derive(Debug, Clone)]
 pub struct GrpcSchedulerClient {
-    client: SchedulerServiceClient<Channel>,
+    connection_pool: ConnectionPool<SchedulerServiceClient<Channel>>,
 }
 
 impl GrpcSchedulerClient {
-    /// Connects to the scheduler gRPC endpoint.
+    /// Connects a pool of `pool_size` connections to the scheduler gRPC endpoint.
     ///
     /// # Returns
     ///
@@ -25,11 +28,17 @@ impl GrpcSchedulerClient {
     /// Returns an error if:
     ///
     /// * [`SchedulerError::Transport`] if tonic cannot create or connect to the endpoint.
-    pub async fn connect(endpoint: Endpoint) -> Result<Self, SchedulerError> {
-        SchedulerServiceClient::connect(endpoint)
-            .await
-            .map(|client| Self { client })
-            .map_err(to_transport_error)
+    pub async fn connect(
+        endpoint: Endpoint,
+        pool_size: NonZeroUsize,
+    ) -> Result<Self, SchedulerError> {
+        let connection_pool = ConnectionPool::connect(endpoint, pool_size, |channel| {
+            Ok(SchedulerServiceClient::new(channel))
+        })
+        .await
+        .map_err(to_transport_error)?;
+
+        Ok(Self { connection_pool })
     }
 }
 
@@ -43,8 +52,8 @@ impl SchedulerClient for GrpcSchedulerClient {
     ) -> Result<SchedulerResponse, SchedulerError> {
         loop {
             let response = self
-                .client
-                .clone()
+                .connection_pool
+                .get_client()
                 .next_task(scheduler::NextTaskRequest {
                     execution_manager_id: em_id.get(),
                     prev_assignment: prev_assignment.map(Into::into),
@@ -63,8 +72,8 @@ impl SchedulerClient for GrpcSchedulerClient {
     }
 
     async fn heartbeat(&self, em_id: ExecutionManagerId) -> Result<(), SchedulerError> {
-        self.client
-            .clone()
+        self.connection_pool
+            .get_client()
             .heartbeat(scheduler::HeartbeatRequest {
                 execution_manager_id: em_id.get(),
             })
@@ -79,8 +88,8 @@ impl SchedulerClient for GrpcSchedulerClient {
         prev_assignments: Vec<TaskAssignmentRecord>,
     ) {
         if let Err(error) = self
-            .client
-            .clone()
+            .connection_pool
+            .get_client()
             .shutdown(scheduler::ShutdownRequest {
                 execution_manager_id: em_id.get(),
                 prev_assignments: prev_assignments.into_iter().map(Into::into).collect(),

--- a/components/spider-execution-manager/src/client/grpc/storage.rs
+++ b/components/spider-execution-manager/src/client/grpc/storage.rs
@@ -3,6 +3,8 @@
 //! Wraps the generated [`TaskInstanceManagementServiceClient`] and adapts its protobuf
 //! request/response types to the transport-agnostic [`StorageClient`] trait.
 
+use std::num::NonZeroUsize;
+
 use async_trait::async_trait;
 use spider_core::types::{
     id::{ExecutionManagerId, JobId, SessionId, TaskId, TaskInstanceId},
@@ -12,6 +14,7 @@ use spider_proto_rust::{
     common,
     storage::{self, task_instance_management_service_client::TaskInstanceManagementServiceClient},
 };
+use spider_utils::grpc::client::ConnectionPool;
 use tonic::{
     Code,
     Status,
@@ -23,11 +26,11 @@ use crate::client::storage::{StorageClient, StorageResponseError};
 /// gRPC-backed [`StorageClient`] implementation.
 #[derive(Debug, Clone)]
 pub struct GrpcStorageClient {
-    client: TaskInstanceManagementServiceClient<Channel>,
+    connection_pool: ConnectionPool<TaskInstanceManagementServiceClient<Channel>>,
 }
 
 impl GrpcStorageClient {
-    /// Connects to the storage gRPC endpoint.
+    /// Connects a pool of `pool_size` connections to the storage gRPC endpoint.
     ///
     /// # Returns
     ///
@@ -38,11 +41,17 @@ impl GrpcStorageClient {
     /// Returns an error if:
     ///
     /// * [`StorageResponseError::Transport`] if tonic cannot create or connect to the endpoint.
-    pub async fn connect(endpoint: Endpoint) -> Result<Self, StorageResponseError> {
-        TaskInstanceManagementServiceClient::connect(endpoint)
-            .await
-            .map(|client| Self { client })
-            .map_err(to_transport_error)
+    pub async fn connect(
+        endpoint: Endpoint,
+        pool_size: NonZeroUsize,
+    ) -> Result<Self, StorageResponseError> {
+        let connection_pool = ConnectionPool::connect(endpoint, pool_size, |channel| {
+            Ok(TaskInstanceManagementServiceClient::new(channel))
+        })
+        .await
+        .map_err(to_transport_error)?;
+
+        Ok(Self { connection_pool })
     }
 }
 
@@ -62,8 +71,8 @@ impl StorageClient for GrpcStorageClient {
             session_id,
         };
         let response = self
-            .client
-            .clone()
+            .connection_pool
+            .get_client()
             .register_task_instance(request)
             .await
             .map_err(|status| status_to_error(&status))?
@@ -95,8 +104,8 @@ impl StorageClient for GrpcStorageClient {
             serialized_outputs: serialized_outputs.unwrap_or_default(),
             task_instance_id,
         };
-        self.client
-            .clone()
+        self.connection_pool
+            .get_client()
             .report_task_success(request)
             .await
             .map_err(|status| status_to_error(&status))?;
@@ -120,8 +129,8 @@ impl StorageClient for GrpcStorageClient {
             error_message,
             task_instance_id,
         };
-        self.client
-            .clone()
+        self.connection_pool
+            .get_client()
             .report_task_failure(request)
             .await
             .map_err(|status| status_to_error(&status))?;

--- a/components/spider-execution-manager/src/client/grpc/storage.rs
+++ b/components/spider-execution-manager/src/client/grpc/storage.rs
@@ -46,7 +46,7 @@ impl GrpcStorageClient {
         pool_size: NonZeroUsize,
     ) -> Result<Self, StorageResponseError> {
         let connection_pool = ConnectionPool::connect(endpoint, pool_size, |channel| {
-            Ok(TaskInstanceManagementServiceClient::new(channel))
+            TaskInstanceManagementServiceClient::new(channel)
         })
         .await
         .map_err(to_transport_error)?;

--- a/components/spider-scheduler/Cargo.toml
+++ b/components/spider-scheduler/Cargo.toml
@@ -13,6 +13,7 @@ async-trait = "0.1.89"
 serde = { version = "1.0.228", features = ["derive"] }
 spider-core = { path = "../spider-core" }
 spider-proto-rust = { path = "../spider-proto-rust" }
+spider-utils = { path = "../spider-utils" }
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["macros", "rt", "sync", "time"] }
 tokio-util = "0.7.18"

--- a/components/spider-scheduler/src/storage_client/grpc.rs
+++ b/components/spider-scheduler/src/storage_client/grpc.rs
@@ -1,6 +1,6 @@
 //! gRPC-backed [`SchedulerStorageClient`] implementation.
 
-use std::time::Duration;
+use std::{num::NonZeroUsize, time::Duration};
 
 use async_trait::async_trait;
 use spider_core::{
@@ -14,6 +14,7 @@ use spider_proto_rust::storage::{
     job_orchestration_service_client::JobOrchestrationServiceClient,
     poll_ready_tasks_response,
 };
+use spider_utils::grpc::client::ConnectionPool;
 use tonic::{
     Code,
     transport::{Channel, Endpoint},
@@ -28,12 +29,12 @@ use crate::{
 /// gRPC-backed [`SchedulerStorageClient`] implementation.
 #[derive(Debug, Clone)]
 pub struct GrpcSchedulerStorageClient {
-    scheduler_client: InboundQueueServiceClient<Channel>,
-    job_client: JobOrchestrationServiceClient<Channel>,
+    inbound_queue_connection_pool: ConnectionPool<InboundQueueServiceClient<Channel>>,
+    job_orchestration_connection_pool: ConnectionPool<JobOrchestrationServiceClient<Channel>>,
 }
 
 impl GrpcSchedulerStorageClient {
-    /// Connects to the storage gRPC endpoint.
+    /// Connects pools of `pool_size` connections to the storage gRPC endpoint.
     ///
     /// # Returns
     ///
@@ -44,12 +45,26 @@ impl GrpcSchedulerStorageClient {
     /// Returns an error if:
     ///
     /// * [`StorageClientError::Transport`] if tonic cannot create or connect to the endpoint.
-    pub async fn connect(endpoint: Endpoint) -> Result<Self, StorageClientError> {
-        let channel = endpoint.connect().await.map_err(to_transport_error)?;
+    pub async fn connect(
+        endpoint: Endpoint,
+        pool_size: NonZeroUsize,
+    ) -> Result<Self, StorageClientError> {
+        let inbound_queue_connection_pool =
+            ConnectionPool::connect(endpoint.clone(), pool_size, |channel| {
+                Ok(InboundQueueServiceClient::new(channel))
+            })
+            .await
+            .map_err(to_transport_error)?;
+        let job_orchestration_connection_pool =
+            ConnectionPool::connect(endpoint, pool_size, |channel| {
+                Ok(JobOrchestrationServiceClient::new(channel))
+            })
+            .await
+            .map_err(to_transport_error)?;
 
         Ok(Self {
-            scheduler_client: InboundQueueServiceClient::new(channel.clone()),
-            job_client: JobOrchestrationServiceClient::new(channel),
+            inbound_queue_connection_pool,
+            job_orchestration_connection_pool,
         })
     }
 }
@@ -63,8 +78,8 @@ impl SchedulerStorageClient for GrpcSchedulerStorageClient {
     ) -> Result<(SessionId, Vec<InboundEntry>), StorageClientError> {
         let request = poll_ready_tasks_request(max_items, wait)?;
         let response = self
-            .scheduler_client
-            .clone()
+            .inbound_queue_connection_pool
+            .get_client()
             .poll_ready_tasks(request)
             .await
             .map_err(to_transport_error)?
@@ -79,8 +94,8 @@ impl SchedulerStorageClient for GrpcSchedulerStorageClient {
     ) -> Result<(SessionId, Vec<InboundEntry>), StorageClientError> {
         let request = poll_ready_tasks_request(max_items, wait)?;
         let response = self
-            .scheduler_client
-            .clone()
+            .inbound_queue_connection_pool
+            .get_client()
             .poll_ready_commit_tasks(request)
             .await
             .map_err(to_transport_error)?
@@ -95,8 +110,8 @@ impl SchedulerStorageClient for GrpcSchedulerStorageClient {
     ) -> Result<(SessionId, Vec<InboundEntry>), StorageClientError> {
         let request = poll_ready_tasks_request(max_items, wait)?;
         let response = self
-            .scheduler_client
-            .clone()
+            .inbound_queue_connection_pool
+            .get_client()
             .poll_ready_cleanup_tasks(request)
             .await
             .map_err(to_transport_error)?
@@ -109,8 +124,8 @@ impl SchedulerStorageClient for GrpcSchedulerStorageClient {
             job_id: job_id.get(),
         };
         let response = self
-            .job_client
-            .clone()
+            .job_orchestration_connection_pool
+            .get_client()
             .get_job_state(request)
             .await
             .map_err(|status| match status.code() {

--- a/components/spider-scheduler/src/storage_client/grpc.rs
+++ b/components/spider-scheduler/src/storage_client/grpc.rs
@@ -51,13 +51,13 @@ impl GrpcSchedulerStorageClient {
     ) -> Result<Self, StorageClientError> {
         let inbound_queue_connection_pool =
             ConnectionPool::connect(endpoint.clone(), pool_size, |channel| {
-                Ok(InboundQueueServiceClient::new(channel))
+                InboundQueueServiceClient::new(channel)
             })
             .await
             .map_err(to_transport_error)?;
         let job_orchestration_connection_pool =
             ConnectionPool::connect(endpoint, pool_size, |channel| {
-                Ok(JobOrchestrationServiceClient::new(channel))
+                JobOrchestrationServiceClient::new(channel)
             })
             .await
             .map_err(to_transport_error)?;

--- a/components/spider-utils/Cargo.toml
+++ b/components/spider-utils/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/lib.rs"
 rmp-serde = "1.3.1"
 serde = { version = "1.0.228", features = ["derive"] }
 thiserror = "2.0.18"
+tonic = "0.12.3"
 tracing-appender = "0.2.5"
 tracing-subscriber = {
   version = "0.3.23",

--- a/components/spider-utils/src/grpc/client.rs
+++ b/components/spider-utils/src/grpc/client.rs
@@ -41,8 +41,7 @@ impl<GrpcServiceClientType: Clone> ConnectionPool<GrpcServiceClientType> {
     /// Returns an error if:
     ///
     /// * [`Error::TonicTransport`] if a connection to `endpoint` fails to establish.
-    /// * Forwards `client_factory`'s return values on failure.
-    pub async fn connect<ClientFactory: Fn(Channel) -> Result<GrpcServiceClientType, Error>>(
+    pub async fn connect<ClientFactory: Fn(Channel) -> GrpcServiceClientType>(
         endpoint: Endpoint,
         pool_size: NonZeroUsize,
         client_factory: ClientFactory,
@@ -54,7 +53,7 @@ impl<GrpcServiceClientType: Clone> ConnectionPool<GrpcServiceClientType> {
                 .connect()
                 .await
                 .map_err(Error::TonicTransport)?;
-            connections.push(client_factory(channel)?);
+            connections.push(client_factory(channel));
         }
 
         Ok(Self {

--- a/components/spider-utils/src/grpc/client.rs
+++ b/components/spider-utils/src/grpc/client.rs
@@ -1,0 +1,87 @@
+//! A round-robin pool of gRPC service-client connections.
+
+use std::{
+    num::NonZeroUsize,
+    sync::{Arc, atomic::AtomicUsize},
+};
+
+use tonic::transport::{Channel, Endpoint};
+
+use super::Error;
+
+/// A pool of independent gRPC connections to a single endpoint.
+///
+/// Each pooled client holds its own connection, so spreading requests across the pool avoids the
+/// throughput bottleneck caused by [hyperium/h2#531](https://github.com/hyperium/h2/issues/531).
+///
+/// # Type Parameters
+///
+/// * `GrpcServiceClientType` - The gRPC service client type held by the pool.
+#[derive(Clone, Debug)]
+pub struct ConnectionPool<GrpcServiceClientType: Clone> {
+    inner: Arc<ConnectionPoolInner<GrpcServiceClientType>>,
+}
+
+impl<GrpcServiceClientType: Clone> ConnectionPool<GrpcServiceClientType> {
+    /// Builds a pool of `pool_size` independent connections to `endpoint`.
+    ///
+    /// Each connection is established eagerly, then handed to `client_factory` to build the service
+    /// client that wraps it.
+    ///
+    /// # Type Parameters
+    ///
+    /// * `ClientFactory` - Builds a service client from a connected [`Channel`].
+    ///
+    /// # Returns
+    ///
+    /// A new [`ConnectionPool`] holding `pool_size` connected clients on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * [`Error::TonicTransport`] if a connection to `endpoint` fails to establish.
+    /// * Forwards `client_factory`'s return values on failure.
+    pub async fn connect<ClientFactory: Fn(Channel) -> Result<GrpcServiceClientType, Error>>(
+        endpoint: Endpoint,
+        pool_size: NonZeroUsize,
+        client_factory: ClientFactory,
+    ) -> Result<Self, Error> {
+        let mut connections = Vec::with_capacity(pool_size.get());
+        for _ in 0..pool_size.get() {
+            let channel = endpoint
+                .clone()
+                .connect()
+                .await
+                .map_err(Error::TonicTransport)?;
+            connections.push(client_factory(channel)?);
+        }
+
+        Ok(Self {
+            inner: Arc::new(ConnectionPoolInner {
+                connections,
+                next: AtomicUsize::new(0),
+            }),
+        })
+    }
+
+    /// Selects the next client from the pool in round-robin order.
+    ///
+    /// # Returns
+    ///
+    /// A clone of the next pooled client.
+    #[must_use]
+    pub fn get_client(&self) -> GrpcServiceClientType {
+        let next = self
+            .inner
+            .next
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.inner.connections[next % self.inner.connections.len()].clone()
+    }
+}
+
+#[derive(Debug)]
+struct ConnectionPoolInner<GrpcServiceClientType: Clone> {
+    connections: Vec<GrpcServiceClientType>,
+    next: AtomicUsize,
+}

--- a/components/spider-utils/src/grpc/mod.rs
+++ b/components/spider-utils/src/grpc/mod.rs
@@ -4,9 +4,6 @@ pub mod client;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error("invalid endpoint: {0}")]
-    InvalidEndpoint(String),
-
     #[error(transparent)]
     TonicTransport(tonic::transport::Error),
 }

--- a/components/spider-utils/src/grpc/mod.rs
+++ b/components/spider-utils/src/grpc/mod.rs
@@ -1,0 +1,12 @@
+//! gRPC-related utilities.
+
+pub mod client;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("invalid endpoint: {0}")]
+    InvalidEndpoint(String),
+
+    #[error(transparent)]
+    TonicTransport(tonic::transport::Error),
+}

--- a/components/spider-utils/src/lib.rs
+++ b/components/spider-utils/src/lib.rs
@@ -1,4 +1,5 @@
 //! Shared utilities for Spider crates.
 
+pub mod grpc;
 pub mod logging;
 pub mod wire;


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

## Summary

A `tonic` [`Channel`] multiplexes every request over a single HTTP/2 connection, and cloning the channel does not change that — all clones share one connection and one dispatch buffer. Under concurrency this serializes request dispatch and caps throughput (see [hyperium/h2#531](https://github.com/hyperium/h2/issues/531)). This PR adds a small `ConnectionPool` to `spider-utils` that holds several independent connections to one endpoint and hands them out round-robin, then migrates the execution-manager and scheduler gRPC clients to build on it instead of a single cloned channel.

## New pool (`spider-utils/src/grpc`)

- Added `grpc::client::ConnectionPool<GrpcServiceClientType>`, a cheaply-cloneable handle (`Arc`-backed) over a fixed set of pre-connected service clients.
- `ConnectionPool::connect(endpoint, pool_size, client_factory)` eagerly opens `pool_size` independent connections and wraps each in a service client via the `client_factory` closure. `pool_size` is a `NonZeroUsize` so an empty pool is unrepresentable.
- `ConnectionPool::get_client()` returns the next client by a relaxed atomic round-robin counter; the returned client is a cheap clone that callers issue a single RPC on.
- Added the `grpc::Error` enum (`InvalidEndpoint`, `TonicTransport`) that the factory returns.

## Execution-manager clients (`spider-execution-manager`)

`GrpcStorageClient`, `GrpcLivenessClient`, and `GrpcSchedulerClient` each replace their single `…Client<Channel>` field with a `ConnectionPool<…Client<Channel>>`. Their `connect` constructors gain a `pool_size: NonZeroUsize` parameter and build the pool, mapping the pool's `grpc::Error` through each module's existing transport-error conversion. Every per-RPC `self.client.clone()` becomes `self.connection_pool.get_client()`; the request/response and error-mapping logic is otherwise unchanged.

## Scheduler client (`spider-scheduler`)

`GrpcSchedulerStorageClient` wraps two distinct storage services (`InboundQueueService` and `JobOrchestrationService`), so it now holds one pool per service (`scheduler_connection_pool` and `job_connection_pool`), each with `pool_size` connections. Its `connect` constructor gains the same `pool_size` parameter. Added `spider-utils` as a dependency of `spider-scheduler`.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [ ] Ensure all workflows pass.
* [ ] There's no e2e testing in the system yet since it doesn't wire to any binary yet. However, this idea has been tested in metalog with a similar implementation [here](https://github.com/y-scope/metalog/blob/558594a5d600ab2915dd34dbd7dfdd457bc73eb4/crates/metalog-grpc/src/client_pool.rs#L20).

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pooled gRPC connections for several scheduler, storage, and execution manager services.
  * Requests now rotate across multiple active connections, which can improve reliability and throughput.
  * Added shared gRPC utilities for connection pooling and error handling.

* **Bug Fixes**
  * Reduced dependence on a single connection for service calls, helping avoid disruptions when one connection becomes unavailable.

* **Chores**
  * Updated project dependencies to support the new gRPC connection pooling features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->