### PR TITLE
fix(gh-workflow): Use install-dev-wolf.sh for the `lint-python` for `libmariadb-dev` installation.

### DIFF
--- a/.github/workflows/code-linting-checks.yaml
+++ b/.github/workflows/code-linting-checks.yaml
@@ -151,7 +151,7 @@ jobs:
       - uses: "./tools/yscope-dev-utils/exports/github/actions/install-uv"
 
       - name: "Install dev dependencies"
-        run: "./tools/scripts/lib_install/ubuntu/install-dev-common.sh"
+        run: "./tools/scripts/lib_install/ubuntu/install-dev-wolf.sh"
 
       - run: "task lint:py-check"
 


### PR DESCRIPTION
# Description

When running `task lint:py-check`, CI job fails with `OSError: mariadb_config not found.` if built without any cache. This is because `install-dev-common.sh` does **not** include `libmariadb-dev`.

**Why it passed before but breaks now:** This is a long-standing latent gap, not a recent upstream/runner change. We never hit it because the `setup-uv` cache served a pre-built `mariadb` wheel — until caught bt #383 which edited `requirements-dev.txt`, invalidating the cache and forcing `uv` to rebuild `mariadb` from source (which needs the missing `mariadb_config`).

This change points `lint-python` at `install-dev-wolf.sh`, which installs `libmariadb-dev`.


# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Reproduced on a branch whose `requirements-dev.txt` edit forced the cold-cache path, toggling only the installer script:

* **Before** — `lint-python` using `install-dev-common.sh`: fails at `Building mariadb==1.1.14` with `mariadb_config: not found`.
  https://github.com/y-scope/spider/actions/runs/29102792655/job/86396000160
* **After** — `lint-python` using `install-dev-wolf.sh`: `Built mariadb==1.1.14`, `task lint:py-check` passes.
  https://github.com/y-scope/spider/actions/runs/29105396825/job/86404556321

All jobs on the "after" run completed successfully (15/15 checks green: `lint-python`, `lint-cpp`, `lint-rust`, `lint-common`, `huntsman-tests`, `wolf-tests`, `build-and-push`, and the code-generation checks).

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
