### PR TITLE
build(huntsman): Add Dockerfile and GitHub CI for Spider Huntsman images.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git/
+build/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,0 @@
-.git/
-build/
-target/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 .git/
 build/
+target/

--- a/.github/workflows/spider-image-build.yaml
+++ b/.github/workflows/spider-image-build.yaml
@@ -20,7 +20,7 @@ jobs:
       packages: "write"
     strategy:
       matrix:
-        service: ["storage", "scheduler", "execution-manager-and-task-executor"]
+        service: ["storage", "scheduler", "worker"]
     steps:
       - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
         with:

--- a/.github/workflows/spider-image-build.yaml
+++ b/.github/workflows/spider-image-build.yaml
@@ -1,0 +1,56 @@
+name: "spider-image-build"
+
+on:
+  push:
+    branches: ["main"]
+    tags: ["v*"]
+  workflow_dispatch:
+
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  build-and-push:
+    runs-on: "ubuntu-latest"
+    permissions:
+      contents: "read"
+      packages: "write"
+    strategy:
+      matrix:
+        service: ["storage", "scheduler", "execution-manager-and-task-executor"]
+    steps:
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
+
+      - name: "Lowercase the image repository"
+        id: "repo"
+        run: >-
+          echo "name=${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+
+      - uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"  # v3.10.0
+
+      - uses: "docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121"  # v4.1.0
+        with:
+          registry: "ghcr.io"
+          username: "${{github.actor}}"
+          password: "${{secrets.GITHUB_TOKEN}}"
+
+      - uses: "docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804"  # v5.7.0
+        id: "meta"
+        with:
+          images: "ghcr.io/${{steps.repo.outputs.name}}/${{matrix.service}}"
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha
+
+      - uses: "docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4"  # v6.15.0
+        with:
+          context: "."
+          file: "tools/docker/Dockerfile"
+          target: "${{matrix.service}}"
+          push: true
+          tags: "${{steps.meta.outputs.tags}}"
+          labels: "${{steps.meta.outputs.labels}}"

--- a/.github/workflows/spider-image-build.yaml
+++ b/.github/workflows/spider-image-build.yaml
@@ -1,16 +1,33 @@
 name: "spider-image-build"
 
 on:
+  pull_request:
+    paths: &monitored_paths
+      - ".cargo/**"
+      - ".dockerignore"
+      - ".github/workflows/spider-image-build.yaml"
+      - ".gitmodules"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "components/**"
+      - "taskfile.yaml"
+      - "taskfiles/**"
+      - "tools/docker/**"
+      - "tools/scripts/**"
+      - "tools/yscope-dev-utils"
   push:
     branches: ["main"]
+    paths: *monitored_paths
     tags: ["spider-huntsman-v*"]
   workflow_dispatch:
 
+permissions: {}
+
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"
-  cancel-in-progress: true
-
-permissions: {}
+  # Cancel in-progress jobs for efficiency. Exclude the `main` branch to allow uninterrupted
+  # publishing of container images.
+  cancel-in-progress: "${{github.ref != 'refs/heads/main'}}"
 
 jobs:
   build-and-push:
@@ -26,7 +43,7 @@ jobs:
         with:
           submodules: "recursive"
 
-      - name: "Lowercase the image repository"
+      - name: "Sanitize repository name"
         id: "repo"
         run: >-
           echo "name=${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
@@ -34,6 +51,7 @@ jobs:
       - uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"  # v3.10.0
 
       - uses: "docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121"  # v4.1.0
+        if: "github.event_name != 'pull_request'"
         with:
           registry: "ghcr.io"
           username: "${{github.actor}}"
@@ -53,6 +71,6 @@ jobs:
           context: "."
           file: "tools/docker/Dockerfile"
           target: "${{matrix.service}}"
-          push: true
+          push: "${{github.event_name != 'pull_request'}}"
           tags: "${{steps.meta.outputs.tags}}"
           labels: "${{steps.meta.outputs.labels}}"

--- a/.github/workflows/spider-image-build.yaml
+++ b/.github/workflows/spider-image-build.yaml
@@ -4,7 +4,6 @@ on:
   pull_request:
     paths: &monitored_paths
       - ".cargo/**"
-      - ".dockerignore"
       - ".github/workflows/spider-image-build.yaml"
       - ".gitmodules"
       - "Cargo.lock"

--- a/.github/workflows/spider-image-build.yaml
+++ b/.github/workflows/spider-image-build.yaml
@@ -3,7 +3,7 @@ name: "spider-image-build"
 on:
   push:
     branches: ["main"]
-    tags: ["v*"]
+    tags: ["spider-huntsman-v*"]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/spider-image-build.yaml
+++ b/.github/workflows/spider-image-build.yaml
@@ -23,6 +23,8 @@ jobs:
         service: ["storage", "scheduler", "execution-manager-and-task-executor"]
     steps:
       - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
+        with:
+          submodules: "recursive"
 
       - name: "Lowercase the image repository"
         id: "repo"

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1
+
+ARG RUST_VERSION=1.96
+ARG DEBIAN_VERSION_CODENAME=bookworm
+
+FROM rust:${RUST_VERSION}-${DEBIAN_VERSION_CODENAME} AS builder
+
+WORKDIR /spider
+COPY . .
+
+RUN cargo build --release \
+    --bin spider_storage_grpc_server \
+    --bin spider_scheduler_grpc_server \
+    --bin spider_execution_manager \
+    --bin spider-task-executor
+
+FROM debian:${DEBIAN_VERSION_CODENAME}-slim AS storage
+COPY --from=builder /spider/target/release/spider_storage_grpc_server /usr/local/bin/
+
+FROM debian:${DEBIAN_VERSION_CODENAME}-slim AS scheduler
+COPY --from=builder /spider/target/release/spider_scheduler_grpc_server /usr/local/bin/
+
+FROM debian:${DEBIAN_VERSION_CODENAME}-slim AS execution-manager-and-task-executor
+COPY --from=builder /spider/target/release/spider_execution_manager /usr/local/bin/
+COPY --from=builder /spider/target/release/spider-task-executor /usr/local/bin/

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -5,7 +5,17 @@ ARG UBUNTU_VERSION_CODENAME=jammy
 FROM ubuntu:${UBUNTU_VERSION_CODENAME} AS builder
 
 WORKDIR /spider
-COPY --link . .
+
+# Whitelist only the sources required to build the Rust ("Huntsman") binaries; the C++ and spider-py
+# components are deliberately excluded.
+COPY --link Cargo.toml Cargo.lock taskfile.yaml ./
+COPY --link .cargo ./.cargo
+COPY --link components ./components
+COPY --link examples/huntsman ./examples/huntsman
+COPY --link taskfiles ./taskfiles
+COPY --link tests/huntsman ./tests/huntsman
+COPY --link tools/scripts ./tools/scripts
+COPY --link tools/yscope-dev-utils ./tools/yscope-dev-utils
 
 RUN tools/scripts/lib_install/ubuntu/install-dev-huntsman.sh
 RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -5,7 +5,7 @@ ARG UBUNTU_VERSION_CODENAME=jammy
 FROM ubuntu:${UBUNTU_VERSION_CODENAME} AS builder
 
 WORKDIR /spider
-COPY . .
+COPY --link . .
 
 RUN tools/scripts/lib_install/ubuntu/install-dev-huntsman.sh
 RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
@@ -16,11 +16,11 @@ RUN useradd --create-home spider-user
 USER spider-user
 
 FROM runtime-base AS storage
-COPY --from=builder /spider/build/rust-targets/release/spider_storage_grpc_server /usr/local/bin/
+COPY --from=builder --link /spider/build/rust-targets/release/spider_storage_grpc_server /usr/local/bin/
 
 FROM runtime-base AS scheduler
-COPY --from=builder /spider/build/rust-targets/release/spider_scheduler_grpc_server /usr/local/bin/
+COPY --from=builder --link /spider/build/rust-targets/release/spider_scheduler_grpc_server /usr/local/bin/
 
 FROM runtime-base AS worker
-COPY --from=builder /spider/build/rust-targets/release/spider_execution_manager /usr/local/bin/
-COPY --from=builder /spider/build/rust-targets/release/spider-task-executor /usr/local/bin/
+COPY --from=builder --link /spider/build/rust-targets/release/spider_execution_manager /usr/local/bin/
+COPY --from=builder --link /spider/build/rust-targets/release/spider-task-executor /usr/local/bin/

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN useradd --create-home spider-user
 USER spider-user
 
 FROM runtime-base AS storage
-COPY --from=builder --link /spider/build/rust-targets/release/spdier-storage /usr/local/bin/
+COPY --from=builder --link /spider/build/rust-targets/release/spider-storage /usr/local/bin/
 
 FROM runtime-base AS scheduler
 COPY --from=builder --link /spider/build/rust-targets/release/spider-scheduler /usr/local/bin/

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -4,6 +4,8 @@ ARG UBUNTU_VERSION_CODENAME=jammy
 
 FROM ubuntu:${UBUNTU_VERSION_CODENAME} AS builder
 
+ARG GO_TASK_VERSION=3.49.1
+
 WORKDIR /spider
 
 COPY --link Cargo.toml Cargo.lock taskfile.yaml ./
@@ -16,7 +18,8 @@ COPY --link tools/scripts ./tools/scripts
 COPY --link tools/yscope-dev-utils ./tools/yscope-dev-utils
 
 RUN tools/scripts/lib_install/ubuntu/install-dev-huntsman.sh
-RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
+RUN sh -c "$(curl --fail --location --silent --show-error https://taskfile.dev/install.sh)" -- \
+    -d -b /usr/local/bin "v${GO_TASK_VERSION}"
 RUN task build:rust
 
 FROM ubuntu:${UBUNTU_VERSION_CODENAME} AS runtime-base

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -21,6 +21,6 @@ COPY --from=builder /spider/build/rust-targets/release/spider_storage_grpc_serve
 FROM runtime-base AS scheduler
 COPY --from=builder /spider/build/rust-targets/release/spider_scheduler_grpc_server /usr/local/bin/
 
-FROM runtime-base AS execution-manager-and-task-executor
+FROM runtime-base AS worker
 COPY --from=builder /spider/build/rust-targets/release/spider_execution_manager /usr/local/bin/
 COPY --from=builder /spider/build/rust-targets/release/spider-task-executor /usr/local/bin/

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,25 +1,22 @@
 # syntax=docker/dockerfile:1
 
-ARG RUST_VERSION=1.96
-ARG DEBIAN_VERSION_CODENAME=bookworm
+ARG UBUNTU_VERSION_CODENAME=jammy
 
-FROM rust:${RUST_VERSION}-${DEBIAN_VERSION_CODENAME} AS builder
+FROM ubuntu:${UBUNTU_VERSION_CODENAME} AS builder
 
 WORKDIR /spider
 COPY . .
 
-RUN cargo build --release \
-    --bin spider_storage_grpc_server \
-    --bin spider_scheduler_grpc_server \
-    --bin spider_execution_manager \
-    --bin spider-task-executor
+RUN tools/scripts/lib_install/ubuntu/install-dev-huntsman.sh
+RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
+RUN task build:rust
 
-FROM debian:${DEBIAN_VERSION_CODENAME}-slim AS storage
-COPY --from=builder /spider/target/release/spider_storage_grpc_server /usr/local/bin/
+FROM ubuntu:${UBUNTU_VERSION_CODENAME} AS storage
+COPY --from=builder /spider/build/rust-targets/release/spider_storage_grpc_server /usr/local/bin/
 
-FROM debian:${DEBIAN_VERSION_CODENAME}-slim AS scheduler
-COPY --from=builder /spider/target/release/spider_scheduler_grpc_server /usr/local/bin/
+FROM ubuntu:${UBUNTU_VERSION_CODENAME} AS scheduler
+COPY --from=builder /spider/build/rust-targets/release/spider_scheduler_grpc_server /usr/local/bin/
 
-FROM debian:${DEBIAN_VERSION_CODENAME}-slim AS execution-manager-and-task-executor
-COPY --from=builder /spider/target/release/spider_execution_manager /usr/local/bin/
-COPY --from=builder /spider/target/release/spider-task-executor /usr/local/bin/
+FROM ubuntu:${UBUNTU_VERSION_CODENAME} AS execution-manager-and-task-executor
+COPY --from=builder /spider/build/rust-targets/release/spider_execution_manager /usr/local/bin/
+COPY --from=builder /spider/build/rust-targets/release/spider-task-executor /usr/local/bin/

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -6,8 +6,6 @@ FROM ubuntu:${UBUNTU_VERSION_CODENAME} AS builder
 
 WORKDIR /spider
 
-# Whitelist only the sources required to build the Rust ("Huntsman") binaries; the C++ and spider-py
-# components are deliberately excluded.
 COPY --link Cargo.toml Cargo.lock taskfile.yaml ./
 COPY --link .cargo ./.cargo
 COPY --link components ./components

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -11,12 +11,16 @@ RUN tools/scripts/lib_install/ubuntu/install-dev-huntsman.sh
 RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
 RUN task build:rust
 
-FROM ubuntu:${UBUNTU_VERSION_CODENAME} AS storage
+FROM ubuntu:${UBUNTU_VERSION_CODENAME} AS runtime-base
+RUN useradd --create-home spider-user
+USER spider-user
+
+FROM runtime-base AS storage
 COPY --from=builder /spider/build/rust-targets/release/spider_storage_grpc_server /usr/local/bin/
 
-FROM ubuntu:${UBUNTU_VERSION_CODENAME} AS scheduler
+FROM runtime-base AS scheduler
 COPY --from=builder /spider/build/rust-targets/release/spider_scheduler_grpc_server /usr/local/bin/
 
-FROM ubuntu:${UBUNTU_VERSION_CODENAME} AS execution-manager-and-task-executor
+FROM runtime-base AS execution-manager-and-task-executor
 COPY --from=builder /spider/build/rust-targets/release/spider_execution_manager /usr/local/bin/
 COPY --from=builder /spider/build/rust-targets/release/spider-task-executor /usr/local/bin/

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -24,11 +24,11 @@ RUN useradd --create-home spider-user
 USER spider-user
 
 FROM runtime-base AS storage
-COPY --from=builder --link /spider/build/rust-targets/release/spider_storage_grpc_server /usr/local/bin/
+COPY --from=builder --link /spider/build/rust-targets/release/spdier-storage /usr/local/bin/
 
 FROM runtime-base AS scheduler
-COPY --from=builder --link /spider/build/rust-targets/release/spider_scheduler_grpc_server /usr/local/bin/
+COPY --from=builder --link /spider/build/rust-targets/release/spider-scheduler /usr/local/bin/
 
 FROM runtime-base AS worker
-COPY --from=builder --link /spider/build/rust-targets/release/spider_execution_manager /usr/local/bin/
+COPY --from=builder --link /spider/build/rust-targets/release/spider-execution-manager /usr/local/bin/
 COPY --from=builder --link /spider/build/rust-targets/release/spider-task-executor /usr/local/bin/


### PR DESCRIPTION


<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR adds a multi-stage Dockerfile that builds container images for the Spider Huntsman services, plus a CI workflow to publish them to GHCR. It produces three per-service images:
  - storage → spider_storage_grpc_server
  - scheduler → spider_scheduler_grpc_server
  - worker → spider_execution_manager + spider-task-execution
 
The worker image ships without any TDL .so package. So we expect user-defined TDL package is layered on top of this published worker image during the docker compose or k8s integration.

Configuration for all three images is supplied at the docker compose or k8s integration rather than baked into the images.


## Notes for reviewers
 - The image-build workflow will publish images on push/tags, pull request only builds images for validation. The image publication process will run after merge this PR to main. You can preview the final artifacts on my [fork](https://github.com/20001020ycx/spider).
  - Here I would also like to discuss on the tagging conventions assumed in this PR:
    - Every commit pushed to main publishes an image tagged with its commit SHA (:sha-<commit>), and updates the rolling :main tag to point at that latest build.
    - Each release tag on spider-huntsman also publishes an image (e.g. :spider-huntsman-v0.1.0).

> [!Note]
> This PR does not add new tests.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

All CIs pass, including the new CI that builds the image using the Dockerfile added in this PR.

**Published images (pulled from the fork's GHCR):**
```shell
docker login ghcr.io -u <user>
base=ghcr.io/20001020ycx/spider; tag=sha-c4dd00f
docker pull $base/storage:$tag
docker pull $base/scheduler:$tag
docker pull $base/worker:$tag

docker run --rm $base/storage:$tag                             spider_storage_grpc_server   --help
docker run --rm $base/scheduler:$tag                           spider_scheduler_grpc_server --help
docker run --rm $base/worker:$tag spider_execution_manager     --help
```



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated Docker image builds and publishing for the storage, scheduler, and worker services.
  * Added container support for multiple release images, including tag-based builds and manual runs.
* **Chores**
  * Improved build automation to run only when relevant files change and to manage concurrent runs more safely.
  * Standardized image naming and access rules for container publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
