### PR TITLE
fix(spider-scheduler): Cancel the runtime when the scheduler core exits on error.

### DIFF
--- a/components/spider-scheduler/src/core.rs
+++ b/components/spider-scheduler/src/core.rs
@@ -55,6 +55,9 @@ pub trait SchedulerCore: Send {
     /// and writes assignments to `sink`, repeating until `cancellation_token` is fired, at which
     /// point it returns.
     ///
+    /// The implementation does not need to fire the cancellation token when exiting on error: this
+    /// cancellation is handled by the runtime.
+    ///
     /// # Parameters
     ///
     /// * `storage_client` - The storage client used to poll the inbound queue and read state for

--- a/components/spider-scheduler/src/runtime.rs
+++ b/components/spider-scheduler/src/runtime.rs
@@ -148,12 +148,24 @@ pub async fn create_runtime<SchedulerStorageClientType: SchedulerStorageClient +
     let service = SchedulerServiceState::new(dispatch_queue_reader, registry, scheduler_id);
     let core = scheduler_config.make_core::<SchedulerStorageClientType, DispatchQueueWriter>();
 
-    let core_join_handle = tokio::spawn(core.run(
-        storage_client,
-        dispatch_queue_writer,
-        TaskAssignmentIdIssuer::new(),
-        cancellation_token.clone(),
-    ));
+    let core_cancellation_token = cancellation_token.clone();
+    let core_join_handle = tokio::spawn(async move {
+        core.run(
+            storage_client,
+            dispatch_queue_writer,
+            TaskAssignmentIdIssuer::new(),
+            core_cancellation_token.clone(),
+        )
+        .await
+        .inspect_err(|e| {
+            tracing::error!(
+                scheduler_id = % scheduler_id,
+                error = % e,
+                "Scheduler core exited on error. Cancelling runtime."
+            );
+            core_cancellation_token.cancel();
+        })
+    });
 
     let runtime = Runtime {
         core_join_handle,


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR repeats #387's fix in spider-scheduler.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Ensure all workflows pass.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduler reliability by automatically cancelling the runtime when a scheduler encounters an error.
  * Added clearer error reporting to help identify scheduler failures.
* **Documentation**
  * Clarified cancellation handling when scheduling stops due to an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->