### PR TITLE
feat(spider-scheduler): Add the runtime that wires the scheduler core, dispatch queue, and execution manager registry together.

### DIFF
--- a/components/spider-scheduler/src/config.rs
+++ b/components/spider-scheduler/src/config.rs
@@ -1,0 +1,56 @@
+//! The scheduler core configuration that selects and configures the scheduling algorithm.
+
+use serde::Deserialize;
+
+use crate::{
+    core::SchedulerCore,
+    core_impl::RoundRobinConfig,
+    dispatch_queue::DispatchQueueSink,
+    storage_client::SchedulerStorageClient,
+};
+
+/// The configuration that selects and configures the scheduler core's scheduling algorithm.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SchedulerConfig {
+    /// The round-robin scheduling algorithm.
+    RoundRobin(RoundRobinConfig),
+}
+
+impl SchedulerConfig {
+    /// Creates a ready-to-run scheduler core from the selected configuration.
+    ///
+    /// # Type Parameters
+    ///
+    /// * `SchedulerStorageClientType` - The storage client the core polls and registers through.
+    /// * `DispatchQueueSinkType` - The dispatch sink that task assignments are written to.
+    ///
+    /// # Returns
+    ///
+    /// A boxed [`SchedulerCore`] configured by the selected variant.
+    #[must_use]
+    pub fn make_core<
+        SchedulerStorageClientType: SchedulerStorageClient + 'static,
+        DispatchQueueSinkType: DispatchQueueSink + 'static,
+    >(
+        self,
+    ) -> Box<
+        dyn SchedulerCore<Sink = DispatchQueueSinkType, StorageClient = SchedulerStorageClientType>,
+    > {
+        match self {
+            Self::RoundRobin(config) => {
+                Box::new(config.make_core::<SchedulerStorageClientType, DispatchQueueSinkType>())
+            }
+        }
+    }
+
+    /// # Returns
+    ///
+    /// The dispatch queue capacity of the selected variant.
+    #[must_use]
+    pub const fn dispatch_queue_capacity(&self) -> std::num::NonZeroUsize {
+        match self {
+            Self::RoundRobin(config) => config.dispatch_queue_capacity,
+        }
+    }
+}

--- a/components/spider-scheduler/src/core.rs
+++ b/components/spider-scheduler/src/core.rs
@@ -69,7 +69,7 @@ pub trait SchedulerCore: Send {
     ///
     /// Returns a [`SchedulerError`] instance indicating an irrecoverable error.
     async fn run(
-        self,
+        self: Box<Self>,
         storage_client: Self::StorageClient,
         sink: Self::Sink,
         id_issuer: TaskAssignmentIdIssuer,

--- a/components/spider-scheduler/src/core_impl/round_robin/implementation.rs
+++ b/components/spider-scheduler/src/core_impl/round_robin/implementation.rs
@@ -25,7 +25,7 @@ use crate::{
 };
 
 /// The configuration of the round-robin scheduler core.
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct RoundRobinConfig {
     /// The capacity of the active job queue. The scheduler will make task assignments from these
     /// jobs in a round-robin manner.
@@ -108,7 +108,7 @@ impl<
     type StorageClient = SchedulerStorageClientType;
 
     async fn run(
-        self,
+        self: Box<Self>,
         storage_client: Self::StorageClient,
         sink: Self::Sink,
         id_issuer: TaskAssignmentIdIssuer,

--- a/components/spider-scheduler/src/core_impl/round_robin/tests.rs
+++ b/components/spider-scheduler/src/core_impl/round_robin/tests.rs
@@ -15,7 +15,7 @@ use anyhow::bail;
 use async_trait::async_trait;
 use spider_core::{
     job::JobState,
-    types::id::{JobId, ResourceGroupId, SessionId, TaskId},
+    types::id::{JobId, ResourceGroupId, SchedulerId, SessionId, TaskId},
 };
 use tokio_util::sync::CancellationToken;
 
@@ -143,6 +143,14 @@ impl MockStorageClient {
 
 #[async_trait]
 impl SchedulerStorageClient for MockStorageClient {
+    async fn register(
+        &self,
+        _ip_address: std::net::IpAddr,
+        _port: u16,
+    ) -> Result<SchedulerId, StorageClientError> {
+        Ok(SchedulerId::from(0))
+    }
+
     async fn poll_ready(
         &self,
         max_items: usize,
@@ -268,7 +276,7 @@ fn spawn_scheduler(
     tokio::task::JoinHandle<Result<(), SchedulerError>>,
     CancellationToken,
 ) {
-    let core = config.make_core();
+    let core = Box::new(config.make_core());
     let cancellation_token = CancellationToken::new();
     let scheduler_token = cancellation_token.clone();
     let handle = tokio::spawn(async move {

--- a/components/spider-scheduler/src/error.rs
+++ b/components/spider-scheduler/src/error.rs
@@ -2,6 +2,8 @@
 
 use spider_core::types::id::{JobId, SessionId};
 
+use crate::execution_manager_registry::ExecutionManagerRegistryError;
+
 /// Errors returned by [`crate::storage_client::SchedulerStorageClient`] operations.
 #[derive(Debug, thiserror::Error)]
 pub enum StorageClientError {
@@ -55,4 +57,16 @@ pub enum SchedulerError {
 
     #[error(transparent)]
     SystemTime(#[from] std::time::SystemTimeError),
+}
+
+/// Errors returned by [`crate::service::SchedulerServiceState`] operations.
+#[derive(Debug, thiserror::Error)]
+pub enum SchedulerServiceError {
+    /// Forwarded from the dispatch queue or the scheduler core.
+    #[error(transparent)]
+    Scheduler(#[from] SchedulerError),
+
+    /// Forwarded from the execution manager registry.
+    #[error(transparent)]
+    EMRegistry(#[from] ExecutionManagerRegistryError),
 }

--- a/components/spider-scheduler/src/error.rs
+++ b/components/spider-scheduler/src/error.rs
@@ -56,6 +56,18 @@ pub enum SchedulerError {
     SystemTime(#[from] std::time::SystemTimeError),
 }
 
+/// Errors returned by the scheduler runtime.
+#[derive(Debug, thiserror::Error)]
+pub enum SchedulerRuntimeError {
+    /// Forwarded from the storage client during scheduler registration.
+    #[error(transparent)]
+    StorageClient(#[from] StorageClientError),
+
+    /// A background task did not stop before the configured timeout.
+    #[error("scheduler runtime stop timed out: {0}")]
+    Stopping(String),
+}
+
 /// Errors returned by [`crate::service::SchedulerServiceState`] operations.
 #[derive(Debug, thiserror::Error)]
 pub enum SchedulerServiceError {

--- a/components/spider-scheduler/src/lib.rs
+++ b/components/spider-scheduler/src/lib.rs
@@ -31,19 +31,28 @@
 //!   └───────────────────┘
 //! ```
 
+pub mod config;
 pub mod core;
 pub mod core_impl;
 pub mod dispatch_queue;
 pub mod error;
 pub mod execution_manager_registry;
+pub mod runtime;
 pub mod service;
 pub mod storage_client;
 pub mod types;
 
 pub use crate::{
+    config::SchedulerConfig,
     core::SchedulerCore,
-    dispatch_queue::{DispatchQueueSink, DispatchQueueSource},
-    error::{SchedulerError, SchedulerServiceError, StorageClientError},
+    dispatch_queue::{
+        DispatchQueueReader,
+        DispatchQueueSink,
+        DispatchQueueSource,
+        DispatchQueueWriter,
+    },
+    error::{SchedulerError, SchedulerRuntimeError, SchedulerServiceError, StorageClientError},
+    runtime::{Runtime, RuntimeConfig, create_runtime},
     service::SchedulerServiceState,
     storage_client::{GrpcSchedulerStorageClient, SchedulerStorageClient},
     types::{InboundEntry, TaskAssignment},

--- a/components/spider-scheduler/src/lib.rs
+++ b/components/spider-scheduler/src/lib.rs
@@ -36,13 +36,15 @@ pub mod core_impl;
 pub mod dispatch_queue;
 pub mod error;
 pub mod execution_manager_registry;
+pub mod service;
 pub mod storage_client;
 pub mod types;
 
 pub use crate::{
     core::SchedulerCore,
     dispatch_queue::{DispatchQueueSink, DispatchQueueSource},
-    error::{SchedulerError, StorageClientError},
+    error::{SchedulerError, SchedulerServiceError, StorageClientError},
+    service::SchedulerServiceState,
     storage_client::{GrpcSchedulerStorageClient, SchedulerStorageClient},
     types::{InboundEntry, TaskAssignment},
 };

--- a/components/spider-scheduler/src/runtime.rs
+++ b/components/spider-scheduler/src/runtime.rs
@@ -1,10 +1,9 @@
 //! The scheduler runtime.
 //!
-//! Mirroring the storage runtime, this module registers the scheduler with the storage service,
-//! wires the scheduler core to a freshly created dispatch queue, and spawns the core's scheduling
-//! loop as a background coroutine alongside the execution manager registry. The resulting
-//! [`Runtime`] owns the spawned coroutine and is responsible for cancelling and joining it on
-//! shutdown.
+//! This module registers the scheduler with the storage service, wires the scheduler core to a
+//! freshly created dispatch queue, and spawns the core's scheduling loop as a background coroutine
+//! alongside the execution manager registry. The resulting [`Runtime`] owns the spawned coroutine
+//! and is responsible for cancelling and joining it on shutdown.
 
 use std::time::Duration;
 
@@ -27,11 +26,11 @@ use crate::{
 #[derive(Deserialize)]
 pub struct RuntimeConfig {
     /// The scheduler core configuration that selects and configures the scheduling algorithm.
-    pub scheduler_config: SchedulerConfig,
+    pub scheduler: SchedulerConfig,
 
     /// The execution manager registry configuration.
     #[serde(default)]
-    pub execution_manager_registry_config: ExecutionManagerRegistryConfig,
+    pub em_registry: ExecutionManagerRegistryConfig,
 
     /// The IP address this scheduler advertises to the storage service during registration.
     pub host: std::net::IpAddr,
@@ -47,7 +46,7 @@ pub struct RuntimeConfig {
 /// Runtime state for the scheduler service.
 pub struct Runtime {
     core_join_handle: tokio::task::JoinHandle<Result<(), SchedulerError>>,
-    reschedule_queue_receiver: tokio::sync::mpsc::UnboundedReceiver<TaskAssignment>,
+    _reschedule_queue_receiver: tokio::sync::mpsc::UnboundedReceiver<TaskAssignment>,
     cancellation_token: CancellationToken,
     stop_timeout: Duration,
 }
@@ -56,8 +55,7 @@ impl Runtime {
     /// Stops the runtime.
     ///
     /// The scheduler core coroutine is cancelled and joined. The core's error, if any, is logged
-    /// and will not be returned through this method. Any task assignments still buffered in the
-    /// reschedule queue are drained and dropped.
+    /// and will not be returned through this method.
     ///
     /// # Errors
     ///
@@ -65,7 +63,7 @@ impl Runtime {
     ///
     /// * [`SchedulerRuntimeError::Stopping`] if the scheduler core does not stop before the
     ///   configured timeout.
-    pub async fn stop(mut self) -> Result<(), SchedulerRuntimeError> {
+    pub async fn stop(self) -> Result<(), SchedulerRuntimeError> {
         self.cancellation_token.cancel();
 
         let join_result = tokio::time::timeout(self.stop_timeout, self.core_join_handle)
@@ -85,27 +83,14 @@ impl Runtime {
             }
         }
 
-        // The reschedule queue is reserved for future re-injection wiring; for now, drain and drop
-        // any assignments still buffered at shutdown.
-        let mut num_dropped_assignments = 0;
-        while let Ok(_assignment) = self.reschedule_queue_receiver.try_recv() {
-            num_dropped_assignments += 1;
-        }
-        if num_dropped_assignments > 0 {
-            tracing::warn!(
-                num_assignments = num_dropped_assignments,
-                "Dropped rescheduled task assignments on shutdown."
-            );
-        }
-
         Ok(())
     }
 }
 
 /// Creates a scheduler runtime from the given configuration and storage client.
 ///
-/// Registers this scheduler with the storage service, wires the scheduler core to a freshly
-/// created dispatch queue, and starts the core's scheduling loop as a background coroutine.
+/// Registers this scheduler with the storage service, wires the scheduler core to a freshly created
+/// dispatch queue, and starts the core's scheduling loop as a background coroutine.
 ///
 /// # Type Parameters
 ///
@@ -117,7 +102,7 @@ impl Runtime {
 ///
 /// * The newly created runtime instance.
 /// * The execution-manager-facing scheduler service, built over the dispatch queue reader.
-/// * The runtime's cancellation token, for cancelling the runtime on error.
+/// * The runtime's cancellation token for cancelling the runtime on error.
 ///
 /// # Errors
 ///
@@ -141,8 +126,8 @@ pub async fn create_runtime<SchedulerStorageClientType: SchedulerStorageClient +
     tracing::info!(scheduler_id = % scheduler_id, "Scheduler registered with storage.");
 
     let RuntimeConfig {
-        scheduler_config,
-        execution_manager_registry_config,
+        scheduler: scheduler_config,
+        em_registry: execution_manager_registry_config,
         stop_timeout_sec,
         ..
     } = config;
@@ -156,12 +141,9 @@ pub async fn create_runtime<SchedulerStorageClientType: SchedulerStorageClient +
         cancellation_token.clone(),
         reschedule_queue_sender,
     );
-
     let (dispatch_queue_writer, dispatch_queue_reader) =
         create_dispatch_queue(dispatch_queue_capacity.get(), SessionId::default());
-
     let service = SchedulerServiceState::new(dispatch_queue_reader, registry, scheduler_id);
-
     let core = scheduler_config.make_core::<SchedulerStorageClientType, DispatchQueueWriter>();
 
     let core_join_handle = tokio::spawn(core.run(
@@ -173,7 +155,7 @@ pub async fn create_runtime<SchedulerStorageClientType: SchedulerStorageClient +
 
     let runtime = Runtime {
         core_join_handle,
-        reschedule_queue_receiver,
+        _reschedule_queue_receiver: reschedule_queue_receiver,
         cancellation_token: cancellation_token.clone(),
         stop_timeout: Duration::from_secs(stop_timeout_sec),
     };
@@ -260,7 +242,7 @@ mod tests {
     /// A [`RuntimeConfig`] with a small round-robin core and the given stop timeout.
     fn make_runtime_config(stop_timeout_sec: u64) -> RuntimeConfig {
         RuntimeConfig {
-            scheduler_config: SchedulerConfig::RoundRobin(RoundRobinConfig {
+            scheduler: SchedulerConfig::RoundRobin(RoundRobinConfig {
                 active_job_queue_capacity: NonZeroUsize::new(4).expect("4 is non-zero"),
                 dispatch_queue_capacity: NonZeroUsize::new(8).expect("8 is non-zero"),
                 ready_task_capacity: NonZeroUsize::new(64).expect("64 is non-zero"),
@@ -270,7 +252,7 @@ mod tests {
                 tick_interval_ms: NonZeroU64::new(1).expect("1 is non-zero"),
                 finalizing_job_expiration_timeout_sec: 60,
             }),
-            execution_manager_registry_config: ExecutionManagerRegistryConfig::default(),
+            em_registry: ExecutionManagerRegistryConfig::default(),
             host: IpAddr::V4(Ipv4Addr::LOCALHOST),
             port: 0,
             stop_timeout_sec,
@@ -290,7 +272,7 @@ mod tests {
             tokio::sync::mpsc::unbounded_channel();
         Runtime {
             core_join_handle: core_task,
-            reschedule_queue_receiver,
+            _reschedule_queue_receiver: reschedule_queue_receiver,
             cancellation_token,
             stop_timeout: Duration::from_secs(stop_timeout_sec),
         }

--- a/components/spider-scheduler/src/runtime.rs
+++ b/components/spider-scheduler/src/runtime.rs
@@ -1,0 +1,365 @@
+//! The scheduler runtime.
+//!
+//! Mirroring the storage runtime, this module registers the scheduler with the storage service,
+//! wires the scheduler core to a freshly created dispatch queue, and spawns the core's scheduling
+//! loop as a background coroutine alongside the execution manager registry. The resulting
+//! [`Runtime`] owns the spawned coroutine and is responsible for cancelling and joining it on
+//! shutdown.
+
+use std::time::Duration;
+
+use serde::Deserialize;
+use spider_core::types::id::SessionId;
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    config::SchedulerConfig,
+    core::TaskAssignmentIdIssuer,
+    dispatch_queue::{DispatchQueueReader, DispatchQueueWriter, create_dispatch_queue},
+    error::{SchedulerError, SchedulerRuntimeError},
+    execution_manager_registry::{ExecutionManagerRegistry, ExecutionManagerRegistryConfig},
+    service::SchedulerServiceState,
+    storage_client::SchedulerStorageClient,
+    types::TaskAssignment,
+};
+
+/// Runtime configuration for the scheduler service.
+#[derive(Deserialize)]
+pub struct RuntimeConfig {
+    /// The scheduler core configuration that selects and configures the scheduling algorithm.
+    pub scheduler_config: SchedulerConfig,
+
+    /// The execution manager registry configuration.
+    #[serde(default)]
+    pub execution_manager_registry_config: ExecutionManagerRegistryConfig,
+
+    /// The IP address this scheduler advertises to the storage service during registration.
+    pub host: std::net::IpAddr,
+
+    /// The port this scheduler advertises to the storage service during registration.
+    pub port: u16,
+
+    /// The maximum time, in seconds, to wait for background tasks to stop during shutdown.
+    #[serde(default = "default_stop_timeout_sec")]
+    pub stop_timeout_sec: u64,
+}
+
+/// Runtime state for the scheduler service.
+pub struct Runtime {
+    core_join_handle: tokio::task::JoinHandle<Result<(), SchedulerError>>,
+    reschedule_queue_receiver: tokio::sync::mpsc::UnboundedReceiver<TaskAssignment>,
+    cancellation_token: CancellationToken,
+    stop_timeout: Duration,
+}
+
+impl Runtime {
+    /// Stops the runtime.
+    ///
+    /// The scheduler core coroutine is cancelled and joined. The core's error, if any, is logged
+    /// and will not be returned through this method. Any task assignments still buffered in the
+    /// reschedule queue are drained and dropped.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * [`SchedulerRuntimeError::Stopping`] if the scheduler core does not stop before the
+    ///   configured timeout.
+    pub async fn stop(mut self) -> Result<(), SchedulerRuntimeError> {
+        self.cancellation_token.cancel();
+
+        let join_result = tokio::time::timeout(self.stop_timeout, self.core_join_handle)
+            .await
+            .map_err(|_| {
+                SchedulerRuntimeError::Stopping("scheduler core stop timed out".to_owned())
+            })?;
+        match join_result {
+            Ok(Ok(())) => {
+                tracing::info!("Scheduler core stopped.");
+            }
+            Ok(Err(e)) => {
+                tracing::error!(error = % e, "Scheduler core exited on error.");
+            }
+            Err(e) => {
+                tracing::error!(error = % e, "Scheduler core exited on panic.");
+            }
+        }
+
+        // The reschedule queue is reserved for future re-injection wiring; for now, drain and drop
+        // any assignments still buffered at shutdown.
+        let mut num_dropped_assignments = 0;
+        while let Ok(_assignment) = self.reschedule_queue_receiver.try_recv() {
+            num_dropped_assignments += 1;
+        }
+        if num_dropped_assignments > 0 {
+            tracing::warn!(
+                num_assignments = num_dropped_assignments,
+                "Dropped rescheduled task assignments on shutdown."
+            );
+        }
+
+        Ok(())
+    }
+}
+
+/// Creates a scheduler runtime from the given configuration and storage client.
+///
+/// Registers this scheduler with the storage service, wires the scheduler core to a freshly
+/// created dispatch queue, and starts the core's scheduling loop as a background coroutine.
+///
+/// # Type Parameters
+///
+/// * `SchedulerStorageClientType` - The storage client the core polls and registers through.
+///
+/// # Returns
+///
+/// A tuple on success, containing:
+///
+/// * The newly created runtime instance.
+/// * The execution-manager-facing scheduler service, built over the dispatch queue reader.
+/// * The runtime's cancellation token, for cancelling the runtime on error.
+///
+/// # Errors
+///
+/// Returns an error if:
+///
+/// * Forwards [`SchedulerStorageClient::register`]'s return values on failure.
+pub async fn create_runtime<SchedulerStorageClientType: SchedulerStorageClient + 'static>(
+    config: RuntimeConfig,
+    storage_client: SchedulerStorageClientType,
+) -> Result<
+    (
+        Runtime,
+        SchedulerServiceState<DispatchQueueReader>,
+        CancellationToken,
+    ),
+    SchedulerRuntimeError,
+> {
+    let cancellation_token = CancellationToken::new();
+
+    let scheduler_id = storage_client.register(config.host, config.port).await?;
+    tracing::info!(scheduler_id = % scheduler_id, "Scheduler registered with storage.");
+
+    let RuntimeConfig {
+        scheduler_config,
+        execution_manager_registry_config,
+        stop_timeout_sec,
+        ..
+    } = config;
+    let dispatch_queue_capacity = scheduler_config.dispatch_queue_capacity();
+
+    let (reschedule_queue_sender, reschedule_queue_receiver) =
+        tokio::sync::mpsc::unbounded_channel();
+
+    let registry = ExecutionManagerRegistry::new(
+        &execution_manager_registry_config,
+        cancellation_token.clone(),
+        reschedule_queue_sender,
+    );
+
+    let (dispatch_queue_writer, dispatch_queue_reader) =
+        create_dispatch_queue(dispatch_queue_capacity.get(), SessionId::default());
+
+    let service = SchedulerServiceState::new(dispatch_queue_reader, registry, scheduler_id);
+
+    let core = scheduler_config.make_core::<SchedulerStorageClientType, DispatchQueueWriter>();
+
+    let core_join_handle = tokio::spawn(core.run(
+        storage_client,
+        dispatch_queue_writer,
+        TaskAssignmentIdIssuer::new(),
+        cancellation_token.clone(),
+    ));
+
+    let runtime = Runtime {
+        core_join_handle,
+        reschedule_queue_receiver,
+        cancellation_token: cancellation_token.clone(),
+        stop_timeout: Duration::from_secs(stop_timeout_sec),
+    };
+
+    Ok((runtime, service, cancellation_token))
+}
+
+/// The maximum time, in seconds, to wait for background tasks to stop during shutdown.
+const STOP_BACKGROUND_TASKS_TIMEOUT_SEC: u64 = 30;
+
+/// # Returns
+///
+/// The default maximum time, in seconds, to wait for background tasks to stop during shutdown.
+const fn default_stop_timeout_sec() -> u64 {
+    STOP_BACKGROUND_TASKS_TIMEOUT_SEC
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        net::{IpAddr, Ipv4Addr},
+        num::{NonZeroU64, NonZeroUsize},
+    };
+
+    use async_trait::async_trait;
+    use spider_core::{
+        job::JobState,
+        types::id::{JobId, SchedulerId},
+    };
+
+    use super::*;
+    use crate::{core_impl::RoundRobinConfig, error::StorageClientError, types::InboundEntry};
+
+    /// The scheduler identifier the mock storage client hands back from registration.
+    const SCHEDULER_ID: u64 = 7;
+
+    /// A minimal [`SchedulerStorageClient`] mock: registration returns a fixed identifier and every
+    /// poll returns an empty batch under session zero, so the scheduler core can spin without any
+    /// external services.
+    #[derive(Clone)]
+    struct MockStorageClient;
+
+    #[async_trait]
+    impl SchedulerStorageClient for MockStorageClient {
+        async fn register(
+            &self,
+            _ip_address: IpAddr,
+            _port: u16,
+        ) -> Result<SchedulerId, StorageClientError> {
+            Ok(SchedulerId::from(SCHEDULER_ID))
+        }
+
+        async fn poll_ready(
+            &self,
+            _max_items: usize,
+            _wait: Duration,
+        ) -> Result<(SessionId, Vec<InboundEntry>), StorageClientError> {
+            Ok((SessionId::default(), Vec::new()))
+        }
+
+        async fn poll_commit_ready(
+            &self,
+            _max_items: usize,
+            _wait: Duration,
+        ) -> Result<(SessionId, Vec<InboundEntry>), StorageClientError> {
+            Ok((SessionId::default(), Vec::new()))
+        }
+
+        async fn poll_cleanup_ready(
+            &self,
+            _max_items: usize,
+            _wait: Duration,
+        ) -> Result<(SessionId, Vec<InboundEntry>), StorageClientError> {
+            Ok((SessionId::default(), Vec::new()))
+        }
+
+        async fn job_state(&self, _job_id: JobId) -> Result<JobState, StorageClientError> {
+            Ok(JobState::Running)
+        }
+    }
+
+    /// # Returns
+    ///
+    /// A [`RuntimeConfig`] with a small round-robin core and the given stop timeout.
+    fn make_runtime_config(stop_timeout_sec: u64) -> RuntimeConfig {
+        RuntimeConfig {
+            scheduler_config: SchedulerConfig::RoundRobin(RoundRobinConfig {
+                active_job_queue_capacity: NonZeroUsize::new(4).expect("4 is non-zero"),
+                dispatch_queue_capacity: NonZeroUsize::new(8).expect("8 is non-zero"),
+                ready_task_capacity: NonZeroUsize::new(64).expect("64 is non-zero"),
+                commit_ready_task_capacity: NonZeroUsize::new(8).expect("8 is non-zero"),
+                cleanup_ready_task_capacity: NonZeroUsize::new(8).expect("8 is non-zero"),
+                storage_poll_timeout_ms: 1,
+                tick_interval_ms: NonZeroU64::new(1).expect("1 is non-zero"),
+                finalizing_job_expiration_timeout_sec: 60,
+            }),
+            execution_manager_registry_config: ExecutionManagerRegistryConfig::default(),
+            host: IpAddr::V4(Ipv4Addr::LOCALHOST),
+            port: 0,
+            stop_timeout_sec,
+        }
+    }
+
+    /// # Returns
+    ///
+    /// A [`Runtime`] whose core coroutine is `core_task`, wired to a fresh cancellation token and
+    /// reschedule queue.
+    fn make_runtime(
+        cancellation_token: CancellationToken,
+        core_task: tokio::task::JoinHandle<Result<(), SchedulerError>>,
+        stop_timeout_sec: u64,
+    ) -> Runtime {
+        let (_reschedule_queue_sender, reschedule_queue_receiver) =
+            tokio::sync::mpsc::unbounded_channel();
+        Runtime {
+            core_join_handle: core_task,
+            reschedule_queue_receiver,
+            cancellation_token,
+            stop_timeout: Duration::from_secs(stop_timeout_sec),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_runtime_registers_and_stops() -> anyhow::Result<()> {
+        let (runtime, service, cancellation_token) =
+            create_runtime(make_runtime_config(30), MockStorageClient).await?;
+
+        // The service is stamped with the identifier handed back by registration.
+        assert_eq!(service.scheduler_id(), SchedulerId::from(SCHEDULER_ID));
+        assert!(!cancellation_token.is_cancelled());
+
+        runtime.stop().await?;
+
+        // Stopping the runtime cancels the token that drives the core coroutine.
+        assert!(cancellation_token.is_cancelled());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stop_runtime_on_success() -> anyhow::Result<()> {
+        let cancellation_token = CancellationToken::new();
+        let core_cancellation_token = cancellation_token.clone();
+        let core_task = tokio::spawn(async move {
+            core_cancellation_token.cancelled().await;
+            Ok(())
+        });
+
+        let runtime = make_runtime(cancellation_token, core_task, 30);
+        runtime
+            .stop()
+            .await
+            .expect("the runtime should stop cleanly");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stop_runtime_on_timeout() -> anyhow::Result<()> {
+        let cancellation_token = CancellationToken::new();
+        let core_task = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(10)).await;
+            Ok(())
+        });
+
+        let runtime = make_runtime(cancellation_token, core_task, 0);
+        let result = runtime.stop().await;
+
+        assert!(
+            matches!(result, Err(SchedulerRuntimeError::Stopping(_))),
+            "a core that does not stop in time should yield a Stopping error"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stop_runtime_on_core_error() -> anyhow::Result<()> {
+        let cancellation_token = CancellationToken::new();
+        let core_task =
+            tokio::spawn(async move { Err(SchedulerError::Internal("test failure".to_owned())) });
+
+        let runtime = make_runtime(cancellation_token, core_task, 30);
+
+        // A core error is logged during teardown, not forwarded through `stop`.
+        runtime
+            .stop()
+            .await
+            .expect("a core error should not be forwarded as a stop error");
+        Ok(())
+    }
+}

--- a/components/spider-scheduler/src/service.rs
+++ b/components/spider-scheduler/src/service.rs
@@ -22,10 +22,6 @@ use crate::{
 
 /// The execution-manager-facing scheduler service.
 ///
-/// Sits between the dispatch queue and the execution manager registry, turning execution-manager
-/// requests into registry bookkeeping. The service stamps every assignment it hands out with the
-/// scheduler's own identifier, captured at registration time.
-///
 /// # Type Parameters
 ///
 /// * `DispatchQueueSourceType` - The reader side of the dispatching queue the service drains.
@@ -131,10 +127,7 @@ impl<DispatchQueueSourceType: DispatchQueueSource> SchedulerServiceState<Dispatc
 
     /// Signals that an execution manager is shutting down.
     ///
-    /// Each assignment in `prev_assignments` is acknowledged as completed best-effort: a missing
-    /// assignment or execution manager is logged and skipped so teardown still proceeds. The
-    /// execution manager is then marked dead, which reschedules any assignments still outstanding
-    /// against it.
+    /// Marks the execution manager as dead in the registry.
     ///
     /// # Parameters
     ///

--- a/components/spider-scheduler/src/service.rs
+++ b/components/spider-scheduler/src/service.rs
@@ -1,0 +1,466 @@
+//! The execution-manager-facing scheduler service.
+//!
+//! [`SchedulerServiceState`] is the domain layer behind the scheduler gRPC service. It serves
+//! execution managers by draining task assignments from the dispatch queue and bookkeeping them in
+//! the [`ExecutionManagerRegistry`]: assignment, completion, heartbeat, and shutdown. The service
+//! is generic over its dispatch source so the runtime can drive it with the real dispatch queue in
+//! production or a mock in tests, while the [`ExecutionManagerRegistry`] is shared by value.
+
+use std::time::Duration;
+
+use spider_core::types::{
+    id::{ExecutionManagerId, SchedulerId, SessionId},
+    scheduler::TaskAssignmentRecord,
+};
+
+use crate::{
+    dispatch_queue::DispatchQueueSource,
+    error::SchedulerServiceError,
+    execution_manager_registry::ExecutionManagerRegistry,
+    types::TaskAssignment,
+};
+
+/// The execution-manager-facing scheduler service.
+///
+/// Sits between the dispatch queue and the execution manager registry, turning execution-manager
+/// requests into registry bookkeeping. The service stamps every assignment it hands out with the
+/// scheduler's own identifier, captured at registration time.
+///
+/// # Type Parameters
+///
+/// * `DispatchQueueSourceType` - The reader side of the dispatching queue the service drains.
+#[derive(Clone)]
+pub struct SchedulerServiceState<DispatchQueueSourceType: DispatchQueueSource> {
+    dispatch_source: DispatchQueueSourceType,
+    registry: ExecutionManagerRegistry,
+    scheduler_id: SchedulerId,
+}
+
+impl<DispatchQueueSourceType: DispatchQueueSource> SchedulerServiceState<DispatchQueueSourceType> {
+    /// Factory function.
+    ///
+    /// # Returns
+    ///
+    /// A new [`SchedulerServiceState`] that drains `dispatch_source`, tracks assignments in
+    /// `registry`, and stamps `scheduler_id` onto every assignment it hands out.
+    #[must_use]
+    pub const fn new(
+        dispatch_source: DispatchQueueSourceType,
+        registry: ExecutionManagerRegistry,
+        scheduler_id: SchedulerId,
+    ) -> Self {
+        Self {
+            dispatch_source,
+            registry,
+            scheduler_id,
+        }
+    }
+
+    /// # Returns
+    ///
+    /// The scheduler identifier this service stamps onto every assignment it hands out.
+    #[must_use]
+    pub const fn scheduler_id(&self) -> SchedulerId {
+        self.scheduler_id
+    }
+
+    /// Hands the next task assignment to an execution manager.
+    ///
+    /// If `prev_assignment` is supplied, the execution manager first acknowledges it as consumed by
+    /// completing it in the registry. The service then drains the next assignment from the dispatch
+    /// queue, waiting up to `wait_time` for one to arrive, and records the assignment against the
+    /// execution manager in the registry before returning it.
+    ///
+    /// # Parameters
+    ///
+    /// * `em_id` - The identity of the calling execution manager.
+    /// * `prev_assignment` - The last assignment produced by this scheduler that the execution
+    ///   manager has successfully consumed, or [`None`] if no previous assignment exists.
+    /// * `wait_time` - The maximum duration to wait for an assignment to become available.
+    ///
+    /// # Returns
+    ///
+    /// A tuple on success, containing:
+    ///
+    /// * The storage session the dispatch queue paired with the assignment.
+    /// * The task assignment handed to the execution manager.
+    ///
+    /// [`None`] is returned when no assignment becomes available within `wait_time`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * [`SchedulerServiceError::EMRegistry`] if completing `prev_assignment` fails because the
+    ///   execution manager or the assignment is not registered.
+    /// * Forwards [`DispatchQueueSource::dequeue`]'s return values on failure.
+    pub async fn next_task(
+        &self,
+        em_id: ExecutionManagerId,
+        prev_assignment: Option<TaskAssignmentRecord>,
+        wait_time: Duration,
+    ) -> Result<Option<(SessionId, TaskAssignment)>, SchedulerServiceError> {
+        if let Some(prev) = prev_assignment {
+            self.registry.complete(em_id, prev.id).await?;
+        }
+        match self.dispatch_source.dequeue(wait_time).await? {
+            None => Ok(None),
+            Some((session_id, assignment)) => {
+                self.registry.assign(em_id, assignment).await;
+                Ok(Some((session_id, assignment)))
+            }
+        }
+    }
+
+    /// Refreshes the liveness of an execution manager.
+    ///
+    /// Registers the execution manager if this is its first heartbeat.
+    ///
+    /// # Parameters
+    ///
+    /// * `em_id` - The identity of the calling execution manager.
+    ///
+    /// # Errors
+    ///
+    /// This method does not currently return an error. The [`Result`] return type is retained for a
+    /// uniform service surface alongside [`Self::next_task`] and [`Self::shutdown`].
+    pub async fn heartbeat(&self, em_id: ExecutionManagerId) -> Result<(), SchedulerServiceError> {
+        self.registry.update_heartbeat(em_id).await;
+        Ok(())
+    }
+
+    /// Signals that an execution manager is shutting down.
+    ///
+    /// Each assignment in `prev_assignments` is acknowledged as completed best-effort: a missing
+    /// assignment or execution manager is logged and skipped so teardown still proceeds. The
+    /// execution manager is then marked dead, which reschedules any assignments still outstanding
+    /// against it.
+    ///
+    /// # Parameters
+    ///
+    /// * `em_id` - The identity of the calling execution manager.
+    /// * `prev_assignments` - The assignments produced by this scheduler that the execution manager
+    ///   has successfully consumed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * [`SchedulerServiceError::EMRegistry`] if marking the execution manager as dead fails.
+    pub async fn shutdown(
+        &self,
+        em_id: ExecutionManagerId,
+        prev_assignments: Vec<TaskAssignmentRecord>,
+    ) -> Result<(), SchedulerServiceError> {
+        for prev in prev_assignments {
+            if let Err(error) = self.registry.complete(em_id, prev.id).await {
+                tracing::warn!(
+                    em_id = %em_id,
+                    error = %error,
+                    assignment_id = ?prev.id,
+                    "Failed to complete a previously consumed assignment during shutdown. Skipping."
+                );
+            }
+        }
+        self.registry.mark_as_dead(em_id).await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+        time::Duration,
+    };
+
+    use async_trait::async_trait;
+    use spider_core::types::{
+        id::{
+            ExecutionManagerId,
+            JobId,
+            ResourceGroupId,
+            SchedulerId,
+            SessionId,
+            TaskAssignmentId,
+            TaskId,
+        },
+        scheduler::TaskAssignmentRecord,
+    };
+    use tokio::{
+        sync::mpsc::{self, UnboundedReceiver},
+        time::timeout,
+    };
+    use tokio_util::sync::CancellationToken;
+
+    use super::SchedulerServiceState;
+    use crate::{
+        dispatch_queue::DispatchQueueSource,
+        error::SchedulerError,
+        execution_manager_registry::{ExecutionManagerRegistry, ExecutionManagerRegistryConfig},
+        types::TaskAssignment,
+    };
+
+    /// The storage session the mock dispatch source pairs with every assignment it returns.
+    const SESSION_ID: SessionId = 7;
+
+    /// The scheduler identifier the service stamps onto assignments.
+    const SCHEDULER_ID: u64 = 42;
+
+    /// The execution manager the tests drive the service with.
+    const EM_ID: u64 = 1;
+
+    /// The maximum time to wait for a rescheduled assignment before failing a test.
+    const RESCHEDULE_TIMEOUT: Duration = Duration::from_secs(2);
+
+    /// A [`DispatchQueueSource`] mock backed by a shared counter.
+    ///
+    /// Each [`DispatchQueueSource::dequeue`] claims one slot from the counter; while it is positive
+    /// it returns a freshly minted task assignment, and once it reaches zero it returns [`None`]
+    /// forever. Using a counter (rather than a canned list of assignments) lets the tests assert on
+    /// dequeue behavior without coupling to recorded argument vectors.
+    #[derive(Clone)]
+    struct CounterDispatchSource {
+        remaining: Arc<AtomicUsize>,
+    }
+
+    impl CounterDispatchSource {
+        /// # Returns
+        ///
+        /// A new [`CounterDispatchSource`] that hands out `remaining` assignments before reporting
+        /// an empty queue.
+        fn new(remaining: usize) -> Self {
+            Self {
+                remaining: Arc::new(AtomicUsize::new(remaining)),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl DispatchQueueSource for CounterDispatchSource {
+        async fn dequeue(
+            &self,
+            _wait_time: Duration,
+        ) -> Result<Option<(SessionId, TaskAssignment)>, SchedulerError> {
+            // Atomically claim one slot: return None once the counter is exhausted, otherwise
+            // decrement and synthesize a fresh assignment.
+            let mut current = self.remaining.load(Ordering::Relaxed);
+            loop {
+                if current == 0 {
+                    return Ok(None);
+                }
+                match self.remaining.compare_exchange(
+                    current,
+                    current - 1,
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                ) {
+                    Ok(_) => return Ok(Some((SESSION_ID, make_assignment()))),
+                    Err(actual) => current = actual,
+                }
+            }
+        }
+    }
+
+    /// # Returns
+    ///
+    /// A fresh [`TaskAssignment`] with a unique, counter-derived identifier. The remaining
+    /// identifier fields are fixed since the service tests do not assert on them.
+    fn make_assignment() -> TaskAssignment {
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+        let id = u64::try_from(COUNTER.fetch_add(1, Ordering::Relaxed))
+            .expect("the counter is well below u64::MAX");
+        TaskAssignment {
+            id: TaskAssignmentId::from(id),
+            resource_group_id: ResourceGroupId::from(0),
+            job_id: JobId::from(0),
+            task_id: TaskId::Index(0),
+        }
+    }
+
+    /// # Returns
+    ///
+    /// A [`TaskAssignmentRecord`] acknowledging `id` as consumed, issued by this scheduler.
+    fn record(id: TaskAssignmentId) -> TaskAssignmentRecord {
+        TaskAssignmentRecord::new(id, SchedulerId::from(SCHEDULER_ID))
+    }
+
+    /// Builds a registry whose background liveness tracker never fires during a test (a one-hour
+    /// cutoff with a one-minute interval), so registration, completion, and teardown can be driven
+    /// explicitly rather than by timeouts.
+    ///
+    /// # Returns
+    ///
+    /// A tuple containing:
+    ///
+    /// * The registry.
+    /// * The receiver end of the re-schedule queue.
+    /// * The registry-level cancellation token.
+    fn build_registry() -> (
+        ExecutionManagerRegistry,
+        UnboundedReceiver<TaskAssignment>,
+        CancellationToken,
+    ) {
+        let config = ExecutionManagerRegistryConfig {
+            dead_em_cutoff_sec: 3600,
+            liveness_tracking_interval_ms: 60_000,
+        };
+        let cancellation_token = CancellationToken::new();
+        let (reschedule_queue_sender, reschedule_queue_receiver) = mpsc::unbounded_channel();
+        let registry = ExecutionManagerRegistry::new(
+            &config,
+            cancellation_token.clone(),
+            reschedule_queue_sender,
+        )
+        .expect("the registry should be constructed successfully");
+        (registry, reschedule_queue_receiver, cancellation_token)
+    }
+
+    /// # Returns
+    ///
+    /// A tuple containing:
+    ///
+    /// * A [`SchedulerServiceState`] over a [`CounterDispatchSource`] with `remaining` assignments,
+    ///   backed by a fresh test registry.
+    /// * The receiver end of the registry's re-schedule queue.
+    /// * The registry-level cancellation token.
+    fn build_service(
+        remaining: usize,
+    ) -> (
+        SchedulerServiceState<CounterDispatchSource>,
+        UnboundedReceiver<TaskAssignment>,
+        CancellationToken,
+    ) {
+        let (registry, reschedule_queue_receiver, cancellation_token) = build_registry();
+        let service = SchedulerServiceState::new(
+            CounterDispatchSource::new(remaining),
+            registry,
+            SchedulerId::from(SCHEDULER_ID),
+        );
+        (service, reschedule_queue_receiver, cancellation_token)
+    }
+
+    #[tokio::test]
+    async fn next_task_returns_none_when_queue_empty() -> anyhow::Result<()> {
+        let (service, _reschedule_queue_receiver, _cancellation_token) = build_service(0);
+
+        let result = service
+            .next_task(
+                ExecutionManagerId::from(EM_ID),
+                None,
+                Duration::from_millis(1),
+            )
+            .await?;
+        assert_eq!(result, None);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn next_task_assigns_and_records_assignment() -> anyhow::Result<()> {
+        let (service, mut reschedule_queue_receiver, _cancellation_token) = build_service(1);
+        let em_id = ExecutionManagerId::from(EM_ID);
+
+        assert_eq!(service.scheduler_id(), SchedulerId::from(SCHEDULER_ID));
+
+        let (session_id, assignment) = service
+            .next_task(em_id, None, Duration::from_millis(1))
+            .await?
+            .expect("an assignment should be dequeued");
+        assert_eq!(session_id, SESSION_ID);
+
+        // The assignment was recorded against the execution manager, so shutting it down without
+        // acknowledging the assignment reschedules it.
+        service.shutdown(em_id, Vec::new()).await?;
+
+        let rescheduled = timeout(RESCHEDULE_TIMEOUT, reschedule_queue_receiver.recv())
+            .await
+            .expect("the recorded assignment should be rescheduled before the timeout")
+            .expect("the reschedule queue should remain open");
+        assert_eq!(rescheduled.id, assignment.id);
+        assert!(reschedule_queue_receiver.try_recv().is_err());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn next_task_completes_prev_assignment() -> anyhow::Result<()> {
+        let (service, mut reschedule_queue_receiver, _cancellation_token) = build_service(2);
+        let em_id = ExecutionManagerId::from(EM_ID);
+
+        let (_, assignment_a) = service
+            .next_task(em_id, None, Duration::from_millis(1))
+            .await?
+            .expect("the first assignment should be dequeued");
+        let (_, assignment_b) = service
+            .next_task(
+                em_id,
+                Some(record(assignment_a.id)),
+                Duration::from_millis(1),
+            )
+            .await?
+            .expect("the second assignment should be dequeued");
+
+        // The previous assignment was completed during the second call, so only the still
+        // outstanding assignment B is rescheduled on shutdown.
+        service.shutdown(em_id, Vec::new()).await?;
+
+        let rescheduled = timeout(RESCHEDULE_TIMEOUT, reschedule_queue_receiver.recv())
+            .await
+            .expect("the outstanding assignment should be rescheduled before the timeout")
+            .expect("the reschedule queue should remain open");
+        assert_eq!(rescheduled.id, assignment_b.id);
+        assert!(reschedule_queue_receiver.try_recv().is_err());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn heartbeat_registers_execution_manager() -> anyhow::Result<()> {
+        let (service, mut reschedule_queue_receiver, _cancellation_token) = build_service(0);
+        let em_id = ExecutionManagerId::from(EM_ID);
+
+        service.heartbeat(em_id).await?;
+
+        // `mark_as_dead` only succeeds for a registered execution manager, so a clean shutdown
+        // confirms the heartbeat registered it.
+        service.shutdown(em_id, Vec::new()).await?;
+        assert!(reschedule_queue_receiver.try_recv().is_err());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn shutdown_completes_prevs_and_reschedules_outstanding() -> anyhow::Result<()> {
+        let (service, mut reschedule_queue_receiver, _cancellation_token) = build_service(3);
+        let em_id = ExecutionManagerId::from(EM_ID);
+
+        let (_, assignment_a) = service
+            .next_task(em_id, None, Duration::from_millis(1))
+            .await?
+            .expect("the first assignment should be dequeued");
+        let (_, assignment_b) = service
+            .next_task(em_id, None, Duration::from_millis(1))
+            .await?
+            .expect("the second assignment should be dequeued");
+        let (_, assignment_c) = service
+            .next_task(em_id, None, Duration::from_millis(1))
+            .await?
+            .expect("the third assignment should be dequeued");
+
+        // A and B are acknowledged as completed; C remains outstanding and is rescheduled.
+        service
+            .shutdown(
+                em_id,
+                vec![record(assignment_a.id), record(assignment_b.id)],
+            )
+            .await?;
+
+        let rescheduled = timeout(RESCHEDULE_TIMEOUT, reschedule_queue_receiver.recv())
+            .await
+            .expect("the outstanding assignment should be rescheduled before the timeout")
+            .expect("the reschedule queue should remain open");
+        assert_eq!(rescheduled.id, assignment_c.id);
+        assert!(reschedule_queue_receiver.try_recv().is_err());
+        Ok(())
+    }
+}

--- a/components/spider-scheduler/src/service.rs
+++ b/components/spider-scheduler/src/service.rs
@@ -67,13 +67,6 @@ impl<DispatchQueueSourceType: DispatchQueueSource> SchedulerServiceState<Dispatc
     /// queue, waiting up to `wait_time` for one to arrive, and records the assignment against the
     /// execution manager in the registry before returning it.
     ///
-    /// # Parameters
-    ///
-    /// * `em_id` - The identity of the calling execution manager.
-    /// * `prev_assignment` - The last assignment produced by this scheduler that the execution
-    ///   manager has successfully consumed, or [`None`] if no previous assignment exists.
-    /// * `wait_time` - The maximum duration to wait for an assignment to become available.
-    ///
     /// # Returns
     ///
     /// A tuple on success, containing:
@@ -112,10 +105,6 @@ impl<DispatchQueueSourceType: DispatchQueueSource> SchedulerServiceState<Dispatc
     ///
     /// Registers the execution manager if this is its first heartbeat.
     ///
-    /// # Parameters
-    ///
-    /// * `em_id` - The identity of the calling execution manager.
-    ///
     /// # Errors
     ///
     /// This method does not currently return an error. The [`Result`] return type is retained for a
@@ -127,13 +116,8 @@ impl<DispatchQueueSourceType: DispatchQueueSource> SchedulerServiceState<Dispatc
 
     /// Signals that an execution manager is shutting down.
     ///
-    /// Marks the execution manager as dead in the registry.
-    ///
-    /// # Parameters
-    ///
-    /// * `em_id` - The identity of the calling execution manager.
-    /// * `prev_assignments` - The assignments produced by this scheduler that the execution manager
-    ///   has successfully consumed.
+    /// Each assignment in `prev_assignments` is acknowledged as completed best-effort, then the
+    /// execution manager is marked as dead in the registry.
     ///
     /// # Errors
     ///

--- a/components/spider-scheduler/src/service.rs
+++ b/components/spider-scheduler/src/service.rs
@@ -147,6 +147,7 @@ impl<DispatchQueueSourceType: DispatchQueueSource> SchedulerServiceState<Dispatc
 #[cfg(test)]
 mod tests {
     use std::{
+        num::NonZeroU64,
         sync::{
             Arc,
             atomic::{AtomicUsize, Ordering},
@@ -282,8 +283,9 @@ mod tests {
         CancellationToken,
     ) {
         let config = ExecutionManagerRegistryConfig {
-            dead_em_cutoff_sec: 3600,
-            liveness_tracking_interval_ms: 60_000,
+            dead_em_cutoff_sec: NonZeroU64::new(3600).expect("the cutoff should be non-zero"),
+            liveness_tracking_interval_ms: NonZeroU64::new(60_000)
+                .expect("the interval should be non-zero"),
         };
         let cancellation_token = CancellationToken::new();
         let (reschedule_queue_sender, reschedule_queue_receiver) = mpsc::unbounded_channel();
@@ -291,8 +293,7 @@ mod tests {
             &config,
             cancellation_token.clone(),
             reschedule_queue_sender,
-        )
-        .expect("the registry should be constructed successfully");
+        );
         (registry, reschedule_queue_receiver, cancellation_token)
     }
 

--- a/components/spider-scheduler/src/storage_client/grpc.rs
+++ b/components/spider-scheduler/src/storage_client/grpc.rs
@@ -5,12 +5,13 @@ use std::{num::NonZeroUsize, time::Duration};
 use async_trait::async_trait;
 use spider_core::{
     job::JobState,
-    types::id::{JobId, ResourceGroupId, SessionId, TaskId},
+    types::id::{JobId, ResourceGroupId, SchedulerId, SessionId, TaskId},
 };
 use spider_proto_rust::storage::{
     self,
     inbound_queue_service_client::InboundQueueServiceClient,
     job_orchestration_service_client::JobOrchestrationServiceClient,
+    scheduler_registration_service_client::SchedulerRegistrationServiceClient,
 };
 use spider_utils::grpc::client::ConnectionPool;
 use tonic::{
@@ -28,8 +29,9 @@ use crate::{
 /// gRPC-backed [`SchedulerStorageClient`] implementation.
 #[derive(Debug, Clone)]
 pub struct GrpcSchedulerStorageClient {
-    inbound_queue_connection_pool: ConnectionPool<InboundQueueServiceClient<Channel>>,
-    job_orchestration_connection_pool: ConnectionPool<JobOrchestrationServiceClient<Channel>>,
+    inbound_queue: ConnectionPool<InboundQueueServiceClient<Channel>>,
+    job_orchestration: ConnectionPool<JobOrchestrationServiceClient<Channel>>,
+    scheduler_registration: ConnectionPool<SchedulerRegistrationServiceClient<Channel>>,
 }
 
 impl GrpcSchedulerStorageClient {
@@ -48,28 +50,56 @@ impl GrpcSchedulerStorageClient {
         endpoint: Endpoint,
         pool_size: NonZeroUsize,
     ) -> Result<Self, StorageClientError> {
-        let inbound_queue_connection_pool =
-            ConnectionPool::connect(endpoint.clone(), pool_size, |channel| {
-                InboundQueueServiceClient::new(channel)
-            })
-            .await
-            .map_err(to_transport_error)?;
-        let job_orchestration_connection_pool =
-            ConnectionPool::connect(endpoint, pool_size, |channel| {
-                JobOrchestrationServiceClient::new(channel)
-            })
-            .await
-            .map_err(to_transport_error)?;
+        let inbound_queue = ConnectionPool::connect(endpoint.clone(), pool_size, |channel| {
+            InboundQueueServiceClient::new(channel)
+        })
+        .await
+        .map_err(to_transport_error)?;
+        let job_orchestration = ConnectionPool::connect(endpoint.clone(), pool_size, |channel| {
+            JobOrchestrationServiceClient::new(channel)
+        })
+        .await
+        .map_err(to_transport_error)?;
+        let scheduler_registration = ConnectionPool::connect(endpoint, pool_size, |channel| {
+            SchedulerRegistrationServiceClient::new(channel)
+        })
+        .await
+        .map_err(to_transport_error)?;
 
         Ok(Self {
-            inbound_queue_connection_pool,
-            job_orchestration_connection_pool,
+            inbound_queue,
+            job_orchestration,
+            scheduler_registration,
         })
     }
 }
 
 #[async_trait]
 impl SchedulerStorageClient for GrpcSchedulerStorageClient {
+    async fn register(
+        &self,
+        ip_address: std::net::IpAddr,
+        port: u16,
+    ) -> Result<SchedulerId, StorageClientError> {
+        let request = storage::RegisterSchedulerRequest {
+            ip_address: ip_address.to_string(),
+            port: u32::from(port),
+        };
+        let response = self
+            .scheduler_registration
+            .get_client()
+            .register_scheduler(request)
+            .await
+            .map_err(|status| StorageClientError::Server(status.message().to_owned()))?
+            .into_inner();
+        let registration = response.registration.ok_or_else(|| {
+            StorageClientError::Transport(
+                "register scheduler response missing `registration` message".to_owned(),
+            )
+        })?;
+        Ok(SchedulerId::from(registration.scheduler_id))
+    }
+
     async fn poll_ready(
         &self,
         max_items: usize,
@@ -77,7 +107,7 @@ impl SchedulerStorageClient for GrpcSchedulerStorageClient {
     ) -> Result<(SessionId, Vec<InboundEntry>), StorageClientError> {
         let request = poll_ready_tasks_request(max_items, wait)?;
         let response = self
-            .inbound_queue_connection_pool
+            .inbound_queue
             .get_client()
             .poll_ready_tasks(request)
             .await
@@ -93,7 +123,7 @@ impl SchedulerStorageClient for GrpcSchedulerStorageClient {
     ) -> Result<(SessionId, Vec<InboundEntry>), StorageClientError> {
         let request = poll_ready_tasks_request(max_items, wait)?;
         let response = self
-            .inbound_queue_connection_pool
+            .inbound_queue
             .get_client()
             .poll_ready_commit_tasks(request)
             .await
@@ -109,7 +139,7 @@ impl SchedulerStorageClient for GrpcSchedulerStorageClient {
     ) -> Result<(SessionId, Vec<InboundEntry>), StorageClientError> {
         let request = poll_ready_tasks_request(max_items, wait)?;
         let response = self
-            .inbound_queue_connection_pool
+            .inbound_queue
             .get_client()
             .poll_ready_cleanup_tasks(request)
             .await
@@ -123,7 +153,7 @@ impl SchedulerStorageClient for GrpcSchedulerStorageClient {
             job_id: job_id.get(),
         };
         let response = self
-            .job_orchestration_connection_pool
+            .job_orchestration
             .get_client()
             .get_job_state(request)
             .await

--- a/components/spider-scheduler/src/storage_client/grpc.rs
+++ b/components/spider-scheduler/src/storage_client/grpc.rs
@@ -90,7 +90,10 @@ impl SchedulerStorageClient for GrpcSchedulerStorageClient {
             .get_client()
             .register_scheduler(request)
             .await
-            .map_err(|status| StorageClientError::Server(status.message().to_owned()))?
+            .map_err(|status| match status.code() {
+                Code::Unavailable => to_transport_error(status.message()),
+                _ => StorageClientError::Server(status.message().to_owned()),
+            })?
             .into_inner();
         let registration = response.registration.ok_or_else(|| {
             StorageClientError::Transport(

--- a/components/spider-scheduler/src/storage_client/mod.rs
+++ b/components/spider-scheduler/src/storage_client/mod.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use spider_core::{
     job::JobState,
-    types::id::{JobId, SessionId},
+    types::id::{JobId, SchedulerId, SessionId},
 };
 
 use crate::{error::StorageClientError, types::InboundEntry};
@@ -21,6 +21,31 @@ pub use grpc::GrpcSchedulerStorageClient;
 /// a real storage client in production or a mock in tests.
 #[async_trait]
 pub trait SchedulerStorageClient: Send + Sync + Clone {
+    /// Registers this scheduler with the storage service, advertising the endpoint execution
+    /// managers should reach it on.
+    ///
+    /// # Parameters
+    ///
+    /// * `ip_address` - The IP address this scheduler is reachable on.
+    /// * `port` - The port this scheduler is reachable on.
+    ///
+    /// # Returns
+    ///
+    /// The scheduler identifier assigned by the storage service on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * [`StorageClientError::Server`] if the storage service returns an error.
+    /// * [`StorageClientError::Transport`] if the storage transport fails or returns malformed
+    ///   data.
+    async fn register(
+        &self,
+        ip_address: std::net::IpAddr,
+        port: u16,
+    ) -> Result<SchedulerId, StorageClientError>;
+
     /// Polls the regular-task lane of the storage-owned inbound queue for ready tasks.
     ///
     /// # Parameters


### PR DESCRIPTION
# Description

This PR adds the `spider-scheduler` runtime: the assembly layer that constructs and supervises the scheduler's moving parts behind a single factory, mirroring the existing `spider-storage` runtime.

`create_runtime` is generic over the storage client (`SchedulerStorageClient`) so it accepts a real gRPC client in production and a mock in tests. Given a `RuntimeConfig` and a storage client, it:

* Creates a cancellation token, passes it to the scheduler core and the execution manager registry, and returns it to the caller so an external failure can cancel every background task.
* Registers the scheduler with storage via the new `SchedulerStorageClient::register` call, advertising the host/port execution managers should reach it on, and adopts the `SchedulerId` storage assigns.
* Builds the real channel-based dispatch queue with `create_dispatch_queue`, hands the sink to the core, and surfaces the reader through the returned service.
* Spawns the scheduler core coroutine and retains its `JoinHandle`.
* Returns the `Runtime`, the `SchedulerServiceState` built from the scheduler ID, the registry, and the dispatch queue reader, and the cancellation token.

`Runtime::stop` cancels the token, joins the core within a configurable timeout, logs the core's exit result, and drains any task assignments still buffered on the reschedule queue.

A serde-deserializable `SchedulerConfig` enum selects and configures the scheduling algorithm (currently only round-robin). Its `make_core` method dispatches to the selected variant to produce a `dyn SchedulerCore`, so the runtime stays agnostic to the concrete algorithm.

## Supporting changes

* Added `SchedulerStorageClient::register` to the trait and its gRPC implementation, routed through the scheduler-registration connection pool.
* Changed `SchedulerCore::run`'s receiver from `self` to `self: Box<Self>` so the core is object-safe and can be held as a `Box<dyn SchedulerCore>`.
* Added the `SchedulerRuntimeError` error type covering storage-client registration failures and stop-timeout failures.
* Exported the new `config`, `runtime` modules and their public types from the crate root.


## Summary by CodeRabbit

* **New Features**
  * Added scheduler runtime support, including startup, background execution, and graceful shutdown handling.
  * Added scheduler service operations for assigning work, sending heartbeats, and shutting down execution managers.
  * Expanded scheduler configuration support with selectable scheduling setup and queue sizing.

* **Bug Fixes**
  * Improved shutdown behaviour so pending work is tracked, drained, and rescheduled more reliably.
  * Updated scheduler processing to work correctly with background task execution and cancellation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable scheduler runtime that starts the scheduler in the background and supports graceful shutdown with a timeout.
  * Added scheduler registration so the service can announce its address and receive an assigned scheduler ID.

* **Bug Fixes**
  * Improved shutdown behaviour to stop cleanly when possible and report a timeout if the scheduler does not exit in time.
  * Expanded scheduling support to better handle the current round-robin configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->