### PR TITLE
feat(helm): Add storage and bundled-MariaDB templates.

### DIFF
--- a/tools/deployment/spider-helm/Chart.yaml
+++ b/tools/deployment/spider-helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: "v2"
 name: "spider"
 description: "A Helm chart for the Spider Huntsman deployment"
 type: "application"
-version: "0.1.0"
+version: "0.1.1"
 appVersion: "0.1.0"
 home: "https://github.com/y-scope/spider"
 sources: ["https://github.com/y-scope/spider"]

--- a/tools/deployment/spider-helm/templates/_helpers.tpl
+++ b/tools/deployment/spider-helm/templates/_helpers.tpl
@@ -1,0 +1,129 @@
+{{/*
+Expands the name of the chart.
+
+@return {string} The chart name (truncated to 63 characters)
+*/}}
+{{- define "spider.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Creates a default fully qualified app name (truncated to 63 chars for the DNS naming spec). If the
+release name already contains the chart name it is used as-is.
+
+@return {string} The fully qualified app name (truncated to 63 characters)
+*/}}
+{{- define "spider.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Creates chart name and version as used by the chart label.
+
+@return {string} Chart name and version (truncated to 63 characters)
+*/}}
+{{- define "spider.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Creates common labels for all resources.
+
+@return {string} YAML-formatted common labels
+*/}}
+{{- define "spider.labels" -}}
+helm.sh/chart: {{ include "spider.chart" . }}
+{{ include "spider.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Creates selector labels for matching resources.
+
+@return {string} YAML-formatted selector labels
+*/}}
+{{- define "spider.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "spider.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Creates a container image reference from `.Values.image.<component>`.
+
+The tag defaults to the chart's appVersion when the component omits it.
+
+@param {object} root Root template context (required)
+@param {string} component Key under `.Values.image` (e.g. "storage", "mariadb")
+@return {string} Full image reference (repository:tag)
+*/}}
+{{- define "spider.imageRef" -}}
+{{- $img := index .root.Values.image .component -}}
+{{- $tag := $img.tag | default .root.Chart.AppVersion -}}
+{{- printf "%s:%s" $img.repository $tag -}}
+{{- end }}
+
+{{/*
+Creates timings for readiness probes (faster checks for quicker startup).
+
+@return {string} YAML-formatted readiness probe timing configuration
+*/}}
+{{- define "spider.readinessProbeTimings" -}}
+initialDelaySeconds: 6
+periodSeconds: 2
+timeoutSeconds: 2
+failureThreshold: 10
+{{- end }}
+
+{{/*
+Creates timings for liveness probes.
+
+@return {string} YAML-formatted liveness probe timing configuration
+*/}}
+{{- define "spider.livenessProbeTimings" -}}
+initialDelaySeconds: 180
+periodSeconds: 30
+timeoutSeconds: 4
+failureThreshold: 3
+{{- end }}
+
+{{/*
+Gets the database host. When "database" is bundled, this is the in-cluster MariaDB Service; when not
+bundled, it is the external `spiderConfig.database.host`.
+
+@param {object} . Root template context
+@return {string} The database host
+*/}}
+{{- define "spider.databaseHost" -}}
+{{- if has "database" .Values.spiderConfig.bundled -}}
+{{- printf "%s-database" (include "spider.fullname" .) -}}
+{{- else -}}
+{{- .Values.spiderConfig.database.host -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Gets the database port. When "database" is bundled, this is 3306 (the bundled MariaDB's port);
+otherwise it is the external `spiderConfig.database.port`.
+
+@param {object} . Root template context
+@return {string} The database port
+*/}}
+{{- define "spider.databasePort" -}}
+{{- if has "database" .Values.spiderConfig.bundled -}}
+3306
+{{- else -}}
+{{- .Values.spiderConfig.database.port -}}
+{{- end -}}
+{{- end }}

--- a/tools/deployment/spider-helm/templates/_helpers.tpl
+++ b/tools/deployment/spider-helm/templates/_helpers.tpl
@@ -22,9 +22,9 @@ release name already contains the chart name it is used as-is.
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- else }}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
-{{- end }}
+{{- end }}{{/* if contains $name .Release.Name */}}
+{{- end }}{{/* if .Values.fullnameOverride */}}
+{{- end }}{{/* define "spider.fullname" */}}
 
 {{/*
 Creates chart name and version as used by the chart label.
@@ -99,8 +99,7 @@ failureThreshold: 3
 {{- end }}
 
 {{/*
-Gets the database host. When "database" is bundled, this is the in-cluster MariaDB Service; when not
-bundled, it is the external `spiderConfig.database.host`.
+Gets the bundled MariaDB Service host or external `spiderConfig.database.host`.
 
 @param {object} . Root template context
 @return {string} The database host
@@ -114,8 +113,7 @@ bundled, it is the external `spiderConfig.database.host`.
 {{- end }}
 
 {{/*
-Gets the database port. When "database" is bundled, this is 3306 (the bundled MariaDB's port);
-otherwise it is the external `spiderConfig.database.port`.
+Gets the bundled MariaDB port or external `spiderConfig.database.port`.
 
 @param {object} . Root template context
 @return {string} The database port

--- a/tools/deployment/spider-helm/templates/_helpers.tpl
+++ b/tools/deployment/spider-helm/templates/_helpers.tpl
@@ -27,6 +27,20 @@ release name already contains the chart name it is used as-is.
 {{- end }}{{/* define "spider.fullname" */}}
 
 {{/*
+Creates a fully qualified component name while preserving its suffix within the 63-character limit.
+
+@param {object} root Root template context (required)
+@param {string} component Component name suffix (required)
+@return {string} The fully qualified component name
+*/}}
+{{- define "spider.componentFullname" -}}
+{{- $suffix := printf "-%s" .component -}}
+{{- $maxBaseLength := sub 63 (len $suffix) | int -}}
+{{- $base := include "spider.fullname" .root | trunc $maxBaseLength | trimSuffix "-" -}}
+{{- printf "%s%s" $base $suffix -}}
+{{- end }}
+
+{{/*
 Creates chart name and version as used by the chart label.
 
 @return {string} Chart name and version (truncated to 63 characters)
@@ -106,7 +120,7 @@ Gets the bundled MariaDB Service host or external `spiderConfig.database.host`.
 */}}
 {{- define "spider.databaseHost" -}}
 {{- if has "database" .Values.spiderConfig.bundled -}}
-{{- printf "%s-database" (include "spider.fullname" .) -}}
+{{- include "spider.componentFullname" (dict "root" . "component" "database") -}}
 {{- else -}}
 {{- .Values.spiderConfig.database.host -}}
 {{- end -}}

--- a/tools/deployment/spider-helm/templates/_helpers.tpl
+++ b/tools/deployment/spider-helm/templates/_helpers.tpl
@@ -74,18 +74,22 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Creates a container image reference from `.Values.image.<component>`.
+Creates a container image reference from .Values.image.
 
-The tag defaults to the chart's appVersion when the component omits it.
+Renders repository@digest when "digest" is set; otherwise, requires "tag" and renders repository:tag.
 
 @param {object} root Root template context (required)
-@param {string} component Key under `.Values.image` (e.g. "storage", "database")
-@return {string} Full image reference (repository:tag)
+@param {string} component Key under .Values.image (e.g., "storage", "database")
+@return {string} Full image reference (repository@digest or repository:tag)
 */}}
 {{- define "spider.imageRef" -}}
 {{- $img := index .root.Values.image .component -}}
-{{- $tag := $img.tag | default .root.Chart.AppVersion -}}
+{{- if $img.digest -}}
+{{- printf "%s@%s" $img.repository $img.digest -}}
+{{- else -}}
+{{- $tag := required (printf "image.%s.tag is required" .component) $img.tag -}}
 {{- printf "%s:%s" $img.repository $tag -}}
+{{- end -}}
 {{- end }}
 
 {{/*

--- a/tools/deployment/spider-helm/templates/_helpers.tpl
+++ b/tools/deployment/spider-helm/templates/_helpers.tpl
@@ -79,7 +79,7 @@ Creates a container image reference from `.Values.image.<component>`.
 The tag defaults to the chart's appVersion when the component omits it.
 
 @param {object} root Root template context (required)
-@param {string} component Key under `.Values.image` (e.g. "storage", "mariadb")
+@param {string} component Key under `.Values.image` (e.g. "storage", "database")
 @return {string} Full image reference (repository:tag)
 */}}
 {{- define "spider.imageRef" -}}
@@ -113,7 +113,7 @@ failureThreshold: 3
 {{- end }}
 
 {{/*
-Gets the bundled MariaDB Service host or external `spiderConfig.database.host`.
+Gets the bundled database Service host or external `spiderConfig.database.host`.
 
 @param {object} . Root template context
 @return {string} The database host
@@ -127,7 +127,7 @@ Gets the bundled MariaDB Service host or external `spiderConfig.database.host`.
 {{- end }}
 
 {{/*
-Gets the bundled MariaDB port or external `spiderConfig.database.port`.
+Gets the bundled database port or external `spiderConfig.database.port`.
 
 @param {object} . Root template context
 @return {string} The database port

--- a/tools/deployment/spider-helm/templates/configmap.yaml
+++ b/tools/deployment/spider-helm/templates/configmap.yaml
@@ -1,0 +1,21 @@
+apiVersion: "v1"
+kind: "ConfigMap"
+metadata:
+  name: {{ include "spider.fullname" . }}-config
+  labels:
+    {{- include "spider.labels" . | nindent 4 }}
+data:
+  storage.yaml: |
+    host: "0.0.0.0"
+    port: {{ .Values.spiderConfig.storage_endpoint.port }}
+    runtime:
+      db_config:
+        host: {{ include "spider.databaseHost" . | quote }}
+        port: {{ include "spider.databasePort" . }}
+        name: {{ .Values.spiderConfig.database.name | quote }}
+        username: {{ .Values.spiderConfig.database.username | quote }}
+        password: {{ .Values.spiderConfig.database.password | quote }}
+        max_connections: {{ .Values.spiderConfig.storage.max_connections }}
+      {{- with omit .Values.spiderConfig.storage "max_connections" }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}

--- a/tools/deployment/spider-helm/templates/configmap.yaml
+++ b/tools/deployment/spider-helm/templates/configmap.yaml
@@ -13,7 +13,7 @@ data:
         host: {{ include "spider.databaseHost" . | quote }}
         port: {{ include "spider.databasePort" . }}
         name: {{ .Values.spiderConfig.database.name | quote }}
-        max_connections: {{ .Values.spiderConfig.storage.max_connections }}
-      {{- with omit .Values.spiderConfig.storage "max_connections" }}
+        max_connections: {{ .Values.spiderConfig.database.max_connections }}
+      {{- with .Values.spiderConfig.storage }}
       {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/tools/deployment/spider-helm/templates/configmap.yaml
+++ b/tools/deployment/spider-helm/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
-  name: {{ include "spider.fullname" . }}-config
+  name: {{ include "spider.componentFullname" (dict "root" . "component" "config") }}
   labels:
     {{- include "spider.labels" . | nindent 4 }}
 data:

--- a/tools/deployment/spider-helm/templates/configmap.yaml
+++ b/tools/deployment/spider-helm/templates/configmap.yaml
@@ -13,8 +13,6 @@ data:
         host: {{ include "spider.databaseHost" . | quote }}
         port: {{ include "spider.databasePort" . }}
         name: {{ .Values.spiderConfig.database.name | quote }}
-        username: {{ .Values.spiderConfig.database.username | quote }}
-        password: {{ .Values.spiderConfig.database.password | quote }}
         max_connections: {{ .Values.spiderConfig.storage.max_connections }}
       {{- with omit .Values.spiderConfig.storage "max_connections" }}
       {{- toYaml . | nindent 6 }}

--- a/tools/deployment/spider-helm/templates/configmap.yaml
+++ b/tools/deployment/spider-helm/templates/configmap.yaml
@@ -7,13 +7,13 @@ metadata:
 data:
   storage.yaml: |
     host: "0.0.0.0"
-    port: {{ .Values.spiderConfig.storage_endpoint.port }}
+    port: {{ .Values.spiderConfig.storage.port }}
     runtime:
       db_config:
         host: {{ include "spider.databaseHost" . | quote }}
-        port: {{ include "spider.databasePort" . }}
-        name: {{ .Values.spiderConfig.database.name | quote }}
         max_connections: {{ .Values.spiderConfig.database.max_connections }}
-      {{- with .Values.spiderConfig.storage }}
+        name: {{ .Values.spiderConfig.database.name | quote }}
+        port: {{ include "spider.databasePort" . }}
+      {{- with .Values.spiderConfig.storage.runtime }}
       {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/tools/deployment/spider-helm/templates/database-secret.yaml
+++ b/tools/deployment/spider-helm/templates/database-secret.yaml
@@ -1,0 +1,14 @@
+{{- if has "database" .Values.spiderConfig.bundled }}
+apiVersion: "v1"
+kind: "Secret"
+metadata:
+  name: {{ include "spider.fullname" . }}-database
+  labels:
+    {{- include "spider.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "database"
+type: "Opaque"
+stringData:
+  username: {{ .Values.spiderConfig.database.username | quote }}
+  password: {{ .Values.spiderConfig.database.password | quote }}
+  root_password: {{ .Values.spiderConfig.database.root_password | quote }}
+{{- end }}

--- a/tools/deployment/spider-helm/templates/database-secret.yaml
+++ b/tools/deployment/spider-helm/templates/database-secret.yaml
@@ -1,4 +1,3 @@
-{{- if has "database" .Values.spiderConfig.bundled }}
 apiVersion: "v1"
 kind: "Secret"
 metadata:
@@ -10,5 +9,6 @@ type: "Opaque"
 stringData:
   username: {{ .Values.spiderConfig.database.username | quote }}
   password: {{ .Values.spiderConfig.database.password | quote }}
+  {{- if has "database" .Values.spiderConfig.bundled }}
   root_password: {{ .Values.spiderConfig.database.root_password | quote }}
-{{- end }}
+  {{- end }}

--- a/tools/deployment/spider-helm/templates/database-secret.yaml
+++ b/tools/deployment/spider-helm/templates/database-secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: "v1"
 kind: "Secret"
 metadata:
-  name: {{ include "spider.fullname" . }}-database
+  name: {{ include "spider.componentFullname" (dict "root" . "component" "database") }}
   labels:
     {{- include "spider.labels" . | nindent 4 }}
     app.kubernetes.io/component: "database"

--- a/tools/deployment/spider-helm/templates/database-service.yaml
+++ b/tools/deployment/spider-helm/templates/database-service.yaml
@@ -1,0 +1,17 @@
+{{- if has "database" .Values.spiderConfig.bundled }}
+apiVersion: "v1"
+kind: "Service"
+metadata:
+  name: {{ include "spider.fullname" . }}-database
+  labels:
+    {{- include "spider.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "database"
+spec:
+  clusterIP: "None"
+  selector:
+    {{- include "spider.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: "database"
+  ports:
+    - port: 3306
+      targetPort: "database"
+{{- end }}

--- a/tools/deployment/spider-helm/templates/database-service.yaml
+++ b/tools/deployment/spider-helm/templates/database-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: "v1"
 kind: "Service"
 metadata:
-  name: {{ include "spider.fullname" . }}-database
+  name: {{ include "spider.componentFullname" (dict "root" . "component" "database") }}
   labels:
     {{- include "spider.labels" . | nindent 4 }}
     app.kubernetes.io/component: "database"

--- a/tools/deployment/spider-helm/templates/database-statefulset.yaml
+++ b/tools/deployment/spider-helm/templates/database-statefulset.yaml
@@ -1,0 +1,71 @@
+{{- if has "database" .Values.spiderConfig.bundled }}
+apiVersion: "apps/v1"
+kind: "StatefulSet"
+metadata:
+  name: {{ include "spider.fullname" . }}-database
+  labels:
+    {{- include "spider.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "database"
+spec:
+  serviceName: {{ include "spider.fullname" . }}-database
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "spider.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "database"
+  template:
+    metadata:
+      labels:
+        {{- include "spider.labels" . | nindent 8 }}
+        app.kubernetes.io/component: "database"
+    spec:
+      containers:
+        - name: "database"
+          image: {{ include "spider.imageRef" (dict "root" . "component" "mariadb") | quote }}
+          imagePullPolicy: {{ .Values.image.mariadb.pullPolicy | quote }}
+          env:
+            - name: "MYSQL_DATABASE"
+              value: {{ .Values.spiderConfig.database.name | quote }}
+            - name: "MYSQL_USER"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spider.fullname" . }}-database
+                  key: "username"
+            - name: "MYSQL_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spider.fullname" . }}-database
+                  key: "password"
+            - name: "MYSQL_ROOT_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spider.fullname" . }}-database
+                  key: "root_password"
+          ports:
+            - name: "database"
+              containerPort: 3306
+          volumeMounts:
+            - name: "data"
+              mountPath: "/var/lib/mysql"
+          readinessProbe:
+            {{- include "spider.readinessProbeTimings" . | nindent 12 }}
+            exec: &health-check
+              command: [
+                "mysqladmin", "ping",
+                "--host=127.0.0.1",
+                "--port=3306",
+                "--user=$(MYSQL_USER)",
+                "--password=$(MYSQL_PASSWORD)"
+              ]
+          livenessProbe:
+            {{- include "spider.livenessProbeTimings" . | nindent 12 }}
+            exec: *health-check
+  volumeClaimTemplates:
+    - metadata:
+        name: "data"
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: "20Gi"
+{{- end }}

--- a/tools/deployment/spider-helm/templates/database-statefulset.yaml
+++ b/tools/deployment/spider-helm/templates/database-statefulset.yaml
@@ -2,12 +2,12 @@
 apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
-  name: {{ include "spider.fullname" . }}-database
+  name: {{ include "spider.componentFullname" (dict "root" . "component" "database") }}
   labels:
     {{- include "spider.labels" . | nindent 4 }}
     app.kubernetes.io/component: "database"
 spec:
-  serviceName: {{ include "spider.fullname" . }}-database
+  serviceName: {{ include "spider.componentFullname" (dict "root" . "component" "database") }}
   replicas: 1
   selector:
     matchLabels:
@@ -29,17 +29,17 @@ spec:
             - name: "MYSQL_USER"
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "spider.fullname" . }}-database
+                  name: {{ include "spider.componentFullname" (dict "root" . "component" "database") }}
                   key: "username"
             - name: "MYSQL_PASSWORD"
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "spider.fullname" . }}-database
+                  name: {{ include "spider.componentFullname" (dict "root" . "component" "database") }}
                   key: "password"
             - name: "MYSQL_ROOT_PASSWORD"
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "spider.fullname" . }}-database
+                  name: {{ include "spider.componentFullname" (dict "root" . "component" "database") }}
                   key: "root_password"
           ports:
             - name: "database"

--- a/tools/deployment/spider-helm/templates/database-statefulset.yaml
+++ b/tools/deployment/spider-helm/templates/database-statefulset.yaml
@@ -21,8 +21,8 @@ spec:
     spec:
       containers:
         - name: "database"
-          image: {{ include "spider.imageRef" (dict "root" . "component" "mariadb") | quote }}
-          imagePullPolicy: {{ .Values.image.mariadb.pullPolicy | quote }}
+          image: {{ include "spider.imageRef" (dict "root" . "component" "database") | quote }}
+          imagePullPolicy: {{ .Values.image.database.pullPolicy | quote }}
           env:
             - name: "MYSQL_DATABASE"
               value: {{ .Values.spiderConfig.database.name | quote }}

--- a/tools/deployment/spider-helm/templates/storage-deployment.yaml
+++ b/tools/deployment/spider-helm/templates/storage-deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: "apps/v1"
+kind: "Deployment"
+metadata:
+  name: {{ include "spider.fullname" . }}-storage
+  labels:
+    {{- include "spider.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "storage"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "spider.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "storage"
+  template:
+    metadata:
+      labels:
+        {{- include "spider.labels" . | nindent 8 }}
+        app.kubernetes.io/component: "storage"
+    spec:
+      containers:
+        - name: "storage"
+          image: {{ include "spider.imageRef" (dict "root" . "component" "storage") | quote }}
+          imagePullPolicy: {{ .Values.image.storage.pullPolicy | quote }}
+          command: ["spider-storage", "--config", "/etc/spider/storage.yaml"]
+          ports:
+            - name: "grpc"
+              containerPort: {{ .Values.spiderConfig.storage_endpoint.port }}
+          volumeMounts:
+            - name: "config"
+              mountPath: "/etc/spider"
+              readOnly: true
+          readinessProbe:
+            {{- include "spider.readinessProbeTimings" . | nindent 12 }}
+            tcpSocket:
+              port: "grpc"
+          livenessProbe:
+            {{- include "spider.livenessProbeTimings" . | nindent 12 }}
+            tcpSocket:
+              port: "grpc"
+      volumes:
+        - name: "config"
+          configMap:
+            name: {{ include "spider.fullname" . }}-config

--- a/tools/deployment/spider-helm/templates/storage-deployment.yaml
+++ b/tools/deployment/spider-helm/templates/storage-deployment.yaml
@@ -38,7 +38,8 @@ spec:
               containerPort: {{ .Values.spiderConfig.storage_endpoint.port }}
           volumeMounts:
             - name: "config"
-              mountPath: "/etc/spider"
+              mountPath: "/etc/spider/storage.yaml"
+              subPath: "storage.yaml"
               readOnly: true
           readinessProbe:
             {{- include "spider.readinessProbeTimings" . | nindent 12 }}

--- a/tools/deployment/spider-helm/templates/storage-deployment.yaml
+++ b/tools/deployment/spider-helm/templates/storage-deployment.yaml
@@ -22,6 +22,17 @@ spec:
           image: {{ include "spider.imageRef" (dict "root" . "component" "storage") | quote }}
           imagePullPolicy: {{ .Values.image.storage.pullPolicy | quote }}
           command: ["spider-storage", "--config", "/etc/spider/storage.yaml"]
+          env:
+            - name: "SPIDER_STORAGE_DB_USERNAME"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spider.componentFullname" (dict "root" . "component" "database") }}
+                  key: "username"
+            - name: "SPIDER_STORAGE_DB_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spider.componentFullname" (dict "root" . "component" "database") }}
+                  key: "password"
           ports:
             - name: "grpc"
               containerPort: {{ .Values.spiderConfig.storage_endpoint.port }}

--- a/tools/deployment/spider-helm/templates/storage-deployment.yaml
+++ b/tools/deployment/spider-helm/templates/storage-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
-  name: {{ include "spider.fullname" . }}-storage
+  name: {{ include "spider.componentFullname" (dict "root" . "component" "storage") }}
   labels:
     {{- include "spider.labels" . | nindent 4 }}
     app.kubernetes.io/component: "storage"
@@ -40,4 +40,4 @@ spec:
       volumes:
         - name: "config"
           configMap:
-            name: {{ include "spider.fullname" . }}-config
+            name: {{ include "spider.componentFullname" (dict "root" . "component" "config") }}

--- a/tools/deployment/spider-helm/templates/storage-deployment.yaml
+++ b/tools/deployment/spider-helm/templates/storage-deployment.yaml
@@ -35,7 +35,7 @@ spec:
                   key: "password"
           ports:
             - name: "grpc"
-              containerPort: {{ .Values.spiderConfig.storage_endpoint.port }}
+              containerPort: {{ .Values.spiderConfig.storage.port }}
           volumeMounts:
             - name: "config"
               mountPath: "/etc/spider/storage.yaml"

--- a/tools/deployment/spider-helm/templates/storage-service.yaml
+++ b/tools/deployment/spider-helm/templates/storage-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: "v1"
+kind: "Service"
+metadata:
+  name: {{ include "spider.fullname" . }}-storage
+  labels:
+    {{- include "spider.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "storage"
+spec:
+  selector:
+    {{- include "spider.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: "storage"
+  ports:
+    - name: "grpc"
+      port: {{ .Values.spiderConfig.storage_endpoint.port }}
+      targetPort: "grpc"

--- a/tools/deployment/spider-helm/templates/storage-service.yaml
+++ b/tools/deployment/spider-helm/templates/storage-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: "v1"
 kind: "Service"
 metadata:
-  name: {{ include "spider.fullname" . }}-storage
+  name: {{ include "spider.componentFullname" (dict "root" . "component" "storage") }}
   labels:
     {{- include "spider.labels" . | nindent 4 }}
     app.kubernetes.io/component: "storage"

--- a/tools/deployment/spider-helm/templates/storage-service.yaml
+++ b/tools/deployment/spider-helm/templates/storage-service.yaml
@@ -11,5 +11,5 @@ spec:
     app.kubernetes.io/component: "storage"
   ports:
     - name: "grpc"
-      port: {{ .Values.spiderConfig.storage_endpoint.port }}
+      port: {{ .Values.spiderConfig.storage.port }}
       targetPort: "grpc"

--- a/tools/deployment/spider-helm/values.yaml
+++ b/tools/deployment/spider-helm/values.yaml
@@ -28,12 +28,12 @@ spiderConfig:
     password: "spider-password"
     root_password: "spider-root-password"
     name: "spider-db"
+    max_connections: 64
 
   storage_endpoint:
     port: 50051
 
   storage:
-    max_connections: 64
     # task_instance_pool_config:
     #   execution_manager_stale_cutoff_sec: 30
     #   gc_interval_sec: 5

--- a/tools/deployment/spider-helm/values.yaml
+++ b/tools/deployment/spider-helm/values.yaml
@@ -1,1 +1,47 @@
+nameOverride: ""
+fullnameOverride: ""
 
+image:
+  storage:
+    repository: "ghcr.io/y-scope/spider/storage"
+    pullPolicy: "Always"
+    tag: "main"
+  mariadb:
+    repository: "mariadb"
+    pullPolicy: "Always"
+    tag: "10.11.16"
+
+spiderConfig:
+  # List of third-party services bundled (deployed) as part of the chart.
+  # Remove a service from this list to use an external instance instead, and configure its host/port
+  # accordingly in the service-specific sections below.
+  bundled:
+    - "database"
+
+  database:
+    # Host and port for the database service. When "database" is in `bundled`, the host is
+    # automatically set to the bundled service name (ignored). When external, set these to the
+    # external service's address.
+    host: "127.0.0.1"
+    port: 3306
+    username: "spider-user"
+    password: "spider-password"
+    root_password: "spider-root-password"
+    name: "spider-db"
+
+  storage_endpoint:
+    port: 50051
+
+  storage:
+    max_connections: 64
+    # task_instance_pool_config:
+    #   execution_manager_stale_cutoff_sec: 30
+    #   gc_interval_sec: 5
+    #   message_channel_capacity: 1024
+    # job_cache_gc_config:
+    #   terminated_job_retention_sec: 300
+    #   gc_interval_sec: 10
+    ready_queue_config:
+      task_capacity: 1048576
+      commit_capacity: 256
+      cleanup_capacity: 256

--- a/tools/deployment/spider-helm/values.yaml
+++ b/tools/deployment/spider-helm/values.yaml
@@ -33,14 +33,7 @@ spiderConfig:
   storage:
     port: 50051
     runtime:
-      # job_cache_gc_config:
-      #   gc_interval_sec: 10
-      #   terminated_job_retention_sec: 300
       ready_queue_config:
         cleanup_capacity: 256
         commit_capacity: 256
         task_capacity: 1048576
-      # task_instance_pool_config:
-      #   execution_manager_stale_cutoff_sec: 30
-      #   gc_interval_sec: 5
-      #   message_channel_capacity: 1024

--- a/tools/deployment/spider-helm/values.yaml
+++ b/tools/deployment/spider-helm/values.yaml
@@ -6,7 +6,7 @@ image:
     repository: "ghcr.io/y-scope/spider/storage"
     pullPolicy: "Always"
     tag: "main"
-  mariadb:
+  database:
     repository: "mariadb"
     pullPolicy: "Always"
     tag: "10.11.16"

--- a/tools/deployment/spider-helm/values.yaml
+++ b/tools/deployment/spider-helm/values.yaml
@@ -1,15 +1,15 @@
-nameOverride: ""
 fullnameOverride: ""
+nameOverride: ""
 
 image:
-  storage:
-    repository: "ghcr.io/y-scope/spider/storage"
-    pullPolicy: "Always"
-    tag: "main"
   database:
-    repository: "mariadb"
     pullPolicy: "Always"
+    repository: "mariadb"
     tag: "10.11.16"
+  storage:
+    pullPolicy: "Always"
+    repository: "ghcr.io/y-scope/spider/storage"
+    tag: "main"
 
 spiderConfig:
   # List of third-party services bundled (deployed) as part of the chart.
@@ -23,25 +23,24 @@ spiderConfig:
     # automatically set to the bundled service name (ignored). When external, set these to the
     # external service's address.
     host: "127.0.0.1"
-    port: 3306
-    username: "spider-user"
-    password: "spider-password"
-    root_password: "spider-root-password"
-    name: "spider-db"
     max_connections: 64
-
-  storage_endpoint:
-    port: 50051
+    name: "spider-db"
+    password: "spider-password"
+    port: 3306
+    root_password: "spider-root-password"
+    username: "spider-user"
 
   storage:
-    # task_instance_pool_config:
-    #   execution_manager_stale_cutoff_sec: 30
-    #   gc_interval_sec: 5
-    #   message_channel_capacity: 1024
-    # job_cache_gc_config:
-    #   terminated_job_retention_sec: 300
-    #   gc_interval_sec: 10
-    ready_queue_config:
-      task_capacity: 1048576
-      commit_capacity: 256
-      cleanup_capacity: 256
+    port: 50051
+    runtime:
+      # job_cache_gc_config:
+      #   gc_interval_sec: 10
+      #   terminated_job_retention_sec: 300
+      ready_queue_config:
+        cleanup_capacity: 256
+        commit_capacity: 256
+        task_capacity: 1048576
+      # task_instance_pool_config:
+      #   execution_manager_stale_cutoff_sec: 30
+      #   gc_interval_sec: 5
+      #   message_channel_capacity: 1024


### PR DESCRIPTION
# Description

This PR adds the chart's **templates** and **`values.yaml`**: the storage gRPC service (Deployment + Service + ConfigMap) and a bundled MariaDB (StatefulSet + Service + Secret). Remove `"database"` from `bundled` to connect to an external MariaDB instead.

> [!NOTE]  
Part of the ongoing Spider Huntsman Kubernetes integration. This PR adds only storage + database; the scheduler, execution manager, and task executor follow in later PRs.

> [!NOTE]
> This PR needs review from two teams:
>
> - Cloud Team: Please review the Helm chart itself — the templates, helpers, and packaging. Feel free to also skim through the configuration itself.
> - Spider Team: Please review the user-facing Spider configuration — the `spiderConfig` block in values.yaml and the storage.yaml it renders in configmap.yaml. You can leave the rest of the chart to the Cloud reviewer.

## A few notes for the reviewers:

For Cloud reviewer:
- ` _helpers.tpl` is mostly helm create boilerplate. We only added: componentFullname (63-char-safe names), imageRef, readiness/livenessProbeTimings, and databaseHost/databasePort.

For Spider reviwer:
- `spiderConfig` in values.yaml is the user-facing config in helm chart; the chart renders it into each component's config file. Naming loosely follows the sample [spider.yaml](https://github.com/sitaowang1998/spider/blob/huntsman-dev-e2e/tools/scripts/stack/spider.yaml). I would appreciate any suggestions to make it more aligning with the real Spider configuration workflow.


# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

We perform the steps below to verify the storage + database Helm chart in this PR works end-to-end in a `kind` cluster. The goal: submit a task through the `spider-client` Rust SDK and observe it persisted in the database.

1. Start a `kind` cluster:
```
kind create cluster --name spider-test
```

2. Install the chart:
```
helm install spider tools/deployment/spider-helm/
```

3. Wait for both components to become ready (storage restarts a few times while MariaDB boots):
```
kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=spider --timeout=180s
```

4. Confirm storage self-created its tables:
```
kubectl exec spider-database-0 -- mysql -uspider-user -pspider-password spider-db -e "SHOW TABLES;"
```
Expected: `execution_managers`, `jobs`, `resource_groups`, `schedulers`, `sessions`.

5. Port-forward storage and submit a task through the `spider-client` SDK, the below code are phsedu-code for illustration purpose:
```
kubectl port-forward svc/spider-storage 50051:50051
```
The client submits a one-task graph — `math::add(2, 3)`:
```rust
let client = SpiderClient::connect(endpoint, pool_size).await?;             // dial storage
let rg = client.add_resource_group("add-rg", b"secret".to_vec()).await?;    // register a resource group

let mut graph = TaskGraph::new(None, None)?;                                // one-task graph
graph.insert_task(TaskDescriptor {                                          // TDL func math::add(i32, i32) -> i32
    tdl_context: TdlContext { package: "math", task_func: "add" },
    inputs: vec![int32, int32], outputs: vec![int32], ..Default::default()
})?;
let inputs = vec![TaskInput::ValuePayload(rmp_serde::to_vec(&2)?),          // msgpack-encode the operands
                  TaskInput::ValuePayload(rmp_serde::to_vec(&3)?)];
let job_id = client.submit_job(rg, &graph, inputs).await?;                  // storage persists the job
```

6. Confirm the task is persisted in the database:
```
kubectl exec spider-database-0 -- mysql -uspider-user -pspider-password spider-db -e "SELECT COUNT(*) FROM jobs; SELECT COUNT(*) FROM resource_groups;"
```
Expected: `jobs=1`, `resource_groups=1`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Helm deployment support for Spider storage, including ConfigMap-backed configuration plus a dedicated storage Deployment and gRPC Service.
  * Added optional bundled MariaDB support, including automatic database credentials Secret creation, a headless database Service, and a database StatefulSet with persistent storage.
  * Introduced chart values for image sources/tags, storage endpoint settings, connection limits, and default queue capacity.
* **Chores**
  * Bumped the Helm chart version to **0.1.1**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->