### PR TITLE
refactor(huntsman): Rename exectuable Rust targets:

### DIFF
--- a/components/spider-execution-manager/Cargo.toml
+++ b/components/spider-execution-manager/Cargo.toml
@@ -8,7 +8,7 @@ name = "spider_execution_manager"
 path = "src/lib.rs"
 
 [[bin]]
-name = "spider_execution_manager"
+name = "spider-execution-manager"
 path = "src/bin/execution_manager.rs"
 
 [dependencies]

--- a/components/spider-scheduler/Cargo.toml
+++ b/components/spider-scheduler/Cargo.toml
@@ -8,7 +8,7 @@ name = "spider_scheduler"
 path = "src/lib.rs"
 
 [[bin]]
-name = "spider_scheduler_grpc_server"
+name = "spider-scheduler"
 path = "src/bin/grpc_server.rs"
 
 [dependencies]

--- a/components/spider-storage/Cargo.toml
+++ b/components/spider-storage/Cargo.toml
@@ -9,7 +9,7 @@ name = "spider_storage"
 path = "src/lib.rs"
 
 [[bin]]
-name = "spider_storage_grpc_server"
+name = "spdier-storage"
 path = "src/bin/grpc_server.rs"
 
 [[test]]


### PR DESCRIPTION
* `spider_execution_manager` -> `spider-execution-manager`
* `spider_scheduler_grpc_server` -> `spider-scheduler`
* `spider_storage_grpc_server` -> `spdier-storage`

<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR renames the exectuable targest for Huntsman:

- Repace `_` with `-` to be consistent with our binary naming convention.
- Drop `grpc` for the storage and the scheduler: there's no need to mention the protocol. Even if we want to support RESTful in the future, it's more likely that we will make a single binary and switch the protocol based on the given config at runtime.
- Drop `server` from the name for simplicity.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Ensure all workflows pass.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
