### PR TITLE
fix(docstring): Remove extra backtick.

### DIFF
--- a/components/spider-execution-manager/src/client/scheduler.rs
+++ b/components/spider-execution-manager/src/client/scheduler.rs
@@ -80,7 +80,7 @@ pub trait SchedulerClient: Send + Sync {
     ///
     /// * `em_id` - The identity of the calling execution manager.
     /// * `prev_assignments` - The task assignments produced by the scheduler that are successfully
-    ///   consumed by the execution manager.`
+    ///   consumed by the execution manager.
     async fn shutdown(
         &self,
         em_id: ExecutionManagerId,


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
An old bug of an extra backtick at the end of a docstring is now being caught by the updated rust linter, and [GitHub workflows](https://github.com/sitaowang1998/spider/actions/runs/29138325250/job/86506788397) start to fail.

This PR fixes the issue by removing the extra backtick.



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
- [x] GitHub workflows pass.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected formatting in the shutdown method’s parameter documentation.
  * No functional changes or API updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->