### PR TITLE
feat(spider-storage)!: Read database credentials via environment variables.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2051,6 +2051,7 @@ dependencies = [
  "rand 0.9.4",
  "secrecy",
  "serde",
+ "serde_json",
  "serial_test",
  "spider-core",
  "spider-derive",

--- a/components/spider-storage/Cargo.toml
+++ b/components/spider-storage/Cargo.toml
@@ -43,6 +43,7 @@ tracing = { version = "0.1.44", features = ["attributes"] }
 [dev-dependencies]
 anyhow = "1.0.98"
 rand = "0.9.1"
+serde_json = "1.0.149"
 serial_test = { version = "3.2.0", features = ["file_locks"] }
 tabled = "0.20.0"
 tokio = { version = "1.50.0", features = ["macros", "rt-multi-thread", "sync"] }

--- a/components/spider-storage/src/bin/grpc_server.rs
+++ b/components/spider-storage/src/bin/grpc_server.rs
@@ -12,6 +12,7 @@ use spider_proto_rust::storage::ResourceGroupManagementServiceServer;
 use spider_proto_rust::storage::SchedulerRegistrationServiceServer;
 use spider_proto_rust::storage::SessionManagementServiceServer;
 use spider_proto_rust::storage::TaskInstanceManagementServiceServer;
+use spider_storage::DatabaseCredentials;
 use spider_storage::ServerConfig;
 use spider_storage::grpc::GrpcServiceState;
 use spider_storage::state::runtime::create_runtime;
@@ -35,7 +36,8 @@ struct Cli {
 async fn main() -> Result<(), Box<dyn Error>> {
     let _log_guard = set_up_logging();
     let cli = Cli::parse();
-    let server_config = ServerConfig::from_yaml_file(&cli.config)?;
+    let mut server_config = ServerConfig::from_yaml_file(&cli.config)?;
+    server_config.runtime.db_config.credentials = DatabaseCredentials::from_env()?;
     let listen_addr = SocketAddr::new(server_config.host, server_config.port);
     let (runtime, cancellation_token) = create_runtime(&server_config.runtime).await?;
     let grpc_service =

--- a/components/spider-storage/src/bin/grpc_server.rs
+++ b/components/spider-storage/src/bin/grpc_server.rs
@@ -12,7 +12,6 @@ use spider_proto_rust::storage::ResourceGroupManagementServiceServer;
 use spider_proto_rust::storage::SchedulerRegistrationServiceServer;
 use spider_proto_rust::storage::SessionManagementServiceServer;
 use spider_proto_rust::storage::TaskInstanceManagementServiceServer;
-use spider_storage::DatabaseCredentials;
 use spider_storage::ServerConfig;
 use spider_storage::grpc::GrpcServiceState;
 use spider_storage::state::runtime::create_runtime;
@@ -36,8 +35,7 @@ struct Cli {
 async fn main() -> Result<(), Box<dyn Error>> {
     let _log_guard = set_up_logging();
     let cli = Cli::parse();
-    let mut server_config = ServerConfig::from_yaml_file(&cli.config)?;
-    server_config.runtime.db_config.credentials = DatabaseCredentials::from_env()?;
+    let server_config = ServerConfig::from_yaml_file(&cli.config)?;
     let listen_addr = SocketAddr::new(server_config.host, server_config.port);
     let (runtime, cancellation_token) = create_runtime(&server_config.runtime).await?;
     let grpc_service =

--- a/components/spider-storage/src/config.rs
+++ b/components/spider-storage/src/config.rs
@@ -3,6 +3,7 @@ use std::net::IpAddr;
 use secrecy::SecretString;
 use serde::Deserialize;
 use serde::Serialize;
+use thiserror::Error;
 
 use crate::state::runtime::RuntimeConfig;
 
@@ -28,8 +29,97 @@ pub struct DatabaseConfig {
     pub host: String,
     pub port: u16,
     pub name: String,
-    pub username: String,
-    #[serde(skip_serializing)]
-    pub password: SecretString,
     pub max_connections: u32,
+
+    #[serde(skip)]
+    pub credentials: DatabaseCredentials,
+}
+
+/// Credentials for authenticating with the database.
+#[derive(Clone, Debug)]
+pub struct DatabaseCredentials {
+    pub username: String,
+    pub password: SecretString,
+}
+
+impl DatabaseCredentials {
+    /// Reads the database credentials from the [`DB_USERNAME_ENV`] and [`DB_PASSWORD_ENV`]
+    /// environment variables.
+    ///
+    /// # Returns
+    ///
+    /// The credentials on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * [`CredentialsError::MissingEnvVar`] if either environment variable is unset.
+    pub fn from_env() -> Result<Self, CredentialsError> {
+        let username = std::env::var(DB_USERNAME_ENV)
+            .map_err(|_| CredentialsError::MissingEnvVar(DB_USERNAME_ENV))?;
+        let password = std::env::var(DB_PASSWORD_ENV)
+            .map_err(|_| CredentialsError::MissingEnvVar(DB_PASSWORD_ENV))?;
+        Ok(Self {
+            username,
+            password: SecretString::from(password),
+        })
+    }
+}
+
+impl Default for DatabaseCredentials {
+    fn default() -> Self {
+        Self {
+            username: String::new(),
+            password: SecretString::from(String::new()),
+        }
+    }
+}
+
+/// An error returned while reading database credentials from the environment.
+#[derive(Debug, Error)]
+pub enum CredentialsError {
+    #[error("required environment variable `{0}` is not set")]
+    MissingEnvVar(&'static str),
+}
+
+/// Environment variable that supplies the database username.
+const DB_USERNAME_ENV: &str = "SPIDER_STORAGE_DB_USERNAME";
+
+/// Environment variable that supplies the database password.
+const DB_PASSWORD_ENV: &str = "SPIDER_STORAGE_DB_PASSWORD";
+
+#[cfg(test)]
+mod tests {
+    use secrecy::ExposeSecret;
+
+    use super::*;
+
+    #[test]
+    fn read_credential_from_env() -> anyhow::Result<()> {
+        // SAFETY: these variables are read only by this test, so mutating this process-global state
+        // does not race with other tests.
+
+        // Both variables set: the credentials are read from the environment.
+        unsafe {
+            std::env::set_var(DB_USERNAME_ENV, "env-user");
+            std::env::set_var(DB_PASSWORD_ENV, "env-pass");
+        }
+        let both_set = DatabaseCredentials::from_env();
+
+        // A variable unset: an error naming the missing variable is returned.
+        unsafe { std::env::remove_var(DB_PASSWORD_ENV) };
+        let password_unset = DatabaseCredentials::from_env();
+
+        unsafe { std::env::remove_var(DB_USERNAME_ENV) };
+
+        let credentials = both_set?;
+        assert_eq!(credentials.username, "env-user");
+        assert_eq!(credentials.password.expose_secret(), "env-pass");
+        assert!(matches!(
+            password_unset,
+            Err(CredentialsError::MissingEnvVar(var)) if var == DB_PASSWORD_ENV
+        ));
+        Ok(())
+    }
 }

--- a/components/spider-storage/src/config.rs
+++ b/components/spider-storage/src/config.rs
@@ -127,8 +127,8 @@ mod tests {
     /// The database password supplied through the environment in these tests.
     const ENV_PASSWORD: &str = "env-pass";
 
-    #[test]
     #[serial]
+    #[test]
     fn deserialize_resolves_credentials_from_env() -> anyhow::Result<()> {
         // SAFETY: these variables are read-only by the serialized credential tests, so mutating
         // this process-global state does not race with other tests.
@@ -149,8 +149,8 @@ mod tests {
         Ok(())
     }
 
-    #[test]
     #[serial]
+    #[test]
     fn read_credential_from_env() -> anyhow::Result<()> {
         // SAFETY: these variables are read only by this test, so mutating this process-global state
         // does not race with other tests.

--- a/components/spider-storage/src/config.rs
+++ b/components/spider-storage/src/config.rs
@@ -7,6 +7,12 @@ use thiserror::Error;
 
 use crate::state::runtime::RuntimeConfig;
 
+/// Environment variable that supplies the database username.
+pub const DB_USERNAME_ENV: &str = "SPIDER_STORAGE_DB_USERNAME";
+
+/// Environment variable that supplies the database password.
+pub const DB_PASSWORD_ENV: &str = "SPIDER_STORAGE_DB_PASSWORD";
+
 /// Top-level configuration for the storage gRPC server.
 ///
 /// Pairs the server's listening endpoint with the [`RuntimeConfig`] used to build the storage
@@ -26,17 +32,31 @@ pub struct ServerConfig {
 /// Configuration parameters for connecting to the database.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct DatabaseConfig {
+    /// The database host.
     pub host: String,
+
+    /// The database port.
     pub port: u16,
+
+    /// The name of the database.
     pub name: String,
+
+    /// The maximum number of database connections maintained by the pool.
     pub max_connections: u32,
 
-    #[serde(skip)]
+    /// The credentials used to connect to the database.
+    ///
+    /// When omitted, the credentials are read from the following environment variables:
+    ///
+    /// * Database username: `SPIDER_STORAGE_DB_USERNAME`
+    /// * Database password: `SPIDER_STORAGE_DB_PASSWORD`
+    #[serde(skip_serializing)]
     pub credentials: DatabaseCredentials,
 }
 
 /// Credentials for authenticating with the database.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize)]
+#[serde(try_from = "Option<RawCredentials>")]
 pub struct DatabaseCredentials {
     pub username: String,
     pub password: SecretString,
@@ -67,15 +87,6 @@ impl DatabaseCredentials {
     }
 }
 
-impl Default for DatabaseCredentials {
-    fn default() -> Self {
-        Self {
-            username: String::new(),
-            password: SecretString::from(String::new()),
-        }
-    }
-}
-
 /// An error returned while reading database credentials from the environment.
 #[derive(Debug, Error)]
 pub enum CredentialsError {
@@ -83,27 +94,71 @@ pub enum CredentialsError {
     MissingEnvVar(&'static str),
 }
 
-/// Environment variable that supplies the database username.
-const DB_USERNAME_ENV: &str = "SPIDER_STORAGE_DB_USERNAME";
+#[derive(Deserialize)]
+struct RawCredentials {
+    username: String,
+    password: String,
+}
 
-/// Environment variable that supplies the database password.
-const DB_PASSWORD_ENV: &str = "SPIDER_STORAGE_DB_PASSWORD";
+impl TryFrom<Option<RawCredentials>> for DatabaseCredentials {
+    type Error = CredentialsError;
+
+    fn try_from(raw: Option<RawCredentials>) -> Result<Self, Self::Error> {
+        match raw {
+            Some(RawCredentials { username, password }) => Ok(Self {
+                username,
+                password: SecretString::from(password),
+            }),
+            None => Self::from_env(),
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {
     use secrecy::ExposeSecret;
+    use serial_test::serial;
 
     use super::*;
 
+    /// The database username supplied through the environment in these tests.
+    const ENV_USERNAME: &str = "env-user";
+
+    /// The database password supplied through the environment in these tests.
+    const ENV_PASSWORD: &str = "env-pass";
+
     #[test]
+    #[serial]
+    fn deserialize_resolves_credentials_from_env() -> anyhow::Result<()> {
+        // SAFETY: these variables are read-only by the serialized credential tests, so mutating
+        // this process-global state does not race with other tests.
+        unsafe {
+            std::env::set_var(DB_USERNAME_ENV, ENV_USERNAME);
+            std::env::set_var(DB_PASSWORD_ENV, ENV_PASSWORD);
+        }
+        let config: DatabaseConfig = serde_json::from_str(
+            r#"{"host": "db", "port": 3306, "name": "spider", "max_connections": 8}"#,
+        )?;
+        unsafe {
+            std::env::remove_var(DB_USERNAME_ENV);
+            std::env::remove_var(DB_PASSWORD_ENV);
+        }
+
+        assert_eq!(config.credentials.username, ENV_USERNAME);
+        assert_eq!(config.credentials.password.expose_secret(), ENV_PASSWORD);
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
     fn read_credential_from_env() -> anyhow::Result<()> {
         // SAFETY: these variables are read only by this test, so mutating this process-global state
         // does not race with other tests.
 
         // Both variables set: the credentials are read from the environment.
         unsafe {
-            std::env::set_var(DB_USERNAME_ENV, "env-user");
-            std::env::set_var(DB_PASSWORD_ENV, "env-pass");
+            std::env::set_var(DB_USERNAME_ENV, ENV_USERNAME);
+            std::env::set_var(DB_PASSWORD_ENV, ENV_PASSWORD);
         }
         let both_set = DatabaseCredentials::from_env();
 
@@ -114,8 +169,8 @@ mod tests {
         unsafe { std::env::remove_var(DB_USERNAME_ENV) };
 
         let credentials = both_set?;
-        assert_eq!(credentials.username, "env-user");
-        assert_eq!(credentials.password.expose_secret(), "env-pass");
+        assert_eq!(credentials.username, ENV_USERNAME);
+        assert_eq!(credentials.password.expose_secret(), ENV_PASSWORD);
         assert!(matches!(
             password_unset,
             Err(CredentialsError::MissingEnvVar(var)) if var == DB_PASSWORD_ENV

--- a/components/spider-storage/src/config.rs
+++ b/components/spider-storage/src/config.rs
@@ -46,10 +46,14 @@ pub struct DatabaseConfig {
 
     /// The credentials used to connect to the database.
     ///
-    /// When omitted, the credentials are read from the following environment variables:
+    /// By default, Spider expects the database credentials to be supplied through the following
+    /// environment variables:
     ///
     /// * Database username: `SPIDER_STORAGE_DB_USERNAME`
     /// * Database password: `SPIDER_STORAGE_DB_PASSWORD`
+    ///
+    /// These can be overridden by explicitly supplying the `credentials` field in the
+    /// configuration file.
     #[serde(skip_serializing)]
     pub credentials: DatabaseCredentials,
 }

--- a/components/spider-storage/src/db/mariadb.rs
+++ b/components/spider-storage/src/db/mariadb.rs
@@ -65,8 +65,8 @@ impl MariaDbStorageConnector {
             .host(&config.host)
             .port(config.port)
             .database(&config.name)
-            .username(&config.username)
-            .password(config.password.expose_secret());
+            .username(&config.credentials.username)
+            .password(config.credentials.password.expose_secret());
 
         let pool = sqlx::mysql::MySqlPoolOptions::new()
             .max_connections(config.max_connections)

--- a/components/spider-storage/src/lib.rs
+++ b/components/spider-storage/src/lib.rs
@@ -7,5 +7,7 @@ pub mod ready_queue;
 pub mod state;
 pub mod task_instance_pool;
 
+pub use config::CredentialsError;
 pub use config::DatabaseConfig;
+pub use config::DatabaseCredentials;
 pub use config::ServerConfig;

--- a/components/spider-storage/tests/mariadb_infra.rs
+++ b/components/spider-storage/tests/mariadb_infra.rs
@@ -1,6 +1,7 @@
 use secrecy::SecretString;
 use spider_core::types::id::ResourceGroupId;
 use spider_storage::DatabaseConfig;
+use spider_storage::DatabaseCredentials;
 use spider_storage::db::MariaDbStorageConnector;
 use spider_storage::db::ResourceGroupManagement;
 
@@ -47,9 +48,11 @@ pub fn create_mariadb_config() -> DatabaseConfig {
         host: "localhost".to_string(),
         port,
         name: database,
-        username,
-        password: SecretString::from(password),
         max_connections: 5,
+        credentials: DatabaseCredentials {
+            username,
+            password: SecretString::from(password),
+        },
     }
 }
 

--- a/components/spider-storage/tests/mariadb_infra.rs
+++ b/components/spider-storage/tests/mariadb_infra.rs
@@ -1,4 +1,3 @@
-use secrecy::SecretString;
 use spider_core::types::id::ResourceGroupId;
 use spider_storage::DatabaseConfig;
 use spider_storage::DatabaseCredentials;
@@ -14,7 +13,8 @@ use spider_storage::db::ResourceGroupManagement;
 /// # Panics
 ///
 /// Panics if any required environment variable (`MARIADB_PORT`, `MARIADB_DATABASE`,
-/// `MARIADB_USERNAME`, `MARIADB_PASSWORD`) is missing or if the connection fails.
+/// `SPIDER_STORAGE_DB_USERNAME`, `SPIDER_STORAGE_DB_PASSWORD`) is missing or if the connection
+/// fails.
 pub async fn create_mariadb_connector() -> MariaDbStorageConnector {
     MariaDbStorageConnector::connect(&create_mariadb_config())
         .await
@@ -31,8 +31,8 @@ pub async fn create_mariadb_connector() -> MariaDbStorageConnector {
 ///
 /// Panics if:
 ///
-/// * Any required environment variable (`MARIADB_PORT`, `MARIADB_DATABASE`, `MARIADB_USERNAME`, or
-///   `MARIADB_PASSWORD`) is missing.
+/// * Any required environment variable (`MARIADB_PORT`, `MARIADB_DATABASE`,
+///   `SPIDER_STORAGE_DB_USERNAME`, or `SPIDER_STORAGE_DB_PASSWORD`) is missing.
 /// * The value of `MARIADB_PORT` is invalid.
 #[must_use]
 pub fn create_mariadb_config() -> DatabaseConfig {
@@ -41,18 +41,13 @@ pub fn create_mariadb_config() -> DatabaseConfig {
         .parse()
         .expect("valid port");
     let database = std::env::var("MARIADB_DATABASE").expect("MARIADB_DATABASE");
-    let username = std::env::var("MARIADB_USERNAME").expect("MARIADB_USERNAME");
-    let password = std::env::var("MARIADB_PASSWORD").expect("MARIADB_PASSWORD");
 
     DatabaseConfig {
         host: "localhost".to_string(),
         port,
         name: database,
         max_connections: 5,
-        credentials: DatabaseCredentials {
-            username,
-            password: SecretString::from(password),
-        },
+        credentials: DatabaseCredentials::from_env().expect("database credentials"),
     }
 }
 

--- a/taskfiles/test.yaml
+++ b/taskfiles/test.yaml
@@ -228,7 +228,12 @@ tasks:
       SPIDER_TEST_INSTRUMENT_OUTPUT_DIR:
         sh: "echo {{.G_BUILD_DIR}}/spider-instrument-$(uuidgen)"
     requires:
-      vars: ["MARIADB_PORT", "MARIADB_DATABASE", "SPIDER_STORAGE_DB_USERNAME", "SPIDER_STORAGE_DB_PASSWORD"]
+      vars: [
+        "MARIADB_PORT",
+        "MARIADB_DATABASE",
+        "SPIDER_STORAGE_DB_USERNAME",
+        "SPIDER_STORAGE_DB_PASSWORD"
+      ]
     dir: "{{.ROOT_DIR}}"
     deps: ["toolchains:rust"]
     cmds:

--- a/taskfiles/test.yaml
+++ b/taskfiles/test.yaml
@@ -120,8 +120,8 @@ tasks:
   # parameters for database connection:
   # - MARIADB_PORT
   # - MARIADB_DATABASE
-  # - MARIADB_USERNAME
-  # - MARIADB_PASSWORD
+  # - SPIDER_STORAGE_DB_USERNAME
+  # - SPIDER_STORAGE_DB_PASSWORD
   huntsman-mariadb-storage-task-executor:
     internal: true
     vars:
@@ -148,8 +148,8 @@ tasks:
         vars:
           MARIADB_PORT: "{{.MARIADB_PORT}}"
           MARIADB_DATABASE: "{{.G_MARIADB_DATABASE}}"
-          MARIADB_USERNAME: "{{.G_MARIADB_USERNAME}}"
-          MARIADB_PASSWORD: "{{.G_MARIADB_PASSWORD}}"
+          SPIDER_STORAGE_DB_USERNAME: "{{.G_MARIADB_USERNAME}}"
+          SPIDER_STORAGE_DB_PASSWORD: "{{.G_MARIADB_PASSWORD}}"
 
   # Internal task that runs all spider-py's unit tests.
   #
@@ -220,15 +220,15 @@ tasks:
     env:
       MARIADB_PORT: "{{.MARIADB_PORT}}"
       MARIADB_DATABASE: "{{.MARIADB_DATABASE}}"
-      MARIADB_USERNAME: "{{.MARIADB_USERNAME}}"
-      MARIADB_PASSWORD: "{{.MARIADB_PASSWORD}}"
+      SPIDER_STORAGE_DB_USERNAME: "{{.SPIDER_STORAGE_DB_USERNAME}}"
+      SPIDER_STORAGE_DB_PASSWORD: "{{.SPIDER_STORAGE_DB_PASSWORD}}"
       SPIDER_TDL_PACKAGE_COMPLEX: "{{.G_TDL_PACKAGES_DIR}}/complex/libcomplex.so"
       SPIDER_TDL_PACKAGE_DIR: "{{.G_TDL_PACKAGES_DIR}}"
       SPIDER_TASK_EXECUTOR_BIN: "{{.G_RUST_RELEASE_DIR}}/spider-task-executor"
       SPIDER_TEST_INSTRUMENT_OUTPUT_DIR:
         sh: "echo {{.G_BUILD_DIR}}/spider-instrument-$(uuidgen)"
     requires:
-      vars: ["MARIADB_PORT", "MARIADB_DATABASE", "MARIADB_USERNAME", "MARIADB_PASSWORD"]
+      vars: ["MARIADB_PORT", "MARIADB_DATABASE", "SPIDER_STORAGE_DB_USERNAME", "SPIDER_STORAGE_DB_PASSWORD"]
     dir: "{{.ROOT_DIR}}"
     deps: ["toolchains:rust"]
     cmds:


### PR DESCRIPTION
# Description

This PR extends how database credentials are passed from storage to the database: the username and password can now be supplied through **environment variables**, not just the config file — addressing the concern of storing them in plaintext (e.g. in a Kubernetes ConfigMap).

Credentials are read from the config file's `credentials` block when present, and from the environment variables when the block is omitted. We carefully enumerate all possible scenarios and define their behavior: 

 - **config and env both set** → config (config takes precedence; env is ignored)
  - **env only** → env
  - **config only** → config
  - **neither** → startup fails with a "required environment variable … is not set" error

 > [!NOTE]
  > **BREAKING CHANGE:**
  > Username and password are optional in config rather mandatory.

# Checklist

- [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
- [x] This is a breaking change and that has been indicated in the PR title.
- [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Added a unit test covering two scenarios: it reads both variables, and it errors when one is unset.

All CI passes

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added typed, environment-based database credential handling with dedicated env vars and a unified credentials field.
  * Publicly exposed credential types and a clear error for missing environment variables.

* **Bug Fixes**
  * MariaDB connections now consistently use the configured grouped credentials.

* **Tests**
  * Updated/extended tests to validate environment loading and missing-variable failures.

* **Chores**
  * Renamed/wired test-task environment variables to use the new credential env var names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->