### PR TITLE
refactor(spider-scheduler): Enforce non-zero config invariants with `NonZero` types instead of manual validation.

### DIFF
--- a/components/spider-scheduler/src/core_impl/round_robin/implementation.rs
+++ b/components/spider-scheduler/src/core_impl/round_robin/implementation.rs
@@ -3,6 +3,7 @@
 
 use std::{
     collections::{HashMap, HashSet, VecDeque},
+    num::{NonZeroU64, NonZeroUsize},
     time::{Duration, Instant},
 };
 
@@ -28,36 +29,26 @@ use crate::{
 pub struct RoundRobinConfig {
     /// The capacity of the active job queue. The scheduler will make task assignments from these
     /// jobs in a round-robin manner.
-    ///
-    /// Must be greater than 0.
-    pub active_job_queue_capacity: usize,
+    pub active_job_queue_capacity: NonZeroUsize,
 
     /// The capacity of the dispatch queue.
-    ///
-    /// Must be greater than 0.
-    pub dispatch_queue_capacity: usize,
+    pub dispatch_queue_capacity: NonZeroUsize,
 
     /// The capacity of the total pending ready tasks buffered in the scheduler.
-    ///
-    /// Must be greater than 0.
-    pub ready_task_capacity: usize,
+    pub ready_task_capacity: NonZeroUsize,
 
     /// The capacity of the total pending commit-ready tasks buffered in the scheduler.
-    ///
-    /// Must be greater than 0.
-    pub commit_ready_task_capacity: usize,
+    pub commit_ready_task_capacity: NonZeroUsize,
 
     /// The capacity of the total pending cleanup-ready tasks buffered in the scheduler.
-    ///
-    /// Must be greater than 0.
-    pub cleanup_ready_task_capacity: usize,
+    pub cleanup_ready_task_capacity: NonZeroUsize,
 
     /// The maximum time (in milliseconds) that the scheduler will wait for the storage server to
     /// fill the inbound-queue reading request.
     pub storage_poll_timeout_ms: u64,
 
     /// The time (in milliseconds) that the scheduler will spend on each tick.
-    pub tick_interval_ms: u64,
+    pub tick_interval_ms: NonZeroU64,
 
     /// The time (in seconds) that a job may remain in the finalizing state before the scheduler
     /// retires it.
@@ -65,7 +56,7 @@ pub struct RoundRobinConfig {
 }
 
 impl RoundRobinConfig {
-    /// Validates the configuration and creates a ready-to-run scheduler core from it.
+    /// Creates a ready-to-run scheduler core from the configuration.
     ///
     /// # Type Parameters
     ///
@@ -74,59 +65,18 @@ impl RoundRobinConfig {
     ///
     /// # Returns
     ///
-    /// A newly created round-robin scheduler core on success.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if:
-    ///
-    /// * [`SchedulerError::InvalidConfig`] if any of the following configuration entries is 0:
-    ///   * `active_job_queue_capacity`
-    ///   * `dispatch_queue_capacity`
-    ///   * `ready_task_capacity`
-    ///   * `commit_ready_task_capacity`
-    ///   * `cleanup_ready_task_capacity`
-    pub fn make_core<
+    /// A newly created round-robin scheduler core.
+    #[must_use]
+    pub const fn make_core<
         SchedulerStorageClientType: SchedulerStorageClient + 'static,
         DispatchQueueSinkType: DispatchQueueSink,
     >(
         self,
-    ) -> Result<RoundRobinCore<SchedulerStorageClientType, DispatchQueueSinkType>, SchedulerError>
-    {
-        if self.active_job_queue_capacity == 0 {
-            return Err(SchedulerError::InvalidConfig(
-                "`active_job_queue_capacity` must be greater than 0".to_string(),
-            ));
-        }
-
-        if self.dispatch_queue_capacity == 0 {
-            return Err(SchedulerError::InvalidConfig(
-                "`dispatch_queue_capacity` must be greater than 0".to_string(),
-            ));
-        }
-
-        if self.ready_task_capacity == 0 {
-            return Err(SchedulerError::InvalidConfig(
-                "`ready_task_capacity` must be greater than 0".to_string(),
-            ));
-        }
-
-        if self.commit_ready_task_capacity == 0 {
-            return Err(SchedulerError::InvalidConfig(
-                "`commit_ready_task_capacity` must be greater than 0".to_string(),
-            ));
-        }
-
-        if self.cleanup_ready_task_capacity == 0 {
-            return Err(SchedulerError::InvalidConfig(
-                "`cleanup_ready_task_capacity` must be greater than 0".to_string(),
-            ));
-        }
-
-        Ok(RoundRobinCore {
+    ) -> RoundRobinCore<SchedulerStorageClientType, DispatchQueueSinkType> {
+        RoundRobinCore {
             config: self,
             _marker: std::marker::PhantomData,
-        })
+        }
     }
 }
 
@@ -258,8 +208,7 @@ impl<
 {
     /// Factory function.
     ///
-    /// Creates a [`RoundRobin`] scheduler from the given config. The config must have been
-    /// validated through [`RoundRobinConfig::make_core`].
+    /// Creates a [`RoundRobin`] scheduler from the given config.
     ///
     /// # Returns
     ///
@@ -272,16 +221,16 @@ impl<
         cancellation_token: CancellationToken,
         config: RoundRobinConfig,
     ) -> Self {
-        let buffered_tasks = HashSet::with_capacity(config.ready_task_capacity);
-        let active_jobs = HashMap::with_capacity(config.active_job_queue_capacity);
-        let rr_queue = Self::new_round_robin_queue(config.active_job_queue_capacity);
+        let buffered_tasks = HashSet::with_capacity(config.ready_task_capacity.get());
+        let active_jobs = HashMap::with_capacity(config.active_job_queue_capacity.get());
+        let rr_queue = Self::new_round_robin_queue(config.active_job_queue_capacity.get());
         let rr_cursor = 0;
-        let pending_jobs = HashMap::with_capacity(config.active_job_queue_capacity);
-        let pending_job_queue = VecDeque::with_capacity(config.active_job_queue_capacity);
-        let commit_ready_jobs = VecDeque::with_capacity(config.commit_ready_task_capacity);
-        let cleanup_ready_jobs = VecDeque::with_capacity(config.cleanup_ready_task_capacity);
+        let pending_jobs = HashMap::with_capacity(config.active_job_queue_capacity.get());
+        let pending_job_queue = VecDeque::with_capacity(config.active_job_queue_capacity.get());
+        let commit_ready_jobs = VecDeque::with_capacity(config.commit_ready_task_capacity.get());
+        let cleanup_ready_jobs = VecDeque::with_capacity(config.cleanup_ready_task_capacity.get());
         let finalizing_jobs = HashSet::with_capacity(
-            config.commit_ready_task_capacity + config.cleanup_ready_task_capacity,
+            config.commit_ready_task_capacity.get() + config.cleanup_ready_task_capacity.get(),
         );
         let finalizing_job_queue = VecDeque::new();
         let inbound_queue_reader = AsyncInboundQueueReader::new(storage_client);
@@ -348,7 +297,7 @@ impl<
             init_session_id = self.storage_session_id,
             "Round-robin scheduler started."
         );
-        let tick_interval = Duration::from_millis(self.config.tick_interval_ms);
+        let tick_interval = Duration::from_millis(self.config.tick_interval_ms.get());
         loop {
             let now = tokio::time::Instant::now();
             let cancellation_token = self.cancellation_token.clone();
@@ -385,7 +334,7 @@ impl<
         self.finalizing_jobs.clear();
         self.finalizing_job_queue.clear();
 
-        self.rr_queue = Self::new_round_robin_queue(self.config.active_job_queue_capacity);
+        self.rr_queue = Self::new_round_robin_queue(self.config.active_job_queue_capacity.get());
         self.rr_cursor = 0;
     }
 
@@ -658,7 +607,7 @@ impl<
                 continue;
             }
 
-            if self.active_jobs.len() < self.config.active_job_queue_capacity {
+            if self.active_jobs.len() < self.config.active_job_queue_capacity.get() {
                 tracing::info!(
                     job_id = ? inbound_entry.job_id,
                     "New job received. Placing in active job queue."
@@ -750,6 +699,7 @@ impl<
         let dispatch_slots = self
             .config
             .dispatch_queue_capacity
+            .get()
             .saturating_sub(self.sink.size());
         let mut remaining_dispatch_slots = dispatch_slots;
         'fill_dispatch_queue: while remaining_dispatch_slots > 0 && !self.buffered_tasks.is_empty()
@@ -785,7 +735,7 @@ impl<
                     remaining_dispatch_slots -= 1;
                 }
                 RoundRobinSlot::CommitReady => {
-                    for _ in 0..self.config.active_job_queue_capacity {
+                    for _ in 0..self.config.active_job_queue_capacity.get() {
                         if remaining_dispatch_slots == 0 {
                             break 'fill_dispatch_queue;
                         }
@@ -852,12 +802,14 @@ impl<
         let max_commit_ready_entries = self
             .config
             .commit_ready_task_capacity
+            .get()
             .saturating_sub(num_commit_ready_tasks);
         let max_cleanup_ready_entries = self
             .config
             .cleanup_ready_task_capacity
+            .get()
             .saturating_sub(num_cleanup_ready_tasks);
-        let max_ready_entries = self.config.ready_task_capacity.saturating_sub(
+        let max_ready_entries = self.config.ready_task_capacity.get().saturating_sub(
             self.buffered_tasks.len() - num_commit_ready_tasks - num_cleanup_ready_tasks,
         );
 

--- a/components/spider-scheduler/src/core_impl/round_robin/tests.rs
+++ b/components/spider-scheduler/src/core_impl/round_robin/tests.rs
@@ -2,6 +2,7 @@
 
 use std::{
     collections::{HashMap, HashSet, VecDeque},
+    num::{NonZeroU64, NonZeroUsize},
     sync::{
         Arc,
         Mutex,
@@ -180,13 +181,15 @@ fn make_config(
     dispatch_queue_capacity: usize,
 ) -> RoundRobinConfig {
     RoundRobinConfig {
-        active_job_queue_capacity,
-        dispatch_queue_capacity,
-        ready_task_capacity: 16_384,
-        commit_ready_task_capacity: 16,
-        cleanup_ready_task_capacity: 16,
+        active_job_queue_capacity: NonZeroUsize::new(active_job_queue_capacity)
+            .expect("the active job queue capacity should be non-zero"),
+        dispatch_queue_capacity: NonZeroUsize::new(dispatch_queue_capacity)
+            .expect("the dispatch queue capacity should be non-zero"),
+        ready_task_capacity: NonZeroUsize::new(16_384).expect("16384 is non-zero"),
+        commit_ready_task_capacity: NonZeroUsize::new(16).expect("16 is non-zero"),
+        cleanup_ready_task_capacity: NonZeroUsize::new(16).expect("16 is non-zero"),
         storage_poll_timeout_ms: 10,
-        tick_interval_ms: 1,
+        tick_interval_ms: NonZeroU64::new(1).expect("1 is non-zero"),
         finalizing_job_expiration_timeout_sec: 6 * 60 * 60,
     }
 }
@@ -249,7 +252,7 @@ fn make_finalizing_batch(jobs: &[(JobId, ResourceGroupId)], task_id: TaskId) -> 
         .collect()
 }
 
-/// Validates the given config and spawns the scheduler's public run loop as a background task.
+/// Spawns the scheduler's public run loop as a background task.
 ///
 /// # Returns
 ///
@@ -257,10 +260,6 @@ fn make_finalizing_batch(jobs: &[(JobId, ResourceGroupId)], task_id: TaskId) -> 
 ///
 /// * The join handle yielding the scheduler's exit result.
 /// * The cancellation token that stops the scheduler.
-///
-/// # Panics
-///
-/// Panics if the given config fails validation.
 fn spawn_scheduler(
     config: RoundRobinConfig,
     storage_client: MockStorageClient,
@@ -269,7 +268,7 @@ fn spawn_scheduler(
     tokio::task::JoinHandle<Result<(), SchedulerError>>,
     CancellationToken,
 ) {
-    let core = config.make_core().expect("config validation failed");
+    let core = config.make_core();
     let cancellation_token = CancellationToken::new();
     let scheduler_token = cancellation_token.clone();
     let handle = tokio::spawn(async move {
@@ -422,45 +421,6 @@ fn assert_round_robin_property(
 
     for &(job_id, _) in jobs {
         assert_eq!(next_task_indices.get(&job_id).copied(), Some(tasks_per_job));
-    }
-}
-
-#[test]
-fn zero_capacity_configs_are_rejected() {
-    let try_make_core =
-        |config: RoundRobinConfig| config.make_core::<MockStorageClient, DispatchQueueWriter>();
-
-    assert!(try_make_core(make_config(2, 2)).is_ok());
-
-    let zeroed_configs = [
-        RoundRobinConfig {
-            active_job_queue_capacity: 0,
-            ..make_config(2, 2)
-        },
-        RoundRobinConfig {
-            dispatch_queue_capacity: 0,
-            ..make_config(2, 2)
-        },
-        RoundRobinConfig {
-            ready_task_capacity: 0,
-            ..make_config(2, 2)
-        },
-        RoundRobinConfig {
-            commit_ready_task_capacity: 0,
-            ..make_config(2, 2)
-        },
-        RoundRobinConfig {
-            cleanup_ready_task_capacity: 0,
-            ..make_config(2, 2)
-        },
-    ];
-    for config in zeroed_configs {
-        let result = try_make_core(config);
-        assert!(
-            matches!(result, Err(SchedulerError::InvalidConfig(_))),
-            "expected InvalidConfig, got {:?}",
-            result.err(),
-        );
     }
 }
 

--- a/components/spider-scheduler/src/error.rs
+++ b/components/spider-scheduler/src/error.rs
@@ -47,9 +47,6 @@ pub enum SchedulerError {
     #[error("internal error: {0}")]
     Internal(String),
 
-    #[error("invalid config: {0}")]
-    InvalidConfig(String),
-
     #[error("async result not ready")]
     ResultNotReady,
 

--- a/components/spider-scheduler/src/execution_manager_registry.rs
+++ b/components/spider-scheduler/src/execution_manager_registry.rs
@@ -2,6 +2,7 @@
 
 use std::{
     collections::{HashMap, hash_map::Entry},
+    num::NonZeroU64,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -23,45 +24,24 @@ pub enum ExecutionManagerRegistryError {
 
     #[error("execution manager not found: {0}")]
     EmNotFound(ExecutionManagerId),
-
-    #[error("invalid config: {0}")]
-    InvalidConfig(String),
 }
 
 #[derive(Clone, Deserialize)]
 pub struct ExecutionManagerRegistryConfig {
     /// The time, in seconds, that an execution manager is considered dead without receiving any
     /// heartbeat.
-    pub dead_em_cutoff_sec: u64,
+    pub dead_em_cutoff_sec: NonZeroU64,
 
     /// The time interval, in milliseconds, between liveness checks.
-    pub liveness_tracking_interval_ms: u64,
+    pub liveness_tracking_interval_ms: NonZeroU64,
 }
 
 impl Default for ExecutionManagerRegistryConfig {
     fn default() -> Self {
         Self {
-            dead_em_cutoff_sec: 30,
-            liveness_tracking_interval_ms: 1000,
+            dead_em_cutoff_sec: NonZeroU64::new(30).expect("30 is non-zero"),
+            liveness_tracking_interval_ms: NonZeroU64::new(1000).expect("1000 is non-zero"),
         }
-    }
-}
-
-impl ExecutionManagerRegistryConfig {
-    /// Validates the configuration.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if:
-    ///
-    /// * [`ExecutionManagerRegistryError::InvalidConfig`] if `dead_em_cutoff_sec` is 0.
-    fn validate(&self) -> Result<(), ExecutionManagerRegistryError> {
-        if self.dead_em_cutoff_sec == 0 {
-            return Err(ExecutionManagerRegistryError::InvalidConfig(
-                "dead_em_cutoff_sec must be greater than 0".to_string(),
-            ));
-        }
-        Ok(())
     }
 }
 
@@ -76,23 +56,17 @@ impl ExecutionManagerRegistry {
     ///
     /// # Returns
     ///
-    /// The newly created execution manager registry on success.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if:
-    ///
-    /// * Forwards [`ExecutionManagerRegistryConfig::validate`]'s return values on failure.
+    /// The newly created execution manager registry.
+    #[must_use]
     pub fn new(
         config: &ExecutionManagerRegistryConfig,
         cancellation_token: CancellationToken,
         reschedule_queue_sender: UnboundedSender<TaskAssignment>,
-    ) -> Result<Self, ExecutionManagerRegistryError> {
-        config.validate()?;
-        let dead_em_cutoff = Duration::from_secs(config.dead_em_cutoff_sec);
+    ) -> Self {
+        let dead_em_cutoff = Duration::from_secs(config.dead_em_cutoff_sec.get());
         let liveness_tracking_interval =
-            Duration::from_millis(config.liveness_tracking_interval_ms);
-        Ok(Self {
+            Duration::from_millis(config.liveness_tracking_interval_ms.get());
+        Self {
             inner: Arc::new(ExecutionManagerRegistryInner {
                 em_table: RwLock::new(HashMap::new()),
                 cancellation_token,
@@ -100,7 +74,7 @@ impl ExecutionManagerRegistry {
                 liveness_tracking_interval,
                 reschedule_queue_sender,
             }),
-        })
+        }
     }
 
     /// Assigns a task to an execution manager.
@@ -418,8 +392,10 @@ mod tests {
         CancellationToken,
     ) {
         let config = ExecutionManagerRegistryConfig {
-            dead_em_cutoff_sec,
-            liveness_tracking_interval_ms,
+            dead_em_cutoff_sec: NonZeroU64::new(dead_em_cutoff_sec)
+                .expect("the cutoff should be non-zero"),
+            liveness_tracking_interval_ms: NonZeroU64::new(liveness_tracking_interval_ms)
+                .expect("the interval should be non-zero"),
         };
         let cancellation_token = CancellationToken::new();
         let (reschedule_queue_sender, reschedule_queue_receiver) = mpsc::unbounded_channel();
@@ -427,8 +403,7 @@ mod tests {
             &config,
             cancellation_token.clone(),
             reschedule_queue_sender,
-        )
-        .expect("the registry should be constructed successfully");
+        );
         (registry, reschedule_queue_receiver, cancellation_token)
     }
 


### PR DESCRIPTION
# Description

The `spider-scheduler` configs previously accepted plain integer fields and rejected zero values through hand-written validation methods that ran at construction time. This pushed the failure to runtime and required every constructor to thread a `Result` through purely for these checks.

This PR moves the "must be greater than zero" invariant into the type system by switching the relevant fields to `NonZero*`, so `serde` rejects an invalid `0` at deserialization time and the invariant is guaranteed everywhere the config is held.

**`ExecutionManagerRegistryConfig`** (`execution_manager_registry.rs`):

* `dead_em_cutoff_sec` and `liveness_tracking_interval_ms` are now `NonZeroU64`.
* Dropped the `validate()` method and the now-unused `ExecutionManagerRegistryError::InvalidConfig` variant.
* `ExecutionManagerRegistry::new` is now infallible (returns `Self` instead of `Result`).

**`RoundRobinConfig`** (`core_impl/round_robin`):

* The five capacity fields (`active_job_queue_capacity`, `dispatch_queue_capacity`, `ready_task_capacity`, `commit_ready_task_capacity`, `cleanup_ready_task_capacity`) are now `NonZeroUsize`.
* `tick_interval_ms` is now `NonZeroU64`. A zero tick interval would otherwise busy-spin the scheduler loop (and is the same hazard as a zero `tokio` interval period).
* Removed the zero-checks from `make_core`, which is now infallible.
* Dropped the corresponding `SchedulerError::InvalidConfig` variant.

This is an API change: the config fields now use `NonZero*` types, and `ExecutionManagerRegistry::new` and `RoundRobinConfig::make_core` no longer return a `Result`.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* [ ] Ensure all workflows pass.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduler and registry setup so invalid zero-value timing/capacity settings are prevented upfront.
  * Reduced the chance of runtime configuration errors during startup.

* **Refactor**
  * Streamlined scheduler and registry construction to be more direct and reliable.
  * Updated internal sizing and timing handling to use safer non-zero values.

* **Tests**
  * Updated scheduler tests to match the new configuration rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->