### PR TITLE
feat(spider-execution-manager): Add the execution-manager binary.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1964,7 +1964,6 @@ dependencies = [
  "tokio-util",
  "tonic",
  "tracing",
- "yaml_serde",
 ]
 
 [[package]]
@@ -2026,7 +2025,6 @@ dependencies = [
  "tokio-util",
  "tonic",
  "tracing",
- "yaml_serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1950,8 +1950,10 @@ dependencies = [
  "async-trait",
  "bincode",
  "bytes",
+ "clap",
  "futures-util",
  "rmp-serde",
+ "serde",
  "spider-core",
  "spider-proto-rust",
  "spider-task-executor",
@@ -1962,6 +1964,7 @@ dependencies = [
  "tokio-util",
  "tonic",
  "tracing",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -2078,6 +2081,7 @@ dependencies = [
  "tonic",
  "tracing-appender",
  "tracing-subscriber",
+ "yaml_serde",
 ]
 
 [[package]]

--- a/components/spider-execution-manager/Cargo.toml
+++ b/components/spider-execution-manager/Cargo.toml
@@ -45,4 +45,3 @@ tokio = {
 tokio-util = { version = "0.7", features = ["codec", "rt"] }
 tonic = "0.14.6"
 tracing = { version = "0.1.41", default-features = false, features = ["std"] }
-yaml_serde = "0.10.4"

--- a/components/spider-execution-manager/Cargo.toml
+++ b/components/spider-execution-manager/Cargo.toml
@@ -7,16 +7,22 @@ edition = "2024"
 name = "spider_execution_manager"
 path = "src/lib.rs"
 
+[[bin]]
+name = "spider_execution_manager"
+path = "src/bin/execution_manager.rs"
+
 [dependencies]
 async-trait = "0.1.89"
 bincode = "1.3.3"
 bytes = "1.10"
+clap = { version = "4.6.1", features = ["derive"] }
 futures-util = {
   version = "0.3.31",
   default-features = false,
   features = ["sink", "std"]
 }
 rmp-serde = "1.3.1"
+serde = { version = "1.0.228", features = ["derive"] }
 spider-core = { path = "../spider-core" }
 spider-proto-rust = { path = "../spider-proto-rust" }
 spider-task-executor = { path = "../spider-task-executor" }
@@ -25,8 +31,18 @@ spider-utils = { path = "../spider-utils" }
 thiserror = "2.0.18"
 tokio = {
   version = "1.50.0",
-  features = ["io-util", "macros", "process", "rt", "sync", "time"]
+  features = [
+    "io-util",
+    "macros",
+    "process",
+    "rt",
+    "rt-multi-thread",
+    "signal",
+    "sync",
+    "time"
+  ]
 }
 tokio-util = { version = "0.7", features = ["codec", "rt"] }
 tonic = "0.14.6"
 tracing = { version = "0.1.41", default-features = false, features = ["std"] }
+yaml_serde = "0.10.4"

--- a/components/spider-execution-manager/src/bin/execution_manager.rs
+++ b/components/spider-execution-manager/src/bin/execution_manager.rs
@@ -1,6 +1,6 @@
 //! Command-line entrypoint for the execution manager.
 
-use std::{error::Error, path::PathBuf, sync::Arc};
+use std::{error::Error, path::PathBuf};
 
 use clap::Parser;
 use spider_execution_manager::{
@@ -39,10 +39,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .inspect_err(
             |error| tracing::error!(error = % error, "Failed to connect to storage gRPC service."),
         )?;
-    let liveness_client = Arc::new(
-        GrpcLivenessClient::connect(storage_endpoint, pool_size).await.
-            inspect_err(|error|
-                tracing::error!(error = % error, "Failed to connect to liveness gRPC service."))?);
+    let liveness_client = GrpcLivenessClient::connect(storage_endpoint, pool_size)
+        .await
+        .inspect_err(
+            |error| tracing::error!(error = % error, "Failed to connect to liveness gRPC service."),
+        )?;
     let scheduler_client = GrpcSchedulerClient::connect(scheduler_endpoint, pool_size).await.inspect_err(|error| tracing::error!(error = % error, "Failed to connect to scheduler gRPC service."))?;
 
     let (runtime, cancellation_token) = Runtime::create(

--- a/components/spider-execution-manager/src/bin/execution_manager.rs
+++ b/components/spider-execution-manager/src/bin/execution_manager.rs
@@ -1,0 +1,86 @@
+//! Command-line entrypoint for the execution manager.
+
+use std::{error::Error, path::PathBuf, sync::Arc};
+
+use clap::Parser;
+use spider_execution_manager::{
+    Config,
+    client::grpc::{GrpcLivenessClient, GrpcSchedulerClient, GrpcStorageClient},
+    runtime::Runtime,
+};
+use spider_utils::{config::YamlConfig, logging::set_up_logging};
+
+/// Command-line arguments for the execution manager.
+#[derive(Debug, Parser)]
+#[command(about = "Run the Spider execution manager.")]
+struct Cli {
+    /// Path to the YAML configuration file.
+    #[arg(short, long, value_name = "PATH")]
+    config: PathBuf,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let _log_guard = set_up_logging();
+    let cli = Cli::parse();
+    let config = Config::from_yaml_file(&cli.config)
+        .inspect_err(|error| tracing::error!(error = % error, "Failed to load configuration."))?;
+
+    let storage_endpoint = config.storage.endpoint().inspect_err(
+        |error| tracing::error!(error = % error, "Failed to parse storage endpoint."),
+    )?;
+    let scheduler_endpoint = config.scheduler.endpoint().inspect_err(
+        |error| tracing::error!(error = % error, "Failed to parse scheduler endpoint."),
+    )?;
+    let pool_size = config.connection_pool_size;
+
+    let storage_client = GrpcStorageClient::connect(storage_endpoint.clone(), pool_size)
+        .await
+        .inspect_err(
+            |error| tracing::error!(error = % error, "Failed to connect to storage gRPC service."),
+        )?;
+    let liveness_client = Arc::new(
+        GrpcLivenessClient::connect(storage_endpoint, pool_size).await.
+            inspect_err(|error|
+                tracing::error!(error = % error, "Failed to connect to liveness gRPC service."))?);
+    let scheduler_client = GrpcSchedulerClient::connect(scheduler_endpoint, pool_size).await.inspect_err(|error| tracing::error!(error = % error, "Failed to connect to scheduler gRPC service."))?;
+
+    let (runtime, cancellation_token) = Runtime::create(
+        scheduler_client,
+        storage_client,
+        liveness_client,
+        config.runtime_config(),
+    )
+    .await
+    .inspect_err(
+        |error| tracing::error!(error = % error, "Failed to create execution manager runtime."),
+    )?;
+
+    let em_id = runtime.get_em_id().get();
+
+    tracing::info!(em_id, "Execution manager started.");
+    let mut run_handle = tokio::spawn(runtime.run());
+
+    let () = tokio::select! {
+        result = tokio::signal::ctrl_c() => {
+            if let Err(error) = result {
+                tracing::error!(em_id, error = % error, "Failed to listen for Ctrl-C.");
+            }
+            tracing::info!(em_id, "Received Ctrl-C. Shutting down execution manager.");
+            cancellation_token.cancel();
+            run_handle.await
+        }
+        result = &mut run_handle => {
+            tracing::info!("Execution manager runtime exited.");
+            result
+        }
+    }
+    .inspect_err(
+        |error| tracing::error!(em_id, error = % error, "Execution manager runtime panicked."),
+    )?
+    .inspect_err(
+        |error| tracing::error!(em_id, error = % error, "Execution manager exited on error."),
+    )?;
+
+    Ok(())
+}

--- a/components/spider-execution-manager/src/client/liveness.rs
+++ b/components/spider-execution-manager/src/client/liveness.rs
@@ -3,7 +3,7 @@
 //! The execution manager registers itself with storage at boot, then sends a periodic heartbeat.
 //! Each heartbeat both keeps the EM marked alive and returns storage's current session id.
 
-use std::net::IpAddr;
+use std::{net::IpAddr, sync::Arc};
 
 use async_trait::async_trait;
 use spider_core::types::id::{ExecutionManagerId, SessionId};
@@ -76,4 +76,18 @@ pub trait LivenessClient: Send + Sync {
         &self,
         em_id: ExecutionManagerId,
     ) -> Result<SessionId, LivenessResponseError>;
+}
+
+#[async_trait]
+impl<LivenessClientType: LivenessClient + ?Sized> LivenessClient for Arc<LivenessClientType> {
+    async fn register(&self, ip: IpAddr) -> Result<RegistrationResponse, LivenessResponseError> {
+        (**self).register(ip).await
+    }
+
+    async fn heartbeat(
+        &self,
+        em_id: ExecutionManagerId,
+    ) -> Result<SessionId, LivenessResponseError> {
+        (**self).heartbeat(em_id).await
+    }
 }

--- a/components/spider-execution-manager/src/config.rs
+++ b/components/spider-execution-manager/src/config.rs
@@ -1,4 +1,9 @@
-use std::{net::IpAddr, num::NonZeroUsize, path::PathBuf, time::Duration};
+use std::{
+    net::IpAddr,
+    num::{NonZeroU64, NonZeroUsize},
+    path::PathBuf,
+    time::Duration,
+};
 
 use serde::Deserialize;
 use spider_utils::config::EndpointConfig;
@@ -23,6 +28,8 @@ pub struct Config {
     pub task_executor: TaskExecutorConfig,
 
     /// The number of connections each gRPC client pool eagerly establishes.
+    ///
+    /// Must be greater than zero.
     pub connection_pool_size: NonZeroUsize,
 
     /// How long, in milliseconds, the scheduler is asked to block each polling request before
@@ -40,9 +47,11 @@ impl Config {
     pub fn runtime_config(&self) -> RuntimeConfig {
         RuntimeConfig {
             em_ip: self.host,
-            heartbeat_interval: Duration::from_secs(self.liveness.storage_heartbeat_interval_sec),
+            heartbeat_interval: Duration::from_secs(
+                self.liveness.storage_heartbeat_interval_sec.get(),
+            ),
             scheduler_heartbeat_interval: Duration::from_secs(
-                self.liveness.scheduler_heartbeat_interval_sec,
+                self.liveness.scheduler_heartbeat_interval_sec.get(),
             ),
             scheduler_poll_wait_ms: self.scheduler_poll_wait_ms,
             executor_binary_path: self.task_executor.bin_path.clone(),
@@ -54,11 +63,15 @@ impl Config {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct LivenessConfig {
-    /// The interval, in seconds, between liveness heartbeats sent to storage.
-    pub storage_heartbeat_interval_sec: u64,
+    /// The interval, in seconds, between liveness heartbeats sent to the storage.
+    ///
+    /// Must be greater than zero.
+    pub storage_heartbeat_interval_sec: NonZeroU64,
 
     /// The interval, in seconds, between scheduler heartbeats sent to the scheduler.
-    pub scheduler_heartbeat_interval_sec: u64,
+    ///
+    /// Must be greater than zero.
+    pub scheduler_heartbeat_interval_sec: NonZeroU64,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/components/spider-execution-manager/src/config.rs
+++ b/components/spider-execution-manager/src/config.rs
@@ -1,0 +1,74 @@
+use std::{net::IpAddr, num::NonZeroUsize, path::PathBuf, time::Duration};
+
+use serde::Deserialize;
+use spider_utils::config::EndpointConfig;
+
+use crate::runtime::RuntimeConfig;
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Config {
+    /// The IP address the execution manager hosts on.
+    pub host: IpAddr,
+
+    /// The endpoint of the storage gRPC server.
+    pub storage: EndpointConfig,
+
+    /// The endpoint of the scheduler gRPC server.
+    pub scheduler: EndpointConfig,
+
+    /// Liveness configuration.
+    pub liveness: LivenessConfig,
+
+    /// Task executor configuration.
+    pub task_executor: TaskExecutorConfig,
+
+    /// The number of connections each gRPC client pool eagerly establishes.
+    pub connection_pool_size: NonZeroUsize,
+
+    /// How long, in milliseconds, the scheduler is asked to block each polling request before
+    /// returning an empty response on task dispatching.
+    pub scheduler_poll_wait_ms: u64,
+}
+
+impl Config {
+    /// Builds the [`RuntimeConfig`] consumed by the runtime from this configuration.
+    ///
+    /// # Returns
+    ///
+    /// The derived [`RuntimeConfig`].
+    #[must_use]
+    pub fn runtime_config(&self) -> RuntimeConfig {
+        RuntimeConfig {
+            em_ip: self.host,
+            heartbeat_interval: Duration::from_secs(self.liveness.storage_heartbeat_interval_sec),
+            scheduler_heartbeat_interval: Duration::from_secs(
+                self.liveness.scheduler_heartbeat_interval_sec,
+            ),
+            scheduler_poll_wait_ms: self.scheduler_poll_wait_ms,
+            executor_binary_path: self.task_executor.bin_path.clone(),
+            package_dir: self.task_executor.package_dir.clone(),
+            log_dir: self.task_executor.log_dir.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct LivenessConfig {
+    /// The interval, in seconds, between liveness heartbeats sent to storage.
+    pub storage_heartbeat_interval_sec: u64,
+
+    /// The interval, in seconds, between scheduler heartbeats sent to the scheduler.
+    pub scheduler_heartbeat_interval_sec: u64,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct TaskExecutorConfig {
+    /// Absolute path the `spider-task-executor` binary the process pool spawns.
+    pub bin_path: PathBuf,
+
+    /// Directory of TDL packages exposed to executors via `SPIDER_TDL_PACKAGE_DIR`.
+    pub package_dir: PathBuf,
+
+    /// Directory the process pool writes per-executor stderr logs into.
+    pub log_dir: PathBuf,
+}

--- a/components/spider-execution-manager/src/lib.rs
+++ b/components/spider-execution-manager/src/lib.rs
@@ -2,6 +2,9 @@
 //! `spider-task-executor` subprocess.
 
 pub mod client;
+mod config;
 pub mod liveness;
 pub mod process_pool;
 pub mod runtime;
+
+pub use config::*;

--- a/components/spider-execution-manager/src/liveness.rs
+++ b/components/spider-execution-manager/src/liveness.rs
@@ -7,7 +7,7 @@
 //! 2. An [`mpsc`] command channel from the rest of the runtime.
 //! 3. A [`CancellationToken`] that the runtime flips on shutdown.
 
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 
 use spider_core::{session::SessionTracker, types::id::ExecutionManagerId};
 use tokio::{
@@ -58,7 +58,7 @@ impl LivenessHandle {
 /// * The spawned task's [`JoinHandle`].
 pub fn spawn<LivenessClientType: LivenessClient + 'static>(
     em_id: ExecutionManagerId,
-    client: Arc<LivenessClientType>,
+    client: LivenessClientType,
     session_tracker: SessionTracker,
     cancellation_token: CancellationToken,
     heartbeat_interval: Duration,
@@ -84,7 +84,7 @@ const COMMAND_CHANNEL_CAP: usize = 16;
 /// The actor's owned state. Lives entirely inside the spawned task.
 struct LivenessActor<LivenessClientType: LivenessClient> {
     em_id: ExecutionManagerId,
-    client: Arc<LivenessClientType>,
+    client: LivenessClientType,
     session_tracker: SessionTracker,
     cmd_receiver: mpsc::Receiver<LivenessCommand>,
     cancellation_token: CancellationToken,

--- a/components/spider-execution-manager/src/liveness.rs
+++ b/components/spider-execution-manager/src/liveness.rs
@@ -56,7 +56,7 @@ impl LivenessHandle {
 ///
 /// * A handle for sending commands to the actor.
 /// * The spawned task's [`JoinHandle`].
-pub fn spawn<LivenessClientType: LivenessClient + 'static>(
+pub fn spawn<LivenessClientType: LivenessClient + Clone + 'static>(
     em_id: ExecutionManagerId,
     client: LivenessClientType,
     session_tracker: SessionTracker,
@@ -82,7 +82,7 @@ pub fn spawn<LivenessClientType: LivenessClient + 'static>(
 const COMMAND_CHANNEL_CAP: usize = 16;
 
 /// The actor's owned state. Lives entirely inside the spawned task.
-struct LivenessActor<LivenessClientType: LivenessClient> {
+struct LivenessActor<LivenessClientType: LivenessClient + Clone> {
     em_id: ExecutionManagerId,
     client: LivenessClientType,
     session_tracker: SessionTracker,
@@ -91,7 +91,7 @@ struct LivenessActor<LivenessClientType: LivenessClient> {
     interval: Interval,
 }
 
-impl<LivenessClientType: LivenessClient> LivenessActor<LivenessClientType> {
+impl<LivenessClientType: LivenessClient + Clone> LivenessActor<LivenessClientType> {
     /// Drives the actor until cancellation or the command channel closes.
     async fn run(mut self) {
         loop {

--- a/components/spider-execution-manager/src/runtime.rs
+++ b/components/spider-execution-manager/src/runtime.rs
@@ -125,7 +125,7 @@ impl<
     ///
     /// * Forwards [`LivenessClient::register`]'s return values on failure.
     /// * Forwards [`ProcessPool::new`]'s return values on failure.
-    pub async fn create<LivenessClientType: LivenessClient + 'static>(
+    pub async fn create<LivenessClientType: LivenessClient + Clone + 'static>(
         scheduler_client: SchedulerClientType,
         storage_client: StorageClientType,
         liveness_client: LivenessClientType,

--- a/components/spider-execution-manager/src/runtime.rs
+++ b/components/spider-execution-manager/src/runtime.rs
@@ -1,6 +1,6 @@
 //! Runtime — the execution manager's main loop.
 
-use std::{collections::VecDeque, net::IpAddr, path::PathBuf, sync::Arc, time::Duration};
+use std::{collections::VecDeque, net::IpAddr, path::PathBuf, time::Duration};
 
 use spider_core::{
     session::SessionTracker,
@@ -128,7 +128,7 @@ impl<
     pub async fn create<LivenessClientType: LivenessClient + 'static>(
         scheduler_client: SchedulerClientType,
         storage_client: StorageClientType,
-        liveness_client: Arc<LivenessClientType>,
+        liveness_client: LivenessClientType,
         config: RuntimeConfig,
     ) -> Result<(Self, CancellationToken), RuntimeError> {
         let registration = liveness_client.register(config.em_ip).await?;

--- a/components/spider-execution-manager/src/runtime.rs
+++ b/components/spider-execution-manager/src/runtime.rs
@@ -200,6 +200,13 @@ impl<
         Ok((runtime, cancellation_token))
     }
 
+    /// # Returns
+    ///
+    /// The ID of the registered execution manager.
+    pub const fn get_em_id(&self) -> ExecutionManagerId {
+        self.em_id
+    }
+
     /// Runs the main loop until the runtime is cancelled, then tears it down.
     ///
     /// # Returns

--- a/components/spider-storage/Cargo.toml
+++ b/components/spider-storage/Cargo.toml
@@ -39,7 +39,6 @@ tokio = {
 tokio-util = { version = "0.7.18", features = ["rt"] }
 tonic = "0.14.6"
 tracing = { version = "0.1.44", features = ["attributes"] }
-yaml_serde = "0.10.4"
 
 [dev-dependencies]
 anyhow = "1.0.98"

--- a/components/spider-storage/src/bin/grpc_server.rs
+++ b/components/spider-storage/src/bin/grpc_server.rs
@@ -13,7 +13,7 @@ use spider_proto_rust::storage::{
     task_instance_management_service_server::TaskInstanceManagementServiceServer,
 };
 use spider_storage::{ServerConfig, grpc::GrpcServiceState, state::runtime::create_runtime};
-use spider_utils::logging::set_up_logging;
+use spider_utils::{config::YamlConfig, logging::set_up_logging};
 use tokio::select;
 use tonic::transport::Server;
 

--- a/components/spider-storage/src/config.rs
+++ b/components/spider-storage/src/config.rs
@@ -1,8 +1,7 @@
-use std::{fs::File, io, net::IpAddr, path::Path};
+use std::net::IpAddr;
 
 use secrecy::SecretString;
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
 
 use crate::state::runtime::RuntimeConfig;
 
@@ -20,37 +19,6 @@ pub struct ServerConfig {
 
     /// Configuration for the storage runtime.
     pub runtime: RuntimeConfig,
-}
-
-impl ServerConfig {
-    /// Loads a [`ServerConfig`] from the YAML file at the given path.
-    ///
-    /// # Returns
-    ///
-    /// The parsed [`ServerConfig`] on success.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if:
-    ///
-    /// * Forwards [`yaml_serde::from_reader`]'s return values on failure.
-    pub fn from_yaml_file(path: &Path) -> Result<Self, ConfigError> {
-        let file = File::open(path)?;
-        let config = yaml_serde::from_reader(file)?;
-        Ok(config)
-    }
-}
-
-/// Errors returned while loading a [`ServerConfig`].
-#[derive(Debug, Error)]
-pub enum ConfigError {
-    /// Forwards an error from opening the configuration file.
-    #[error("failed to open config file: {0}")]
-    Io(#[from] io::Error),
-
-    /// Forwards an error from deserializing the YAML configuration.
-    #[error("failed to parse config file: {0}")]
-    Parse(#[from] yaml_serde::Error),
 }
 
 /// Configuration parameters for connecting to the database.

--- a/components/spider-storage/src/lib.rs
+++ b/components/spider-storage/src/lib.rs
@@ -7,4 +7,4 @@ pub mod ready_queue;
 pub mod state;
 pub mod task_instance_pool;
 
-pub use config::{ConfigError, DatabaseConfig, ServerConfig};
+pub use config::{DatabaseConfig, ServerConfig};

--- a/components/spider-utils/Cargo.toml
+++ b/components/spider-utils/Cargo.toml
@@ -18,3 +18,4 @@ tracing-subscriber = {
   default-features = false,
   features = ["env-filter", "fmt", "json"]
 }
+yaml_serde = "0.10.4"

--- a/components/spider-utils/src/config.rs
+++ b/components/spider-utils/src/config.rs
@@ -1,0 +1,80 @@
+use std::{
+    fs::File,
+    io,
+    net::{IpAddr, SocketAddr},
+    path::Path,
+};
+
+use serde::{Deserialize, de::DeserializeOwned};
+use thiserror::Error;
+use tonic::transport::Endpoint;
+
+/// Errors returned while loading a yaml formatted configuration file.
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    /// Forwards an error from opening the configuration file.
+    #[error("failed to open config file: {0}")]
+    Io(#[from] io::Error),
+
+    /// Forwards an error from deserializing the YAML configuration.
+    #[error("failed to parse config file: {0}")]
+    Parse(#[from] yaml_serde::Error),
+}
+
+/// A configuration type that can be loaded from a YAML file.
+///
+/// A blanket impl covers every [`DeserializeOwned`] type, so any config struct that derives
+/// [`serde::Deserialize`] gets [`from_yaml_file`](YamlConfig::from_yaml_file) for free.
+pub trait YamlConfig: DeserializeOwned {
+    /// Loads the configuration from the YAML file at `path`.
+    ///
+    /// # Returns
+    ///
+    /// The parsed configuration on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * [`ConfigError::Io`] if the file cannot be opened.
+    /// * [`ConfigError::Parse`] if the YAML cannot be deserialized.
+    fn from_yaml_file(path: &Path) -> Result<Self, ConfigError> {
+        let file = File::open(path)?;
+        let config = yaml_serde::from_reader(file)?;
+        Ok(config)
+    }
+}
+
+impl<ConfigType: DeserializeOwned> YamlConfig for ConfigType {}
+
+/// The network location of a gRPC server.
+#[derive(Clone, Debug, Deserialize)]
+pub struct EndpointConfig {
+    pub host: IpAddr,
+    pub port: u16,
+}
+
+impl EndpointConfig {
+    /// # Returns
+    ///
+    /// This endpoint's `host:port` as a [`SocketAddr`].
+    #[must_use]
+    pub const fn socket_addr(&self) -> SocketAddr {
+        SocketAddr::new(self.host, self.port)
+    }
+
+    /// Builds a tonic [`Endpoint`] pointing at this `host:port` over plaintext HTTP/2.
+    ///
+    /// # Returns
+    ///
+    /// The constructed [`Endpoint`] on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * Forwards [`Endpoint::from_shared`]'s return values on failure.
+    pub fn endpoint(&self) -> Result<Endpoint, tonic::transport::Error> {
+        Endpoint::from_shared(format!("http://{}", self.socket_addr()))
+    }
+}

--- a/components/spider-utils/src/lib.rs
+++ b/components/spider-utils/src/lib.rs
@@ -1,5 +1,6 @@
 //! Shared utilities for Spider crates.
 
+pub mod config;
 pub mod grpc;
 pub mod logging;
 pub mod wire;


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

## Summary

This PR adds the `spider_execution_manager` binary that boots the execution manager: it loads a YAML config, connects the storage, liveness, and scheduler gRPC clients, builds the `Runtime`, and runs it until Ctrl-C. Along the way it factors the config-loading boilerplate shared with `spider-storage` into `spider-utils` (an `EndpointConfig`, a `ConfigError`, and a `YamlConfig` trait), and drops the `Arc` that the liveness public API previously forced on callers.

## New binary (`spider-execution-manager/src/bin/execution_manager.rs`)

- Mirrors `spider-storage`'s `grpc_server` entrypoint: installs the shared non-blocking JSON logger via `spider_utils::logging::set_up_logging`, then parses a single `--config <PATH>` argument with `clap`.
- Loads `Config` from the YAML file, builds the storage and scheduler `tonic::Endpoint`s from the config, and connects all three gRPC clients (`GrpcStorageClient`, `GrpcLivenessClient`, `GrpcSchedulerClient`) through the connection pool with the configured `connection_pool_size`. The liveness client reuses the storage endpoint, since storage hosts the liveness service.
- Constructs the `Runtime` from the clients and the derived `RuntimeConfig`, logs the assigned execution-manager id, then spawns `runtime.run()` and races it against `tokio::signal::ctrl_c()` in a `tokio::select!`. On Ctrl-C it cancels the runtime's token and awaits a graceful shutdown; if the runtime exits on its own first, its result is propagated. Each fallible boot step logs a contextual error before returning.
- Each failure path is logged via `inspect_err` so a failed boot surfaces a specific message (config load, endpoint parse, per-client connect, runtime create) rather than a bare error.

## Execution-manager config (`spider-execution-manager/src/config.rs`)

- Adds `Config`, deserialized from YAML, holding the advertised `host`, the storage and scheduler `EndpointConfig`s, the liveness and task-executor sub-configs, the `connection_pool_size`, and `scheduler_poll_wait_ms`.
- `Config::runtime_config()` derives the runtime's `RuntimeConfig` (mapping the liveness heartbeat intervals to `Duration`s and forwarding the task-executor paths). `from_yaml_file` is provided by the shared `YamlConfig` trait rather than an inherent method.

## Shared config utilities (`spider-utils/src/config.rs`)

- Hosts `EndpointConfig { host, port }` with `socket_addr()` and `endpoint()`, the latter building a plaintext-HTTP/2 `tonic::Endpoint` (IPv6-safe via `SocketAddr`).
- Adds `ConfigError` (`Io` / `Parse`) and a `YamlConfig` trait whose default `from_yaml_file` opens the file and deserializes it with `yaml_serde`. A blanket `impl<ConfigType: DeserializeOwned> YamlConfig for ConfigType {}` gives every deserializable config type the loader for free; callers just bring the trait into scope.
- `spider-storage`'s `ServerConfig` drops its inherent `from_yaml_file` and local `ConfigError` and adopts the shared trait, so the two services no longer duplicate the loader.

## Drop the `Arc` from the liveness public API

- `liveness::spawn` and `Runtime::create` now take the liveness client by value (`LivenessClient + Clone + 'static`) instead of `Arc<LivenessClientType>`. The real `GrpcLivenessClient` is already a cheap, `Arc`-backed clone (it wraps a `ConnectionPool`), so the outer `Arc` was redundant; the binary now passes the client directly.
- Adds a blanket `impl<LivenessClientType: LivenessClient + ?Sized> LivenessClient for Arc<LivenessClientType>` that forwards through the shared pointer, so callers who genuinely want shared ownership — such as the actor unit tests that retain a handle to inspect the mock — keep working with no changes. `Arc` is now opt-in rather than mandated.

## Notes

`Config` requires `host` to be set explicitly; an earlier draft auto-detected the local IP routed toward storage, but that was dropped in favor of taking the advertised IP from config.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [ ] Ensure all workflows pass.

> [!WARNING]
> The binary is not tested with storage/scheduler endpoints yet since the required services are not fully implemented.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI entrypoint for the execution manager that loads settings from a YAML config, initializes logging, connects to required services, and supports clean Ctrl-C shutdown.
  * Introduced shared YAML-backed configuration loading and gRPC endpoint helpers for service settings.
* **Bug Fixes**
  * Updated storage/server configuration to remove YAML-loading functionality and stop exporting the associated configuration error type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->