### PR TITLE
feat(huntsman)!: Replace endpoint's IP address with general hostname.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2010,6 +2010,7 @@ version = "0.1.0"
 dependencies = [
  "prost",
  "spider-core",
+ "spider-utils",
  "thiserror",
  "tonic",
  "tonic-prost",
@@ -2114,6 +2115,7 @@ dependencies = [
 name = "spider-utils"
 version = "0.1.0"
 dependencies = [
+ "non-empty-string",
  "rand 0.9.4",
  "rmp-serde",
  "serde",

--- a/components/spider-core/src/types/scheduler.rs
+++ b/components/spider-core/src/types/scheduler.rs
@@ -1,4 +1,4 @@
-use std::net::IpAddr;
+use spider_utils::config::Host;
 
 use crate::types::id::JobId;
 use crate::types::id::ResourceGroupId;
@@ -8,10 +8,10 @@ use crate::types::id::TaskAssignmentId;
 use crate::types::id::TaskId;
 
 /// The currently registered scheduler endpoint.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RegisteredScheduler {
     pub id: SchedulerId,
-    pub ip_address: IpAddr,
+    pub host: Host,
     pub port: u16,
 }
 

--- a/components/spider-proto-rust/Cargo.toml
+++ b/components/spider-proto-rust/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/lib.rs"
 [dependencies]
 prost = "0.14.4"
 spider-core = { path = "../spider-core" }
+spider-utils = { path = "../spider-utils" }
 thiserror = "2.0.18"
 tonic = "0.14.6"
 tonic-prost = "0.14.6"

--- a/components/spider-proto-rust/src/generated/storage.rs
+++ b/components/spider-proto-rust/src/generated/storage.rs
@@ -181,7 +181,7 @@ pub struct UpdateExecutionManagerHeartbeatResponse {
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RegisterSchedulerRequest {
     #[prost(string, tag = "1")]
-    pub ip_address: ::prost::alloc::string::String,
+    pub host: ::prost::alloc::string::String,
     #[prost(uint32, tag = "2")]
     pub port: u32,
 }
@@ -202,7 +202,7 @@ pub struct Scheduler {
     #[prost(uint64, tag = "1")]
     pub scheduler_id: u64,
     #[prost(string, tag = "2")]
-    pub ip_address: ::prost::alloc::string::String,
+    pub host: ::prost::alloc::string::String,
     #[prost(uint32, tag = "3")]
     pub port: u32,
 }

--- a/components/spider-proto-rust/src/scheduler_registration.rs
+++ b/components/spider-proto-rust/src/scheduler_registration.rs
@@ -8,7 +8,7 @@ impl From<RegisteredScheduler> for storage::Scheduler {
     fn from(scheduler: RegisteredScheduler) -> Self {
         Self {
             scheduler_id: scheduler.id.get(),
-            ip_address: scheduler.ip_address.to_string(),
+            host: scheduler.host.into_inner(),
             port: u32::from(scheduler.port),
         }
     }
@@ -16,26 +16,26 @@ impl From<RegisteredScheduler> for storage::Scheduler {
 
 #[cfg(test)]
 mod tests {
-    use std::net::IpAddr;
-
     use spider_core::types::id::SchedulerId;
     use spider_core::types::scheduler::RegisteredScheduler;
+    use spider_utils::config::Host;
 
     use crate::storage;
 
     #[test]
-    fn registered_scheduler_to_protocol_carries_id_ip_and_port() {
+    fn test_registered_scheduler_to_protocol_carries_id_host_and_port() {
         const SCHEDULER_ID: SchedulerId = SchedulerId::from(42);
         const PORT: u16 = 5678;
 
         let scheduler = storage::Scheduler::from(RegisteredScheduler {
             id: SCHEDULER_ID,
-            ip_address: IpAddr::V4("127.0.0.1".parse().expect("valid IP")),
+            host: Host::new("spider-scheduler".to_owned())
+                .expect("scheduler host should not be empty"),
             port: PORT,
         });
 
         assert_eq!(scheduler.scheduler_id, SCHEDULER_ID.get());
-        assert_eq!(scheduler.ip_address, "127.0.0.1");
+        assert_eq!(scheduler.host, "spider-scheduler");
         assert_eq!(scheduler.port, u32::from(PORT));
     }
 }

--- a/components/spider-proto-rust/src/unpack/storage.rs
+++ b/components/spider-proto-rust/src/unpack/storage.rs
@@ -9,6 +9,7 @@ use spider_core::types::id::ResourceGroupId;
 use spider_core::types::id::SessionId;
 use spider_core::types::id::TaskId;
 use spider_core::types::id::TaskInstanceId;
+use spider_utils::config::Host;
 use tonic::Code;
 
 use crate::storage::AddResourceGroupRequest;
@@ -185,21 +186,16 @@ impl RequestUnpack for ExecutionManagerIdRequest {
     }
 }
 
-/// Unpacks [`RegisterSchedulerRequest`] into a tuple containing:
-///
-/// * The scheduler IP address.
-/// * The scheduler port.
+/// Unpacks [`RegisterSchedulerRequest`] into the scheduler host and port.
 impl RequestUnpack for RegisterSchedulerRequest {
-    type Unpacked = (IpAddr, u16);
+    type Unpacked = (Host, u16);
 
     fn unpack(self) -> Result<Self::Unpacked, UnpackError> {
-        let ip_address = self
-            .ip_address
-            .parse::<IpAddr>()
-            .map_err(|error| invalid_argument(format!("invalid IP address: {error}")))?;
+        let host = Host::new(self.host)
+            .map_err(|_| invalid_argument("host must not be empty".to_owned()))?;
         let port = u16::try_from(self.port)
             .map_err(|_| invalid_argument(format!("port does not fit in `u16`: {}", self.port)))?;
-        Ok((ip_address, port))
+        Ok((host, port))
     }
 }
 

--- a/components/spider-proto/storage/storage.proto
+++ b/components/spider-proto/storage/storage.proto
@@ -174,7 +174,7 @@ message UpdateExecutionManagerHeartbeatResponse {
 }
 
 message RegisterSchedulerRequest {
-  string ip_address = 1;
+  string host = 1;
   uint32 port = 2;
 }
 
@@ -189,7 +189,7 @@ message RegisterSchedulerResponse {
 
 message Scheduler {
   uint64 scheduler_id = 1;
-  string ip_address = 2;
+  string host = 2;
   uint32 port = 3;
 }
 

--- a/components/spider-scheduler/src/bin/grpc_server.rs
+++ b/components/spider-scheduler/src/bin/grpc_server.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let cli = Cli::parse();
     let server_config = ServerConfig::from_yaml_file(&cli.config)
         .inspect_err(|error| tracing::error!(error = % error, "Failed to load configuration."))?;
-    let listen_addr = SocketAddr::new(server_config.runtime.host, server_config.runtime.port);
+    let listen_addr = SocketAddr::new(server_config.host, server_config.port);
 
     let storage_endpoint = server_config.storage_endpoint.endpoint().inspect_err(
         |error| tracing::error!(error = % error, "Failed to parse storage endpoint."),

--- a/components/spider-scheduler/src/config.rs
+++ b/components/spider-scheduler/src/config.rs
@@ -1,5 +1,6 @@
 //! Scheduler service configuration.
 
+use std::net::IpAddr;
 use std::num::NonZeroUsize;
 
 use serde::Deserialize;
@@ -14,6 +15,12 @@ use crate::storage_client::SchedulerStorageClient;
 /// Top-level configuration for the scheduler gRPC server.
 #[derive(Clone, Debug, Deserialize)]
 pub struct ServerConfig {
+    /// The IP address the gRPC server listens on.
+    pub host: IpAddr,
+
+    /// The port the gRPC server listens on.
+    pub port: u16,
+
     /// The storage service gRPC endpoint.
     pub storage_endpoint: EndpointConfig,
 
@@ -22,7 +29,7 @@ pub struct ServerConfig {
     /// Must be greater than zero.
     pub connection_pool_size: NonZeroUsize,
 
-    /// The scheduler runtime configuration (also supplies the gRPC listen host/port).
+    /// The scheduler runtime configuration.
     pub runtime: RuntimeConfig,
 }
 

--- a/components/spider-scheduler/src/core_impl/round_robin/tests.rs
+++ b/components/spider-scheduler/src/core_impl/round_robin/tests.rs
@@ -149,7 +149,7 @@ impl MockStorageClient {
 impl SchedulerStorageClient for MockStorageClient {
     async fn register(
         &self,
-        _ip_address: std::net::IpAddr,
+        _host: spider_utils::config::Host,
         _port: u16,
     ) -> Result<SchedulerId, StorageClientError> {
         Ok(SchedulerId::from(0))

--- a/components/spider-scheduler/src/runtime.rs
+++ b/components/spider-scheduler/src/runtime.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 
 use serde::Deserialize;
 use spider_core::types::id::SessionId;
+use spider_utils::config::EndpointConfig;
 use tokio_util::sync::CancellationToken;
 
 use crate::config::SchedulerConfig;
@@ -34,11 +35,8 @@ pub struct RuntimeConfig {
     #[serde(default)]
     pub em_registry: ExecutionManagerRegistryConfig,
 
-    /// The IP address this scheduler advertises to the storage service during registration.
-    pub host: std::net::IpAddr,
-
-    /// The port this scheduler advertises to the storage service during registration.
-    pub port: u16,
+    /// The scheduler endpoint advertised to the storage service during registration.
+    pub advertised_endpoint: EndpointConfig,
 
     /// The maximum time, in seconds, to wait for background tasks to stop during shutdown.
     #[serde(default = "default_stop_timeout_sec")]
@@ -122,17 +120,18 @@ pub async fn create_runtime<SchedulerStorageClientType: SchedulerStorageClient +
     ),
     SchedulerRuntimeError,
 > {
-    let cancellation_token = CancellationToken::new();
-
-    let scheduler_id = storage_client.register(config.host, config.port).await?;
-    tracing::info!(scheduler_id = % scheduler_id, "Scheduler registered with storage.");
-
     let RuntimeConfig {
         scheduler: scheduler_config,
         em_registry: execution_manager_registry_config,
+        advertised_endpoint,
         stop_timeout_sec,
-        ..
     } = config;
+    let cancellation_token = CancellationToken::new();
+
+    let scheduler_id = storage_client
+        .register(advertised_endpoint.host, advertised_endpoint.port)
+        .await?;
+    tracing::info!(scheduler_id = % scheduler_id, "Scheduler registered with storage.");
     let dispatch_queue_capacity = scheduler_config.dispatch_queue_capacity();
 
     let (reschedule_queue_sender, reschedule_queue_receiver) =
@@ -189,8 +188,6 @@ const fn default_stop_timeout_sec() -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use std::net::IpAddr;
-    use std::net::Ipv4Addr;
     use std::num::NonZeroU64;
     use std::num::NonZeroUsize;
 
@@ -198,6 +195,7 @@ mod tests {
     use spider_core::job::JobState;
     use spider_core::types::id::JobId;
     use spider_core::types::id::SchedulerId;
+    use spider_utils::config::Host;
 
     use super::*;
     use crate::core_impl::RoundRobinConfig;
@@ -217,7 +215,7 @@ mod tests {
     impl SchedulerStorageClient for MockStorageClient {
         async fn register(
             &self,
-            _ip_address: IpAddr,
+            _host: Host,
             _port: u16,
         ) -> Result<SchedulerId, StorageClientError> {
             Ok(SchedulerId::from(SCHEDULER_ID))
@@ -268,8 +266,11 @@ mod tests {
                 finalizing_job_expiration_timeout_sec: 60,
             }),
             em_registry: ExecutionManagerRegistryConfig::default(),
-            host: IpAddr::V4(Ipv4Addr::LOCALHOST),
-            port: 0,
+            advertised_endpoint: EndpointConfig {
+                host: Host::new("scheduler.example.com".to_owned())
+                    .expect("advertised host should not be empty"),
+                port: 50052,
+            },
             stop_timeout_sec,
         }
     }

--- a/components/spider-scheduler/src/storage_client/grpc.rs
+++ b/components/spider-scheduler/src/storage_client/grpc.rs
@@ -14,6 +14,7 @@ use spider_proto_rust::storage::InboundQueueServiceClient;
 use spider_proto_rust::storage::JobOrchestrationServiceClient;
 use spider_proto_rust::storage::SchedulerRegistrationServiceClient;
 use spider_proto_rust::storage::{self};
+use spider_utils::config::Host;
 use spider_utils::grpc::client::ConnectionPool;
 use tonic::Code;
 use tonic::Status;
@@ -74,13 +75,9 @@ impl GrpcSchedulerStorageClient {
 
 #[async_trait]
 impl SchedulerStorageClient for GrpcSchedulerStorageClient {
-    async fn register(
-        &self,
-        ip_address: std::net::IpAddr,
-        port: u16,
-    ) -> Result<SchedulerId, StorageClientError> {
+    async fn register(&self, host: Host, port: u16) -> Result<SchedulerId, StorageClientError> {
         let request = storage::RegisterSchedulerRequest {
-            ip_address: ip_address.to_string(),
+            host: host.into_inner(),
             port: u32::from(port),
         };
         let response = self

--- a/components/spider-scheduler/src/storage_client/mod.rs
+++ b/components/spider-scheduler/src/storage_client/mod.rs
@@ -7,6 +7,7 @@ use spider_core::job::JobState;
 use spider_core::types::id::JobId;
 use spider_core::types::id::SchedulerId;
 use spider_core::types::id::SessionId;
+use spider_utils::config::Host;
 
 use crate::error::StorageClientError;
 use crate::types::InboundEntry;
@@ -27,7 +28,7 @@ pub trait SchedulerStorageClient: Send + Sync + Clone {
     ///
     /// # Parameters
     ///
-    /// * `ip_address` - The IP address this scheduler is reachable on.
+    /// * `host` - The host this scheduler is reachable on.
     /// * `port` - The port this scheduler is reachable on.
     ///
     /// # Returns
@@ -41,11 +42,7 @@ pub trait SchedulerStorageClient: Send + Sync + Clone {
     /// * [`StorageClientError::Server`] if the storage service returns an error.
     /// * [`StorageClientError::Transport`] if the storage transport fails or returns malformed
     ///   data.
-    async fn register(
-        &self,
-        ip_address: std::net::IpAddr,
-        port: u16,
-    ) -> Result<SchedulerId, StorageClientError>;
+    async fn register(&self, host: Host, port: u16) -> Result<SchedulerId, StorageClientError>;
 
     /// Polls the regular-task lane of the storage-owned inbound queue for ready tasks.
     ///

--- a/components/spider-storage/src/db/mariadb.rs
+++ b/components/spider-storage/src/db/mariadb.rs
@@ -13,6 +13,7 @@ use spider_core::types::io::SerializedTaskOutputs;
 use spider_core::types::io::TaskOutput;
 use spider_core::types::scheduler::RegisteredScheduler;
 use spider_derive::MySqlEnum;
+use spider_utils::config::Host;
 use sqlx::Connection;
 use sqlx::MySqlPool;
 use sqlx::mysql::MySqlDatabaseError;
@@ -581,22 +582,18 @@ impl ExecutionManagerLivenessManagement for MariaDbStorageConnector {
 
 #[async_trait]
 impl SchedulerRegistrationManagement for MariaDbStorageConnector {
-    async fn register_scheduler(
-        &self,
-        ip_address: IpAddr,
-        port: u16,
-    ) -> Result<SchedulerId, DbError> {
+    async fn register_scheduler(&self, host: &str, port: u16) -> Result<SchedulerId, DbError> {
         const DELETE_QUERY: &str =
             formatcp!("DELETE FROM `{table}`;", table = SCHEDULERS_TABLE_NAME,);
         const INSERT_QUERY: &str = formatcp!(
-            "INSERT INTO `{table}` (`ip_address`, `port`) VALUES (?, ?) RETURNING `id`;",
+            "INSERT INTO `{table}` (`host`, `port`) VALUES (?, ?) RETURNING `id`;",
             table = SCHEDULERS_TABLE_NAME,
         );
 
         let mut tx = self.pool.begin().await?;
         sqlx::query(DELETE_QUERY).execute(&mut *tx).await?;
         let scheduler_id = sqlx::query_scalar(INSERT_QUERY)
-            .bind(ip_address.to_string())
+            .bind(host)
             .bind(port)
             .fetch_one(&mut *tx)
             .await?;
@@ -606,7 +603,7 @@ impl SchedulerRegistrationManagement for MariaDbStorageConnector {
 
     async fn get_schedulers(&self) -> Result<Vec<RegisteredScheduler>, DbError> {
         const QUERY: &str = formatcp!(
-            "SELECT `id`, `ip_address`, `port` FROM `{table}` ORDER BY `id` ASC;",
+            "SELECT `id`, `host`, `port` FROM `{table}` ORDER BY `id` ASC;",
             table = SCHEDULERS_TABLE_NAME,
         );
 
@@ -722,7 +719,7 @@ const fn schedulers_creation_query() -> &'static str {
         r"
 CREATE TABLE IF NOT EXISTS `{SCHEDULERS_TABLE_NAME}` (
   `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-  `ip_address` VARCHAR(45) NOT NULL,
+  `host` VARCHAR(255) NOT NULL,
   `port` SMALLINT UNSIGNED NOT NULL,
   `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
@@ -793,7 +790,7 @@ impl RecoverableJobRowProjection {
 #[derive(sqlx::FromRow)]
 struct SchedulerRowProjection {
     id: SchedulerId,
-    ip_address: String,
+    host: String,
     port: u16,
 }
 
@@ -808,17 +805,14 @@ impl SchedulerRowProjection {
     ///
     /// Returns an error if:
     ///
-    /// * [`DbError::CorruptedDbState`] if the scheduler IP address is invalid.
+    /// * [`DbError::CorruptedDbState`] if the scheduler host is empty.
     fn into_registered_scheduler(self) -> Result<RegisteredScheduler, DbError> {
-        let ip_address = self.ip_address.parse().map_err(|error| {
-            DbError::CorruptedDbState(format!(
-                "scheduler `{}` has invalid IP address `{}`: {error}",
-                self.id, self.ip_address
-            ))
+        let host = Host::new(self.host).map_err(|_| {
+            DbError::CorruptedDbState(format!("scheduler `{}` has an empty host", self.id))
         })?;
         Ok(RegisteredScheduler {
             id: self.id,
-            ip_address,
+            host,
             port: self.port,
         })
     }

--- a/components/spider-storage/src/db/protocol.rs
+++ b/components/spider-storage/src/db/protocol.rs
@@ -439,7 +439,7 @@ pub trait SchedulerRegistrationManagement: Clone + Send + Sync {
     ///
     /// # Parameters
     ///
-    /// * `ip_address` - The scheduler IP address.
+    /// * `host` - The scheduler host.
     /// * `port` - The scheduler port.
     ///
     /// # Returns
@@ -451,11 +451,7 @@ pub trait SchedulerRegistrationManagement: Clone + Send + Sync {
     /// Returns an error if:
     ///
     /// * Forwards [`sqlx::error::Error`] on DB operation failure.
-    async fn register_scheduler(
-        &self,
-        ip_address: IpAddr,
-        port: u16,
-    ) -> Result<SchedulerId, DbError>;
+    async fn register_scheduler(&self, host: &str, port: u16) -> Result<SchedulerId, DbError>;
 
     /// Gets registered schedulers.
     ///

--- a/components/spider-storage/src/grpc.rs
+++ b/components/spider-storage/src/grpc.rs
@@ -859,11 +859,11 @@ impl<
         &self,
         request: Request<storage::RegisterSchedulerRequest>,
     ) -> Result<Response<storage::RegisterSchedulerResponse>, Status> {
-        let (ip_addr, port) = request.into_inner().unpack()?;
-        tracing::info!(% ip_addr, port, "Scheduler registration request received.");
+        let (host, port) = request.into_inner().unpack()?;
+        tracing::info!(host = % host, port, "Scheduler registration request received.");
         let scheduler_id = self
             .inner
-            .register_scheduler(ip_addr, port)
+            .register_scheduler(host, port)
             .await
             .map_err(|error| {
                 self.scheduler_registration_service_error_handler(error, "register_scheduler")

--- a/components/spider-storage/src/state/service.rs
+++ b/components/spider-storage/src/state/service.rs
@@ -16,6 +16,7 @@ use spider_core::types::io::TaskOutput;
 use spider_core::types::io::TaskOutputsSerializer;
 use spider_core::types::scheduler::RegisteredScheduler;
 use spider_tdl::error::TdlError;
+use spider_utils::config::Host;
 use tokio_util::sync::CancellationToken;
 
 use crate::cache::error::CacheError;
@@ -704,15 +705,19 @@ impl<
     ///   failure.
     pub async fn register_scheduler(
         &self,
-        ip_address: IpAddr,
+        host: Host,
         port: u16,
     ) -> Result<SchedulerId, StorageServerError> {
         let mut has_previous_scheduler_connection =
             self.inner.has_previous_scheduler_connection.lock().await;
-        let scheduler_id = self.inner.db.register_scheduler(ip_address, port).await?;
+        let scheduler_id = self
+            .inner
+            .db
+            .register_scheduler(host.as_str(), port)
+            .await?;
         tracing::info!(
             scheduler_id = ? scheduler_id,
-            ip = ? ip_address,
+            host = % host,
             port,
             "Scheduler registered.",
         );
@@ -1766,7 +1771,11 @@ mod tests {
 
         // The first registration has no previous scheduler to replace, so it must not resend.
         service
-            .register_scheduler("127.0.0.1".parse()?, 8080)
+            .register_scheduler(
+                Host::new("scheduler-a.example.com".to_owned())
+                    .expect("scheduler host should not be empty"),
+                8080,
+            )
             .await?;
         tokio::task::yield_now().await;
         let after_first = service
@@ -1780,7 +1789,11 @@ mod tests {
         // The second registration replaces the first scheduler, so it must resend ready tasks. The
         // resend runs in a spawned background task, so yield to let it run before polling.
         service
-            .register_scheduler("127.0.0.1".parse()?, 8081)
+            .register_scheduler(
+                Host::new("scheduler-b.example.com".to_owned())
+                    .expect("scheduler host should not be empty"),
+                8081,
+            )
             .await?;
         tokio::task::yield_now().await;
         let after_second = service

--- a/components/spider-storage/src/state/test_utils.rs
+++ b/components/spider-storage/src/state/test_utils.rs
@@ -251,11 +251,7 @@ impl ExecutionManagerLivenessManagement for MockDbConnector {
 
 #[async_trait::async_trait]
 impl SchedulerRegistrationManagement for MockDbConnector {
-    async fn register_scheduler(
-        &self,
-        _ip_address: IpAddr,
-        _port: u16,
-    ) -> Result<SchedulerId, DbError> {
+    async fn register_scheduler(&self, _host: &str, _port: u16) -> Result<SchedulerId, DbError> {
         let counter = self.next_scheduler_id.fetch_add(1, Ordering::Relaxed);
         Ok(SchedulerId::from(counter as u64))
     }

--- a/components/spider-storage/tests/mariadb_test.rs
+++ b/components/spider-storage/tests/mariadb_test.rs
@@ -1058,15 +1058,15 @@ async fn test_liveness_operations_no_deadlock_under_concurrency() {
 #[serial_test::file_serial]
 async fn test_register_scheduler_replaces_previous_scheduler() {
     let storage = create_mariadb_connector().await;
-    let scheduler_ip_address = IpAddr::V4(Ipv4Addr::LOCALHOST);
-    let updated_scheduler_ip_address = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2));
+    let scheduler_host = "scheduler-a.spider.svc.cluster.local";
+    let updated_scheduler_host = "scheduler-b.spider.svc.cluster.local";
 
     let first_scheduler_id = storage
-        .register_scheduler(scheduler_ip_address, TEST_SCHEDULER_PORT)
+        .register_scheduler(scheduler_host, TEST_SCHEDULER_PORT)
         .await
         .expect("first register_scheduler should succeed");
     let second_scheduler_id = storage
-        .register_scheduler(updated_scheduler_ip_address, TEST_UPDATED_SCHEDULER_PORT)
+        .register_scheduler(updated_scheduler_host, TEST_UPDATED_SCHEDULER_PORT)
         .await
         .expect("second register_scheduler should succeed");
     let schedulers = storage
@@ -1092,7 +1092,7 @@ async fn test_register_scheduler_replaces_previous_scheduler() {
         "only the latest scheduler should remain"
     );
     assert_eq!(schedulers[0].id, second_scheduler_id);
-    assert_eq!(schedulers[0].ip_address, updated_scheduler_ip_address);
+    assert_eq!(schedulers[0].host.as_str(), updated_scheduler_host);
     assert_eq!(schedulers[0].port, TEST_UPDATED_SCHEDULER_PORT);
 }
 

--- a/components/spider-utils/Cargo.toml
+++ b/components/spider-utils/Cargo.toml
@@ -8,6 +8,7 @@ name = "spider_utils"
 path = "src/lib.rs"
 
 [dependencies]
+non-empty-string = { version = "0.2.6", features = ["serde"] }
 rand = "0.9.1"
 rmp-serde = "1.3.1"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/components/spider-utils/src/config.rs
+++ b/components/spider-utils/src/config.rs
@@ -1,9 +1,8 @@
 use std::fs::File;
 use std::io;
-use std::net::IpAddr;
-use std::net::SocketAddr;
 use std::path::Path;
 
+use non_empty_string::NonEmptyString;
 use serde::Deserialize;
 use serde::de::DeserializeOwned;
 use thiserror::Error;
@@ -47,22 +46,17 @@ pub trait YamlConfig: DeserializeOwned {
 
 impl<ConfigType: DeserializeOwned> YamlConfig for ConfigType {}
 
+/// A non-empty DNS name or IP address.
+pub type Host = NonEmptyString;
+
 /// The network location of a gRPC server.
 #[derive(Clone, Debug, Deserialize)]
 pub struct EndpointConfig {
-    pub host: IpAddr,
+    pub host: Host,
     pub port: u16,
 }
 
 impl EndpointConfig {
-    /// # Returns
-    ///
-    /// This endpoint's `host:port` as a [`SocketAddr`].
-    #[must_use]
-    pub const fn socket_addr(&self) -> SocketAddr {
-        SocketAddr::new(self.host, self.port)
-    }
-
     /// Builds a tonic [`Endpoint`] pointing at this `host:port` over plaintext HTTP/2.
     ///
     /// # Returns
@@ -75,6 +69,6 @@ impl EndpointConfig {
     ///
     /// * Forwards [`Endpoint::from_shared`]'s return values on failure.
     pub fn endpoint(&self) -> Result<Endpoint, tonic::transport::Error> {
-        Endpoint::from_shared(format!("http://{}", self.socket_addr()))
+        Endpoint::from_shared(format!("http://{}:{}", self.host, self.port))
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->


> [!Note]
> This PR is a breaking change because it changes configuration.

## Background

Spider's storage and scheduler use the same IP address for them to listen on and for other components to connect to them. However, for deployment in docker compose and helm, the network are split and each service's network typically expose a hostname for other service to connect to, which is different from the IP address inside the network where each server bind on.

## Solution
This PR resolves #400 by separating IP address to bind on with the connecting hostname.
- Adds a shared `Host` alias backed by `NonEmptyString`, representing a DNS name or an IP address.
- Updates `EndpointConfig` to accept the `Host`, so all components use `Host` to connect to storage and scheduler.
- Separates the scheduler's bind address from its advertised endpoint:
  - `ServerConfig.host` and `port` remain the socket bind address.
  - `RuntimeConfig.advertised_endpoint` identifies the scheduler endpoint registered with storage.
- Propagates scheduler hostnames through the registration protobuf, core types, storage, and database.

## Scheduler Configuration
This PR changes the shape of the scheduler's configuration. Below is an example of the configuration after change. `host` can be a DNS name, an IPv4 address of an IPv6 address surrounded by bracket (e.g. `[::1]`).
```
host: "0.0.0.0"
port: 50052

storage_endpoint:
  host: "spider-storage"
  port: 50051

connection_pool_size: 4

runtime:
  advertised_endpoint:
    host: "spider-scheduler"
    port: 50052

  scheduler: !round_robin
    active_job_queue_capacity: 64
    cleanup_ready_task_capacity: 256
    commit_ready_task_capacity: 256
    dispatch_queue_capacity: 64
    finalizing_job_expiration_timeout_sec: 300
    ready_task_capacity: 65536
    storage_poll_timeout_ms: 10
    tick_interval_ms: 5

  stop_timeout_sec: 30

  em_registry:
    dead_em_cutoff_sec: 60
    liveness_tracking_interval_ms: 1000
```


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
- [ ] GitHub workflows pass.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scheduler endpoints now support validated hostnames as well as IP addresses.
  * Scheduler configuration separates the advertised endpoint from the server’s listening address.
  * Scheduler registration and storage now preserve host and port information consistently.

* **Bug Fixes**
  * Improved validation prevents empty scheduler hosts from being registered.
  * Scheduler replacement and persistence now work with DNS hostnames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->