### PR TITLE
feat(spider-scheduler): Add service layer serving execution manager request.

### DIFF
--- a/components/spider-scheduler/src/error.rs
+++ b/components/spider-scheduler/src/error.rs
@@ -2,6 +2,8 @@
 
 use spider_core::types::id::{JobId, SessionId};
 
+use crate::execution_manager_registry::ExecutionManagerRegistryError;
+
 /// Errors returned by [`crate::storage_client::SchedulerStorageClient`] operations.
 #[derive(Debug, thiserror::Error)]
 pub enum StorageClientError {
@@ -55,4 +57,16 @@ pub enum SchedulerError {
 
     #[error(transparent)]
     SystemTime(#[from] std::time::SystemTimeError),
+}
+
+/// Errors returned by [`crate::service::SchedulerServiceState`] operations.
+#[derive(Debug, thiserror::Error)]
+pub enum SchedulerServiceError {
+    /// Forwarded from the dispatch queue or the scheduler core.
+    #[error(transparent)]
+    Scheduler(#[from] SchedulerError),
+
+    /// Forwarded from the execution manager registry.
+    #[error(transparent)]
+    EMRegistry(#[from] ExecutionManagerRegistryError),
 }

--- a/components/spider-scheduler/src/lib.rs
+++ b/components/spider-scheduler/src/lib.rs
@@ -36,13 +36,15 @@ pub mod core_impl;
 pub mod dispatch_queue;
 pub mod error;
 pub mod execution_manager_registry;
+pub mod service;
 pub mod storage_client;
 pub mod types;
 
 pub use crate::{
     core::SchedulerCore,
     dispatch_queue::{DispatchQueueSink, DispatchQueueSource},
-    error::{SchedulerError, StorageClientError},
+    error::{SchedulerError, SchedulerServiceError, StorageClientError},
+    service::SchedulerServiceState,
     storage_client::{GrpcSchedulerStorageClient, SchedulerStorageClient},
     types::{InboundEntry, TaskAssignment},
 };

--- a/components/spider-scheduler/src/service.rs
+++ b/components/spider-scheduler/src/service.rs
@@ -3,7 +3,7 @@
 //! [`SchedulerServiceState`] is the domain layer behind the scheduler gRPC service. It serves
 //! execution managers by draining task assignments from the dispatch queue and bookkeeping them in
 //! the [`ExecutionManagerRegistry`]: assignment, completion, heartbeat, and shutdown. The service
-//! is generic over its dispatch source so the runtime can drive it with the real dispatch queue in
+//! is generic over its dispatch source, so the runtime can drive it with the real dispatch queue in
 //! production or a mock in tests, while the [`ExecutionManagerRegistry`] is shared by value.
 
 use std::{sync::Arc, time::Duration};
@@ -22,25 +22,22 @@ use crate::{
 
 /// The execution-manager-facing scheduler service.
 ///
-/// Wraps [`SchedulerServiceStateInner`] in an [`Arc`] so the per-request and per-connection clones
-/// the gRPC layer makes are cheap reference-count bumps rather than deep copies of the underlying
-/// state.
-///
 /// # Type Parameters
 ///
 /// * `DispatchQueueSourceType` - The reader side of the dispatching queue the service drains.
 #[derive(Clone)]
-pub struct SchedulerServiceState<DispatchQueueSourceType: DispatchQueueSource> {
+pub struct SchedulerServiceState<DispatchQueueSourceType: DispatchQueueSource + 'static> {
     inner: Arc<SchedulerServiceStateInner<DispatchQueueSourceType>>,
 }
 
-impl<DispatchQueueSourceType: DispatchQueueSource> SchedulerServiceState<DispatchQueueSourceType> {
+impl<DispatchQueueSourceType: DispatchQueueSource + 'static>
+    SchedulerServiceState<DispatchQueueSourceType>
+{
     /// Factory function.
     ///
     /// # Returns
     ///
-    /// A new [`SchedulerServiceState`] that drains `dispatch_source`, tracks assignments in
-    /// `registry`, and stamps `scheduler_id` onto every assignment it hands out.
+    /// A newly constructed [`SchedulerServiceState`].
     #[must_use]
     pub fn new(
         dispatch_source: DispatchQueueSourceType,
@@ -66,26 +63,24 @@ impl<DispatchQueueSourceType: DispatchQueueSource> SchedulerServiceState<Dispatc
 
     /// Hands the next task assignment to an execution manager.
     ///
-    /// If `prev_assignment` is supplied, the execution manager first acknowledges it as consumed by
-    /// completing it in the registry. The service then drains the next assignment from the dispatch
-    /// queue, waiting up to `wait_time` for one to arrive, and records the assignment against the
+    /// If `prev_assignment` is supplied, the service acknowledges it as consumed by completing it
+    /// in the registry on a best-effort, fire-and-forget basis: the completion is spawned as a
+    /// background task, so it may land after this call returns, and any failure is logged rather
+    /// than propagated. The service then drains the next assignment from the dispatch queue,
+    /// waiting up to `wait_time` for one to arrive, and records the assignment against the
     /// execution manager in the registry before returning it.
     ///
     /// # Returns
     ///
-    /// A tuple on success, containing:
-    ///
-    /// * The storage session the dispatch queue paired with the assignment.
-    /// * The task assignment handed to the execution manager.
-    ///
-    /// [`None`] is returned when no assignment becomes available within `wait_time`.
+    /// * A tuple on success, containing:
+    ///   * The storage session the dispatch queue paired with the assignment.
+    ///   * The task assignment handed to the execution manager.
+    /// * `None` if no assignment becomes available within `wait_time`.
     ///
     /// # Errors
     ///
     /// Returns an error if:
     ///
-    /// * [`SchedulerServiceError::EMRegistry`] if completing `prev_assignment` fails because the
-    ///   execution manager or the assignment is not registered.
     /// * Forwards [`DispatchQueueSource::dequeue`]'s return values on failure.
     pub async fn next_task(
         &self,
@@ -94,11 +89,33 @@ impl<DispatchQueueSourceType: DispatchQueueSource> SchedulerServiceState<Dispatc
         wait_time: Duration,
     ) -> Result<Option<(SessionId, TaskAssignment)>, SchedulerServiceError> {
         if let Some(prev) = prev_assignment {
-            self.inner.registry.complete(em_id, prev.id).await?;
+            // The previous assignment is handled in a fire-and-forget task. Errors are ignored but
+            // logged for observability purposes.
+            tokio::spawn(Self::complete_task_assignment(
+                self.scheduler_id(),
+                self.inner.registry.clone(),
+                em_id,
+                prev,
+            ));
         }
         match self.inner.dispatch_source.dequeue(wait_time).await? {
-            None => Ok(None),
+            None => {
+                tracing::info!(
+                    scheduler_id = % self.scheduler_id(),
+                    em_id = % em_id,
+                    "No task assignment available within the specified wait time."
+                );
+                Ok(None)
+            }
             Some((session_id, assignment)) => {
+                tracing::info!(
+                    scheduler_id = % self.scheduler_id(),
+                    em_id = % em_id,
+                    assignment_id = % assignment.id,
+                    assignment_job_id = % assignment.job_id,
+                    assignment_task_id = % assignment.task_id,
+                    "Task dispatched to execution manager."
+                );
                 self.inner.registry.assign(em_id, assignment).await;
                 Ok(Some((session_id, assignment)))
             }
@@ -114,6 +131,11 @@ impl<DispatchQueueSourceType: DispatchQueueSource> SchedulerServiceState<Dispatc
     /// This method does not currently return an error. The [`Result`] return type is retained for a
     /// uniform service surface alongside [`Self::next_task`] and [`Self::shutdown`].
     pub async fn heartbeat(&self, em_id: ExecutionManagerId) -> Result<(), SchedulerServiceError> {
+        tracing::info!(
+            scheduler_id = % self.scheduler_id(),
+            em_id = % em_id,
+            "Execution manager heartbeat received."
+        );
         self.inner.registry.update_heartbeat(em_id).await;
         Ok(())
     }
@@ -127,24 +149,60 @@ impl<DispatchQueueSourceType: DispatchQueueSource> SchedulerServiceState<Dispatc
     ///
     /// Returns an error if:
     ///
-    /// * [`SchedulerServiceError::EMRegistry`] if marking the execution manager as dead fails.
+    /// * Forwards [`ExecutionManagerRegistry::mark_as_dead`]'s return values on failure.
     pub async fn shutdown(
         &self,
         em_id: ExecutionManagerId,
         prev_assignments: Vec<TaskAssignmentRecord>,
     ) -> Result<(), SchedulerServiceError> {
         for prev in prev_assignments {
-            if let Err(error) = self.inner.registry.complete(em_id, prev.id).await {
-                tracing::warn!(
-                    em_id = %em_id,
-                    error = %error,
-                    assignment_id = ?prev.id,
-                    "Failed to complete a previously consumed assignment during shutdown. Skipping."
-                );
-            }
+            Self::complete_task_assignment(
+                self.scheduler_id(),
+                self.inner.registry.clone(),
+                em_id,
+                prev,
+            )
+            .await;
         }
         self.inner.registry.mark_as_dead(em_id).await?;
+        tracing::info!(
+            scheduler_id = % self.scheduler_id(),
+            em_id = % em_id,
+            "Execution manager shutdown complete."
+        );
         Ok(())
+    }
+
+    /// Marks a task assignment as completed in the registry.
+    async fn complete_task_assignment(
+        scheduler_id: SchedulerId,
+        registry: ExecutionManagerRegistry,
+        em_id: ExecutionManagerId,
+        record: TaskAssignmentRecord,
+    ) {
+        if scheduler_id != record.from {
+            tracing::warn!(
+                scheduler_id = % scheduler_id,
+                assignment_id = % record.id,
+                from_scheduler_id = % record.from,
+                from_em_id = % em_id,
+                "Received a completed assignment from a stale scheduler. Skipping."
+            );
+            return;
+        }
+        let _ = registry
+            .complete(em_id, record.id)
+            .await
+            .inspect_err(|error| {
+                tracing::warn!(
+                    scheduler_id = % scheduler_id,
+                    assignment_id = % record.id,
+                    from_scheduler_id = % record.from,
+                    from_em_id = % em_id,
+                    error = % error,
+                    "Failed to complete a previously consumed assignment. Skipping."
+                );
+            });
     }
 }
 
@@ -373,37 +431,6 @@ mod tests {
             .expect("the recorded assignment should be rescheduled before the timeout")
             .expect("the reschedule queue should remain open");
         assert_eq!(rescheduled.id, assignment.id);
-        assert!(reschedule_queue_receiver.try_recv().is_err());
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn next_task_completes_prev_assignment() -> anyhow::Result<()> {
-        let (service, mut reschedule_queue_receiver, _cancellation_token) = build_service(2);
-        let em_id = ExecutionManagerId::from(EM_ID);
-
-        let (_, assignment_a) = service
-            .next_task(em_id, None, Duration::from_millis(1))
-            .await?
-            .expect("the first assignment should be dequeued");
-        let (_, assignment_b) = service
-            .next_task(
-                em_id,
-                Some(record(assignment_a.id)),
-                Duration::from_millis(1),
-            )
-            .await?
-            .expect("the second assignment should be dequeued");
-
-        // The previous assignment was completed during the second call, so only the still
-        // outstanding assignment B is rescheduled on shutdown.
-        service.shutdown(em_id, Vec::new()).await?;
-
-        let rescheduled = timeout(RESCHEDULE_TIMEOUT, reschedule_queue_receiver.recv())
-            .await
-            .expect("the outstanding assignment should be rescheduled before the timeout")
-            .expect("the reschedule queue should remain open");
-        assert_eq!(rescheduled.id, assignment_b.id);
         assert!(reschedule_queue_receiver.try_recv().is_err());
         Ok(())
     }

--- a/components/spider-scheduler/src/service.rs
+++ b/components/spider-scheduler/src/service.rs
@@ -22,10 +22,6 @@ use crate::{
 
 /// The execution-manager-facing scheduler service.
 ///
-/// Sits between the dispatch queue and the execution manager registry, turning execution-manager
-/// requests into registry bookkeeping. The service stamps every assignment it hands out with the
-/// scheduler's own identifier, captured at registration time.
-///
 /// # Type Parameters
 ///
 /// * `DispatchQueueSourceType` - The reader side of the dispatching queue the service drains.
@@ -131,10 +127,7 @@ impl<DispatchQueueSourceType: DispatchQueueSource> SchedulerServiceState<Dispatc
 
     /// Signals that an execution manager is shutting down.
     ///
-    /// Each assignment in `prev_assignments` is acknowledged as completed best-effort: a missing
-    /// assignment or execution manager is logged and skipped so teardown still proceeds. The
-    /// execution manager is then marked dead, which reschedules any assignments still outstanding
-    /// against it.
+    /// Marks the execution manager as dead in the registry.
     ///
     /// # Parameters
     ///

--- a/components/spider-scheduler/src/service.rs
+++ b/components/spider-scheduler/src/service.rs
@@ -6,7 +6,7 @@
 //! is generic over its dispatch source so the runtime can drive it with the real dispatch queue in
 //! production or a mock in tests, while the [`ExecutionManagerRegistry`] is shared by value.
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use spider_core::types::{
     id::{ExecutionManagerId, SchedulerId, SessionId},
@@ -22,14 +22,16 @@ use crate::{
 
 /// The execution-manager-facing scheduler service.
 ///
+/// Wraps [`SchedulerServiceStateInner`] in an [`Arc`] so the per-request and per-connection clones
+/// the gRPC layer makes are cheap reference-count bumps rather than deep copies of the underlying
+/// state.
+///
 /// # Type Parameters
 ///
 /// * `DispatchQueueSourceType` - The reader side of the dispatching queue the service drains.
 #[derive(Clone)]
 pub struct SchedulerServiceState<DispatchQueueSourceType: DispatchQueueSource> {
-    dispatch_source: DispatchQueueSourceType,
-    registry: ExecutionManagerRegistry,
-    scheduler_id: SchedulerId,
+    inner: Arc<SchedulerServiceStateInner<DispatchQueueSourceType>>,
 }
 
 impl<DispatchQueueSourceType: DispatchQueueSource> SchedulerServiceState<DispatchQueueSourceType> {
@@ -40,15 +42,17 @@ impl<DispatchQueueSourceType: DispatchQueueSource> SchedulerServiceState<Dispatc
     /// A new [`SchedulerServiceState`] that drains `dispatch_source`, tracks assignments in
     /// `registry`, and stamps `scheduler_id` onto every assignment it hands out.
     #[must_use]
-    pub const fn new(
+    pub fn new(
         dispatch_source: DispatchQueueSourceType,
         registry: ExecutionManagerRegistry,
         scheduler_id: SchedulerId,
     ) -> Self {
         Self {
-            dispatch_source,
-            registry,
-            scheduler_id,
+            inner: Arc::new(SchedulerServiceStateInner {
+                dispatch_source,
+                registry,
+                scheduler_id,
+            }),
         }
     }
 
@@ -56,8 +60,8 @@ impl<DispatchQueueSourceType: DispatchQueueSource> SchedulerServiceState<Dispatc
     ///
     /// The scheduler identifier this service stamps onto every assignment it hands out.
     #[must_use]
-    pub const fn scheduler_id(&self) -> SchedulerId {
-        self.scheduler_id
+    pub fn scheduler_id(&self) -> SchedulerId {
+        self.inner.scheduler_id
     }
 
     /// Hands the next task assignment to an execution manager.
@@ -90,12 +94,12 @@ impl<DispatchQueueSourceType: DispatchQueueSource> SchedulerServiceState<Dispatc
         wait_time: Duration,
     ) -> Result<Option<(SessionId, TaskAssignment)>, SchedulerServiceError> {
         if let Some(prev) = prev_assignment {
-            self.registry.complete(em_id, prev.id).await?;
+            self.inner.registry.complete(em_id, prev.id).await?;
         }
-        match self.dispatch_source.dequeue(wait_time).await? {
+        match self.inner.dispatch_source.dequeue(wait_time).await? {
             None => Ok(None),
             Some((session_id, assignment)) => {
-                self.registry.assign(em_id, assignment).await;
+                self.inner.registry.assign(em_id, assignment).await;
                 Ok(Some((session_id, assignment)))
             }
         }
@@ -110,7 +114,7 @@ impl<DispatchQueueSourceType: DispatchQueueSource> SchedulerServiceState<Dispatc
     /// This method does not currently return an error. The [`Result`] return type is retained for a
     /// uniform service surface alongside [`Self::next_task`] and [`Self::shutdown`].
     pub async fn heartbeat(&self, em_id: ExecutionManagerId) -> Result<(), SchedulerServiceError> {
-        self.registry.update_heartbeat(em_id).await;
+        self.inner.registry.update_heartbeat(em_id).await;
         Ok(())
     }
 
@@ -130,7 +134,7 @@ impl<DispatchQueueSourceType: DispatchQueueSource> SchedulerServiceState<Dispatc
         prev_assignments: Vec<TaskAssignmentRecord>,
     ) -> Result<(), SchedulerServiceError> {
         for prev in prev_assignments {
-            if let Err(error) = self.registry.complete(em_id, prev.id).await {
+            if let Err(error) = self.inner.registry.complete(em_id, prev.id).await {
                 tracing::warn!(
                     em_id = %em_id,
                     error = %error,
@@ -139,9 +143,20 @@ impl<DispatchQueueSourceType: DispatchQueueSource> SchedulerServiceState<Dispatc
                 );
             }
         }
-        self.registry.mark_as_dead(em_id).await?;
+        self.inner.registry.mark_as_dead(em_id).await?;
         Ok(())
     }
+}
+
+/// The shared inner state of [`SchedulerServiceState`].
+///
+/// # Type Parameters
+///
+/// * `DispatchQueueSourceType` - The reader side of the dispatching queue the service drains.
+struct SchedulerServiceStateInner<DispatchQueueSourceType: DispatchQueueSource> {
+    dispatch_source: DispatchQueueSourceType,
+    registry: ExecutionManagerRegistry,
+    scheduler_id: SchedulerId,
 }
 
 #[cfg(test)]

--- a/components/spider-scheduler/src/service.rs
+++ b/components/spider-scheduler/src/service.rs
@@ -1,0 +1,466 @@
+//! The execution-manager-facing scheduler service.
+//!
+//! [`SchedulerServiceState`] is the domain layer behind the scheduler gRPC service. It serves
+//! execution managers by draining task assignments from the dispatch queue and bookkeeping them in
+//! the [`ExecutionManagerRegistry`]: assignment, completion, heartbeat, and shutdown. The service
+//! is generic over its dispatch source so the runtime can drive it with the real dispatch queue in
+//! production or a mock in tests, while the [`ExecutionManagerRegistry`] is shared by value.
+
+use std::time::Duration;
+
+use spider_core::types::{
+    id::{ExecutionManagerId, SchedulerId, SessionId},
+    scheduler::TaskAssignmentRecord,
+};
+
+use crate::{
+    dispatch_queue::DispatchQueueSource,
+    error::SchedulerServiceError,
+    execution_manager_registry::ExecutionManagerRegistry,
+    types::TaskAssignment,
+};
+
+/// The execution-manager-facing scheduler service.
+///
+/// Sits between the dispatch queue and the execution manager registry, turning execution-manager
+/// requests into registry bookkeeping. The service stamps every assignment it hands out with the
+/// scheduler's own identifier, captured at registration time.
+///
+/// # Type Parameters
+///
+/// * `DispatchQueueSourceType` - The reader side of the dispatching queue the service drains.
+#[derive(Clone)]
+pub struct SchedulerServiceState<DispatchQueueSourceType: DispatchQueueSource> {
+    dispatch_source: DispatchQueueSourceType,
+    registry: ExecutionManagerRegistry,
+    scheduler_id: SchedulerId,
+}
+
+impl<DispatchQueueSourceType: DispatchQueueSource> SchedulerServiceState<DispatchQueueSourceType> {
+    /// Factory function.
+    ///
+    /// # Returns
+    ///
+    /// A new [`SchedulerServiceState`] that drains `dispatch_source`, tracks assignments in
+    /// `registry`, and stamps `scheduler_id` onto every assignment it hands out.
+    #[must_use]
+    pub const fn new(
+        dispatch_source: DispatchQueueSourceType,
+        registry: ExecutionManagerRegistry,
+        scheduler_id: SchedulerId,
+    ) -> Self {
+        Self {
+            dispatch_source,
+            registry,
+            scheduler_id,
+        }
+    }
+
+    /// # Returns
+    ///
+    /// The scheduler identifier this service stamps onto every assignment it hands out.
+    #[must_use]
+    pub const fn scheduler_id(&self) -> SchedulerId {
+        self.scheduler_id
+    }
+
+    /// Hands the next task assignment to an execution manager.
+    ///
+    /// If `prev_assignment` is supplied, the execution manager first acknowledges it as consumed by
+    /// completing it in the registry. The service then drains the next assignment from the dispatch
+    /// queue, waiting up to `wait_time` for one to arrive, and records the assignment against the
+    /// execution manager in the registry before returning it.
+    ///
+    /// # Parameters
+    ///
+    /// * `em_id` - The identity of the calling execution manager.
+    /// * `prev_assignment` - The last assignment produced by this scheduler that the execution
+    ///   manager has successfully consumed, or [`None`] if no previous assignment exists.
+    /// * `wait_time` - The maximum duration to wait for an assignment to become available.
+    ///
+    /// # Returns
+    ///
+    /// A tuple on success, containing:
+    ///
+    /// * The storage session the dispatch queue paired with the assignment.
+    /// * The task assignment handed to the execution manager.
+    ///
+    /// [`None`] is returned when no assignment becomes available within `wait_time`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * [`SchedulerServiceError::EMRegistry`] if completing `prev_assignment` fails because the
+    ///   execution manager or the assignment is not registered.
+    /// * Forwards [`DispatchQueueSource::dequeue`]'s return values on failure.
+    pub async fn next_task(
+        &self,
+        em_id: ExecutionManagerId,
+        prev_assignment: Option<TaskAssignmentRecord>,
+        wait_time: Duration,
+    ) -> Result<Option<(SessionId, TaskAssignment)>, SchedulerServiceError> {
+        if let Some(prev) = prev_assignment {
+            self.registry.complete(em_id, prev.id).await?;
+        }
+        match self.dispatch_source.dequeue(wait_time).await? {
+            None => Ok(None),
+            Some((session_id, assignment)) => {
+                self.registry.assign(em_id, assignment).await;
+                Ok(Some((session_id, assignment)))
+            }
+        }
+    }
+
+    /// Refreshes the liveness of an execution manager.
+    ///
+    /// Registers the execution manager if this is its first heartbeat.
+    ///
+    /// # Parameters
+    ///
+    /// * `em_id` - The identity of the calling execution manager.
+    ///
+    /// # Errors
+    ///
+    /// This method does not currently return an error. The [`Result`] return type is retained for a
+    /// uniform service surface alongside [`Self::next_task`] and [`Self::shutdown`].
+    pub async fn heartbeat(&self, em_id: ExecutionManagerId) -> Result<(), SchedulerServiceError> {
+        self.registry.update_heartbeat(em_id).await;
+        Ok(())
+    }
+
+    /// Signals that an execution manager is shutting down.
+    ///
+    /// Each assignment in `prev_assignments` is acknowledged as completed best-effort: a missing
+    /// assignment or execution manager is logged and skipped so teardown still proceeds. The
+    /// execution manager is then marked dead, which reschedules any assignments still outstanding
+    /// against it.
+    ///
+    /// # Parameters
+    ///
+    /// * `em_id` - The identity of the calling execution manager.
+    /// * `prev_assignments` - The assignments produced by this scheduler that the execution manager
+    ///   has successfully consumed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * [`SchedulerServiceError::EMRegistry`] if marking the execution manager as dead fails.
+    pub async fn shutdown(
+        &self,
+        em_id: ExecutionManagerId,
+        prev_assignments: Vec<TaskAssignmentRecord>,
+    ) -> Result<(), SchedulerServiceError> {
+        for prev in prev_assignments {
+            if let Err(error) = self.registry.complete(em_id, prev.id).await {
+                tracing::warn!(
+                    em_id = %em_id,
+                    error = %error,
+                    assignment_id = ?prev.id,
+                    "Failed to complete a previously consumed assignment during shutdown. Skipping."
+                );
+            }
+        }
+        self.registry.mark_as_dead(em_id).await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+        time::Duration,
+    };
+
+    use async_trait::async_trait;
+    use spider_core::types::{
+        id::{
+            ExecutionManagerId,
+            JobId,
+            ResourceGroupId,
+            SchedulerId,
+            SessionId,
+            TaskAssignmentId,
+            TaskId,
+        },
+        scheduler::TaskAssignmentRecord,
+    };
+    use tokio::{
+        sync::mpsc::{self, UnboundedReceiver},
+        time::timeout,
+    };
+    use tokio_util::sync::CancellationToken;
+
+    use super::SchedulerServiceState;
+    use crate::{
+        dispatch_queue::DispatchQueueSource,
+        error::SchedulerError,
+        execution_manager_registry::{ExecutionManagerRegistry, ExecutionManagerRegistryConfig},
+        types::TaskAssignment,
+    };
+
+    /// The storage session the mock dispatch source pairs with every assignment it returns.
+    const SESSION_ID: SessionId = 7;
+
+    /// The scheduler identifier the service stamps onto assignments.
+    const SCHEDULER_ID: u64 = 42;
+
+    /// The execution manager the tests drive the service with.
+    const EM_ID: u64 = 1;
+
+    /// The maximum time to wait for a rescheduled assignment before failing a test.
+    const RESCHEDULE_TIMEOUT: Duration = Duration::from_secs(2);
+
+    /// A [`DispatchQueueSource`] mock backed by a shared counter.
+    ///
+    /// Each [`DispatchQueueSource::dequeue`] claims one slot from the counter; while it is positive
+    /// it returns a freshly minted task assignment, and once it reaches zero it returns [`None`]
+    /// forever. Using a counter (rather than a canned list of assignments) lets the tests assert on
+    /// dequeue behavior without coupling to recorded argument vectors.
+    #[derive(Clone)]
+    struct CounterDispatchSource {
+        remaining: Arc<AtomicUsize>,
+    }
+
+    impl CounterDispatchSource {
+        /// # Returns
+        ///
+        /// A new [`CounterDispatchSource`] that hands out `remaining` assignments before reporting
+        /// an empty queue.
+        fn new(remaining: usize) -> Self {
+            Self {
+                remaining: Arc::new(AtomicUsize::new(remaining)),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl DispatchQueueSource for CounterDispatchSource {
+        async fn dequeue(
+            &self,
+            _wait_time: Duration,
+        ) -> Result<Option<(SessionId, TaskAssignment)>, SchedulerError> {
+            // Atomically claim one slot: return None once the counter is exhausted, otherwise
+            // decrement and synthesize a fresh assignment.
+            let mut current = self.remaining.load(Ordering::Relaxed);
+            loop {
+                if current == 0 {
+                    return Ok(None);
+                }
+                match self.remaining.compare_exchange(
+                    current,
+                    current - 1,
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                ) {
+                    Ok(_) => return Ok(Some((SESSION_ID, make_assignment()))),
+                    Err(actual) => current = actual,
+                }
+            }
+        }
+    }
+
+    /// # Returns
+    ///
+    /// A fresh [`TaskAssignment`] with a unique, counter-derived identifier. The remaining
+    /// identifier fields are fixed since the service tests do not assert on them.
+    fn make_assignment() -> TaskAssignment {
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+        let id = u64::try_from(COUNTER.fetch_add(1, Ordering::Relaxed))
+            .expect("the counter is well below u64::MAX");
+        TaskAssignment {
+            id: TaskAssignmentId::from(id),
+            resource_group_id: ResourceGroupId::from(0),
+            job_id: JobId::from(0),
+            task_id: TaskId::Index(0),
+        }
+    }
+
+    /// # Returns
+    ///
+    /// A [`TaskAssignmentRecord`] acknowledging `id` as consumed, issued by this scheduler.
+    fn record(id: TaskAssignmentId) -> TaskAssignmentRecord {
+        TaskAssignmentRecord::new(id, SchedulerId::from(SCHEDULER_ID))
+    }
+
+    /// Builds a registry whose background liveness tracker never fires during a test (a one-hour
+    /// cutoff with a one-minute interval), so registration, completion, and teardown can be driven
+    /// explicitly rather than by timeouts.
+    ///
+    /// # Returns
+    ///
+    /// A tuple containing:
+    ///
+    /// * The registry.
+    /// * The receiver end of the re-schedule queue.
+    /// * The registry-level cancellation token.
+    fn build_registry() -> (
+        ExecutionManagerRegistry,
+        UnboundedReceiver<TaskAssignment>,
+        CancellationToken,
+    ) {
+        let config = ExecutionManagerRegistryConfig {
+            dead_em_cutoff_sec: 3600,
+            liveness_tracking_interval_ms: 60_000,
+        };
+        let cancellation_token = CancellationToken::new();
+        let (reschedule_queue_sender, reschedule_queue_receiver) = mpsc::unbounded_channel();
+        let registry = ExecutionManagerRegistry::new(
+            &config,
+            cancellation_token.clone(),
+            reschedule_queue_sender,
+        )
+        .expect("the registry should be constructed successfully");
+        (registry, reschedule_queue_receiver, cancellation_token)
+    }
+
+    /// # Returns
+    ///
+    /// A tuple containing:
+    ///
+    /// * A [`SchedulerServiceState`] over a [`CounterDispatchSource`] with `remaining` assignments,
+    ///   backed by a fresh test registry.
+    /// * The receiver end of the registry's re-schedule queue.
+    /// * The registry-level cancellation token.
+    fn build_service(
+        remaining: usize,
+    ) -> (
+        SchedulerServiceState<CounterDispatchSource>,
+        UnboundedReceiver<TaskAssignment>,
+        CancellationToken,
+    ) {
+        let (registry, reschedule_queue_receiver, cancellation_token) = build_registry();
+        let service = SchedulerServiceState::new(
+            CounterDispatchSource::new(remaining),
+            registry,
+            SchedulerId::from(SCHEDULER_ID),
+        );
+        (service, reschedule_queue_receiver, cancellation_token)
+    }
+
+    #[tokio::test]
+    async fn next_task_returns_none_when_queue_empty() -> anyhow::Result<()> {
+        let (service, _reschedule_queue_receiver, _cancellation_token) = build_service(0);
+
+        let result = service
+            .next_task(
+                ExecutionManagerId::from(EM_ID),
+                None,
+                Duration::from_millis(1),
+            )
+            .await?;
+        assert_eq!(result, None);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn next_task_assigns_and_records_assignment() -> anyhow::Result<()> {
+        let (service, mut reschedule_queue_receiver, _cancellation_token) = build_service(1);
+        let em_id = ExecutionManagerId::from(EM_ID);
+
+        assert_eq!(service.scheduler_id(), SchedulerId::from(SCHEDULER_ID));
+
+        let (session_id, assignment) = service
+            .next_task(em_id, None, Duration::from_millis(1))
+            .await?
+            .expect("an assignment should be dequeued");
+        assert_eq!(session_id, SESSION_ID);
+
+        // The assignment was recorded against the execution manager, so shutting it down without
+        // acknowledging the assignment reschedules it.
+        service.shutdown(em_id, Vec::new()).await?;
+
+        let rescheduled = timeout(RESCHEDULE_TIMEOUT, reschedule_queue_receiver.recv())
+            .await
+            .expect("the recorded assignment should be rescheduled before the timeout")
+            .expect("the reschedule queue should remain open");
+        assert_eq!(rescheduled.id, assignment.id);
+        assert!(reschedule_queue_receiver.try_recv().is_err());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn next_task_completes_prev_assignment() -> anyhow::Result<()> {
+        let (service, mut reschedule_queue_receiver, _cancellation_token) = build_service(2);
+        let em_id = ExecutionManagerId::from(EM_ID);
+
+        let (_, assignment_a) = service
+            .next_task(em_id, None, Duration::from_millis(1))
+            .await?
+            .expect("the first assignment should be dequeued");
+        let (_, assignment_b) = service
+            .next_task(
+                em_id,
+                Some(record(assignment_a.id)),
+                Duration::from_millis(1),
+            )
+            .await?
+            .expect("the second assignment should be dequeued");
+
+        // The previous assignment was completed during the second call, so only the still
+        // outstanding assignment B is rescheduled on shutdown.
+        service.shutdown(em_id, Vec::new()).await?;
+
+        let rescheduled = timeout(RESCHEDULE_TIMEOUT, reschedule_queue_receiver.recv())
+            .await
+            .expect("the outstanding assignment should be rescheduled before the timeout")
+            .expect("the reschedule queue should remain open");
+        assert_eq!(rescheduled.id, assignment_b.id);
+        assert!(reschedule_queue_receiver.try_recv().is_err());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn heartbeat_registers_execution_manager() -> anyhow::Result<()> {
+        let (service, mut reschedule_queue_receiver, _cancellation_token) = build_service(0);
+        let em_id = ExecutionManagerId::from(EM_ID);
+
+        service.heartbeat(em_id).await?;
+
+        // `mark_as_dead` only succeeds for a registered execution manager, so a clean shutdown
+        // confirms the heartbeat registered it.
+        service.shutdown(em_id, Vec::new()).await?;
+        assert!(reschedule_queue_receiver.try_recv().is_err());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn shutdown_completes_prevs_and_reschedules_outstanding() -> anyhow::Result<()> {
+        let (service, mut reschedule_queue_receiver, _cancellation_token) = build_service(3);
+        let em_id = ExecutionManagerId::from(EM_ID);
+
+        let (_, assignment_a) = service
+            .next_task(em_id, None, Duration::from_millis(1))
+            .await?
+            .expect("the first assignment should be dequeued");
+        let (_, assignment_b) = service
+            .next_task(em_id, None, Duration::from_millis(1))
+            .await?
+            .expect("the second assignment should be dequeued");
+        let (_, assignment_c) = service
+            .next_task(em_id, None, Duration::from_millis(1))
+            .await?
+            .expect("the third assignment should be dequeued");
+
+        // A and B are acknowledged as completed; C remains outstanding and is rescheduled.
+        service
+            .shutdown(
+                em_id,
+                vec![record(assignment_a.id), record(assignment_b.id)],
+            )
+            .await?;
+
+        let rescheduled = timeout(RESCHEDULE_TIMEOUT, reschedule_queue_receiver.recv())
+            .await
+            .expect("the outstanding assignment should be rescheduled before the timeout")
+            .expect("the reschedule queue should remain open");
+        assert_eq!(rescheduled.id, assignment_c.id);
+        assert!(reschedule_queue_receiver.try_recv().is_err());
+        Ok(())
+    }
+}

--- a/components/spider-scheduler/src/service.rs
+++ b/components/spider-scheduler/src/service.rs
@@ -67,13 +67,6 @@ impl<DispatchQueueSourceType: DispatchQueueSource> SchedulerServiceState<Dispatc
     /// queue, waiting up to `wait_time` for one to arrive, and records the assignment against the
     /// execution manager in the registry before returning it.
     ///
-    /// # Parameters
-    ///
-    /// * `em_id` - The identity of the calling execution manager.
-    /// * `prev_assignment` - The last assignment produced by this scheduler that the execution
-    ///   manager has successfully consumed, or [`None`] if no previous assignment exists.
-    /// * `wait_time` - The maximum duration to wait for an assignment to become available.
-    ///
     /// # Returns
     ///
     /// A tuple on success, containing:
@@ -112,10 +105,6 @@ impl<DispatchQueueSourceType: DispatchQueueSource> SchedulerServiceState<Dispatc
     ///
     /// Registers the execution manager if this is its first heartbeat.
     ///
-    /// # Parameters
-    ///
-    /// * `em_id` - The identity of the calling execution manager.
-    ///
     /// # Errors
     ///
     /// This method does not currently return an error. The [`Result`] return type is retained for a
@@ -127,13 +116,8 @@ impl<DispatchQueueSourceType: DispatchQueueSource> SchedulerServiceState<Dispatc
 
     /// Signals that an execution manager is shutting down.
     ///
-    /// Marks the execution manager as dead in the registry.
-    ///
-    /// # Parameters
-    ///
-    /// * `em_id` - The identity of the calling execution manager.
-    /// * `prev_assignments` - The assignments produced by this scheduler that the execution manager
-    ///   has successfully consumed.
+    /// Each assignment in `prev_assignments` is acknowledged as completed best-effort, then the
+    /// execution manager is marked as dead in the registry.
     ///
     /// # Errors
     ///

--- a/components/spider-scheduler/src/service.rs
+++ b/components/spider-scheduler/src/service.rs
@@ -147,6 +147,7 @@ impl<DispatchQueueSourceType: DispatchQueueSource> SchedulerServiceState<Dispatc
 #[cfg(test)]
 mod tests {
     use std::{
+        num::NonZeroU64,
         sync::{
             Arc,
             atomic::{AtomicUsize, Ordering},
@@ -282,8 +283,9 @@ mod tests {
         CancellationToken,
     ) {
         let config = ExecutionManagerRegistryConfig {
-            dead_em_cutoff_sec: 3600,
-            liveness_tracking_interval_ms: 60_000,
+            dead_em_cutoff_sec: NonZeroU64::new(3600).expect("the cutoff should be non-zero"),
+            liveness_tracking_interval_ms: NonZeroU64::new(60_000)
+                .expect("the interval should be non-zero"),
         };
         let cancellation_token = CancellationToken::new();
         let (reschedule_queue_sender, reschedule_queue_receiver) = mpsc::unbounded_channel();
@@ -291,8 +293,7 @@ mod tests {
             &config,
             cancellation_token.clone(),
             reschedule_queue_sender,
-        )
-        .expect("the registry should be constructed successfully");
+        );
         (registry, reschedule_queue_receiver, cancellation_token)
     }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR adds scheduler service layer that coordinates dispatch queue and execution manager registry to server execution manager requests.



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
- [x] GitHub workflows pass.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a scheduler service that assigns the next task to execution managers, accepts task-consumption acknowledgements, and handles execution-manager heartbeats.
  * Expanded the scheduler component’s public API with a new service state type and corresponding service-level error handling.

* **Bug Fixes**
  * Improved shutdown behavior to best-effort complete acknowledged prior assignments and safely reschedule only any still-outstanding work.

* **Documentation**
  * Updated public API exports to include the new service state and error type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->