### PR TITLE
fix(spider-storage): Cancel the service when a background tokio task exits on error.

### DIFF
--- a/components/spider-storage/src/state/job_cache_gc.rs
+++ b/components/spider-storage/src/state/job_cache_gc.rs
@@ -122,8 +122,12 @@ pub fn create_job_cache_gc<
         Duration::from_secs(config.terminated_job_retention_sec),
         receiver,
     );
-    let join_handle =
-        tokio::spawn(async move { gc.run(cancellation_token, gc_interval_sec).await });
+    let join_handle = tokio::spawn(async move {
+        gc.run(cancellation_token.clone(), gc_interval_sec).await.inspect_err(|e| {
+            tracing::error!(error = % e, "Job cache GC actor exited with error. Cancelling the service.");
+            cancellation_token.cancel();
+        })
+    });
     Ok((JobCacheGcHandle::new(sender), join_handle))
 }
 

--- a/components/spider-storage/src/task_instance_pool.rs
+++ b/components/spider-storage/src/task_instance_pool.rs
@@ -527,8 +527,12 @@ pub fn create_task_instance_pool<
         receiver,
     };
     let gc_interval_sec = config.gc_interval_sec;
-    let pool_join_handle =
-        tokio::spawn(async move { pool.run(cancellation_token, gc_interval_sec).await });
+    let pool_join_handle = tokio::spawn(async move {
+        pool.run(cancellation_token.clone(), gc_interval_sec).await.inspect_err(|e| {
+            tracing::error!(error = % e, "Task instance pool actor exited with error. Cancelling the service.");
+            cancellation_token.cancel();
+        })
+    });
     let handle = TaskInstancePoolHandle {
         next_task_instance_id,
         sender,


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Before this PR, the storage runtime didn't track the background tokio tasks' status. That means the background tasks may exit silently on error. This PR fixes this issue by:

- Adding a log statement to keep track of the service cancellation.
- Fire the service-wise cancellation token.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Ensure all workflows pass.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of background service failures by logging errors and automatically stopping related services when critical tasks fail.
  * Enhanced shutdown behaviour for job cache cleanup and task instance management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->