### PR TITLE
fix(spider-client): Make the gRPC client's request futures `Send`.

### DIFF
--- a/components/spider-client/src/client.rs
+++ b/components/spider-client/src/client.rs
@@ -290,3 +290,32 @@ impl SpiderClientBuilder {
 }
 
 const DEFAULT_POOL_SIZE: NonZeroUsize = NonZeroUsize::new(8).unwrap();
+
+/// Compile-time assertion that the public client handles are `Send + Sync`.
+const _: () = {
+    const fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<SpiderClient>();
+    assert_send_sync::<SpiderClientBuilder>();
+};
+
+/// Compile-time assertion that every public [`SpiderClient`] async method returns a `Send` future.
+///
+/// This function is never called; it exists only to type-check the `Send` bound on each returned
+/// future. The arguments are taken as parameters (never constructed) so no real values are needed.
+#[expect(dead_code, reason = "compile-time-only `Send` assertion; never called")]
+fn assert_client_futures_send(
+    client: &SpiderClient,
+    resource_group_id: ResourceGroupId,
+    job_id: JobId,
+    task_graph: &TaskGraph,
+) {
+    const fn assert_send<FutureType: Send>(_: &FutureType) {}
+    assert_send(&client.submit_job(resource_group_id, task_graph, Vec::new()));
+    assert_send(&client.start_job(job_id));
+    assert_send(&client.cancel_job(job_id));
+    assert_send(&client.get_job_state(job_id));
+    assert_send(&client.get_job_outputs(job_id));
+    assert_send(&client.get_job_error(job_id));
+    assert_send(&client.add_resource_group(String::new(), Vec::new()));
+    assert_send(&client.verify_resource_group(resource_group_id, Vec::new()));
+}

--- a/components/spider-client/src/grpc/job.rs
+++ b/components/spider-client/src/grpc/job.rs
@@ -121,7 +121,7 @@ impl JobOrchestrationClient {
         };
         let pool = self.connection_pool.clone();
         let response = call_with_retry(self.retry_config, move || {
-            let mut client = pool.get_client().clone();
+            let mut client = pool.get_client();
             let request = request;
             async move { client.start_job(request).await }
         })

--- a/components/spider-client/src/grpc/job.rs
+++ b/components/spider-client/src/grpc/job.rs
@@ -121,7 +121,7 @@ impl JobOrchestrationClient {
         };
         let pool = self.connection_pool.clone();
         let response = call_with_retry(self.retry_config, move || {
-            let mut client = pool.get_client();
+            let mut client = pool.get_client().clone();
             let request = request;
             async move { client.start_job(request).await }
         })

--- a/components/spider-client/src/grpc/job.rs
+++ b/components/spider-client/src/grpc/job.rs
@@ -90,11 +90,11 @@ impl JobOrchestrationClient {
             compressed_serialized_task_graph,
             compressed_serialized_inputs,
         };
-        let response = call_with_retry(self.retry_config, async || {
-            self.connection_pool
-                .get_client()
-                .register_job(request.clone())
-                .await
+        let pool = self.connection_pool.clone();
+        let response = call_with_retry(self.retry_config, move || {
+            let mut client = pool.get_client();
+            let request = request.clone();
+            async move { client.register_job(request).await }
         })
         .await
         .map_err(|status| job_status_to_error(&status))?
@@ -119,8 +119,11 @@ impl JobOrchestrationClient {
         let request = storage::JobIdRequest {
             job_id: job_id.get(),
         };
-        let response = call_with_retry(self.retry_config, async || {
-            self.connection_pool.get_client().start_job(request).await
+        let pool = self.connection_pool.clone();
+        let response = call_with_retry(self.retry_config, move || {
+            let mut client = pool.get_client();
+            let request = request;
+            async move { client.start_job(request).await }
         })
         .await
         .map_err(|status| job_status_to_error(&status))?
@@ -145,8 +148,11 @@ impl JobOrchestrationClient {
         let request = storage::JobIdRequest {
             job_id: job_id.get(),
         };
-        let response = call_with_retry(self.retry_config, async || {
-            self.connection_pool.get_client().cancel_job(request).await
+        let pool = self.connection_pool.clone();
+        let response = call_with_retry(self.retry_config, move || {
+            let mut client = pool.get_client();
+            let request = request;
+            async move { client.cancel_job(request).await }
         })
         .await
         .map_err(|status| job_status_to_error(&status))?
@@ -171,11 +177,11 @@ impl JobOrchestrationClient {
         let request = storage::JobIdRequest {
             job_id: job_id.get(),
         };
-        let response = call_with_retry(self.retry_config, async || {
-            self.connection_pool
-                .get_client()
-                .get_job_state(request)
-                .await
+        let pool = self.connection_pool.clone();
+        let response = call_with_retry(self.retry_config, move || {
+            let mut client = pool.get_client();
+            let request = request;
+            async move { client.get_job_state(request).await }
         })
         .await
         .map_err(|status| job_status_to_error(&status))?
@@ -202,11 +208,11 @@ impl JobOrchestrationClient {
         let request = storage::JobIdRequest {
             job_id: job_id.get(),
         };
-        let response = call_with_retry(self.retry_config, async || {
-            self.connection_pool
-                .get_client()
-                .get_job_outputs(request)
-                .await
+        let pool = self.connection_pool.clone();
+        let response = call_with_retry(self.retry_config, move || {
+            let mut client = pool.get_client();
+            let request = request;
+            async move { client.get_job_outputs(request).await }
         })
         .await
         .map_err(|status| job_status_to_error(&status))?
@@ -231,11 +237,11 @@ impl JobOrchestrationClient {
         let request = storage::JobIdRequest {
             job_id: job_id.get(),
         };
-        let response = call_with_retry(self.retry_config, async || {
-            self.connection_pool
-                .get_client()
-                .get_job_error(request)
-                .await
+        let pool = self.connection_pool.clone();
+        let response = call_with_retry(self.retry_config, move || {
+            let mut client = pool.get_client();
+            let request = request;
+            async move { client.get_job_error(request).await }
         })
         .await
         .map_err(|status| job_status_to_error(&status))?

--- a/components/spider-client/src/grpc/job.rs
+++ b/components/spider-client/src/grpc/job.rs
@@ -85,15 +85,14 @@ impl JobOrchestrationClient {
             .to_zstd_compressed_json()
             .map_err(|error| ClientError::Serialization(error.to_string()))?;
         let compressed_serialized_inputs = serialize_inputs(inputs)?;
-        let request = storage::RegisterJobRequest {
-            resource_group_id: resource_group_id.get(),
-            compressed_serialized_task_graph,
-            compressed_serialized_inputs,
-        };
         let pool = self.connection_pool.clone();
         let response = call_with_retry(self.retry_config, move || {
             let mut client = pool.get_client();
-            let request = request.clone();
+            let request = storage::RegisterJobRequest {
+                resource_group_id: resource_group_id.get(),
+                compressed_serialized_task_graph: compressed_serialized_task_graph.clone(),
+                compressed_serialized_inputs: compressed_serialized_inputs.clone(),
+            };
             async move { client.register_job(request).await }
         })
         .await
@@ -116,13 +115,12 @@ impl JobOrchestrationClient {
     /// * Forwards [`JobOrchestrationServiceClient::start_job`]'s status on failure.
     /// * Forwards [`job_state_response_to_result`]'s return values on failure.
     pub async fn start_job(&self, job_id: JobId) -> Result<JobState, ClientError> {
-        let request = storage::JobIdRequest {
-            job_id: job_id.get(),
-        };
         let pool = self.connection_pool.clone();
         let response = call_with_retry(self.retry_config, move || {
             let mut client = pool.get_client();
-            let request = request;
+            let request = storage::JobIdRequest {
+                job_id: job_id.get(),
+            };
             async move { client.start_job(request).await }
         })
         .await
@@ -145,13 +143,12 @@ impl JobOrchestrationClient {
     /// * Forwards [`JobOrchestrationServiceClient::cancel_job`]'s status on failure.
     /// * Forwards [`job_state_response_to_result`]'s return values on failure.
     pub async fn cancel_job(&self, job_id: JobId) -> Result<JobState, ClientError> {
-        let request = storage::JobIdRequest {
-            job_id: job_id.get(),
-        };
         let pool = self.connection_pool.clone();
         let response = call_with_retry(self.retry_config, move || {
             let mut client = pool.get_client();
-            let request = request;
+            let request = storage::JobIdRequest {
+                job_id: job_id.get(),
+            };
             async move { client.cancel_job(request).await }
         })
         .await
@@ -174,13 +171,12 @@ impl JobOrchestrationClient {
     /// * Forwards [`JobOrchestrationServiceClient::get_job_state`]'s status on failure.
     /// * Forwards [`job_state_response_to_result`]'s return values on failure.
     pub async fn get_job_state(&self, job_id: JobId) -> Result<JobState, ClientError> {
-        let request = storage::JobIdRequest {
-            job_id: job_id.get(),
-        };
         let pool = self.connection_pool.clone();
         let response = call_with_retry(self.retry_config, move || {
             let mut client = pool.get_client();
-            let request = request;
+            let request = storage::JobIdRequest {
+                job_id: job_id.get(),
+            };
             async move { client.get_job_state(request).await }
         })
         .await
@@ -205,13 +201,12 @@ impl JobOrchestrationClient {
     ///   [`ClientError::Deserialization`].
     /// * Forwards [`JobOrchestrationServiceClient::get_job_outputs`]'s status on failure.
     pub async fn get_job_outputs(&self, job_id: JobId) -> Result<Vec<TaskOutput>, ClientError> {
-        let request = storage::JobIdRequest {
-            job_id: job_id.get(),
-        };
         let pool = self.connection_pool.clone();
         let response = call_with_retry(self.retry_config, move || {
             let mut client = pool.get_client();
-            let request = request;
+            let request = storage::JobIdRequest {
+                job_id: job_id.get(),
+            };
             async move { client.get_job_outputs(request).await }
         })
         .await
@@ -234,13 +229,12 @@ impl JobOrchestrationClient {
     ///
     /// * Forwards [`JobOrchestrationServiceClient::get_job_error`]'s status on failure.
     pub async fn get_job_error(&self, job_id: JobId) -> Result<String, ClientError> {
-        let request = storage::JobIdRequest {
-            job_id: job_id.get(),
-        };
         let pool = self.connection_pool.clone();
         let response = call_with_retry(self.retry_config, move || {
             let mut client = pool.get_client();
-            let request = request;
+            let request = storage::JobIdRequest {
+                job_id: job_id.get(),
+            };
             async move { client.get_job_error(request).await }
         })
         .await

--- a/components/spider-client/src/grpc/resource_group.rs
+++ b/components/spider-client/src/grpc/resource_group.rs
@@ -73,11 +73,11 @@ impl ResourceGroupManagementClient {
             external_resource_group_id,
             password,
         };
-        let response = call_with_retry(self.retry_config, async || {
-            self.connection_pool
-                .get_client()
-                .add_resource_group(request.clone())
-                .await
+        let pool = self.connection_pool.clone();
+        let response = call_with_retry(self.retry_config, move || {
+            let mut client = pool.get_client();
+            let request = request.clone();
+            async move { client.add_resource_group(request).await }
         })
         .await
         .map_err(|status| resource_group_status_to_error(&status))?
@@ -107,11 +107,11 @@ impl ResourceGroupManagementClient {
             resource_group_id: resource_group_id.get(),
             password,
         };
-        call_with_retry(self.retry_config, async || {
-            self.connection_pool
-                .get_client()
-                .verify_resource_group(request.clone())
-                .await
+        let pool = self.connection_pool.clone();
+        call_with_retry(self.retry_config, move || {
+            let mut client = pool.get_client();
+            let request = request.clone();
+            async move { client.verify_resource_group(request).await }
         })
         .await
         .map_err(|status| resource_group_status_to_error(&status))?;

--- a/components/spider-client/src/grpc/resource_group.rs
+++ b/components/spider-client/src/grpc/resource_group.rs
@@ -69,14 +69,13 @@ impl ResourceGroupManagementClient {
         external_resource_group_id: String,
         password: Vec<u8>,
     ) -> Result<ResourceGroupId, ClientError> {
-        let request = storage::AddResourceGroupRequest {
-            external_resource_group_id,
-            password,
-        };
         let pool = self.connection_pool.clone();
         let response = call_with_retry(self.retry_config, move || {
             let mut client = pool.get_client();
-            let request = request.clone();
+            let request = storage::AddResourceGroupRequest {
+                external_resource_group_id: external_resource_group_id.clone(),
+                password: password.clone(),
+            };
             async move { client.add_resource_group(request).await }
         })
         .await
@@ -103,14 +102,13 @@ impl ResourceGroupManagementClient {
         resource_group_id: ResourceGroupId,
         password: Vec<u8>,
     ) -> Result<(), ClientError> {
-        let request = storage::VerifyResourceGroupRequest {
-            resource_group_id: resource_group_id.get(),
-            password,
-        };
         let pool = self.connection_pool.clone();
         call_with_retry(self.retry_config, move || {
             let mut client = pool.get_client();
-            let request = request.clone();
+            let request = storage::VerifyResourceGroupRequest {
+                resource_group_id: resource_group_id.get(),
+                password: password.clone(),
+            };
             async move { client.verify_resource_group(request).await }
         })
         .await

--- a/components/spider-utils/src/grpc/retry.rs
+++ b/components/spider-utils/src/grpc/retry.rs
@@ -1,6 +1,7 @@
 //! An async retry helper for transient gRPC call failures.
 
 use std::error::Error;
+use std::future::Future;
 use std::time::Duration;
 
 use rand::Rng;
@@ -43,7 +44,8 @@ impl Default for RetryConfig {
 ///
 /// * `ResponseType` - The success value produced by `grpc_call`.
 /// * `ErrorType` - The error produced by `grpc_call`.
-/// * `GrpcCall` - The async closure performing the gRPC call.
+/// * `GrpcCall` - The closure performing the gRPC call.
+/// * `FutureType` - The `Send` future returned by `grpc_call`.
 /// * `RetriableCheck` - Classifies an error as retriable or not.
 ///
 /// # Returns
@@ -60,7 +62,8 @@ impl Default for RetryConfig {
 pub async fn execute_with_retry<
     ResponseType,
     ErrorType,
-    GrpcCall: AsyncFnMut() -> Result<ResponseType, ErrorType>,
+    GrpcCall: FnMut() -> FutureType,
+    FutureType: Future<Output = Result<ResponseType, ErrorType>> + Send,
     RetriableCheck: Fn(&ErrorType) -> bool,
 >(
     max_retries: usize,
@@ -88,7 +91,8 @@ pub async fn execute_with_retry<
 /// # Type Parameters
 ///
 /// * `ResponseType` - The success value produced by `grpc_call`.
-/// * `GrpcCall` - The async closure performing the gRPC round-trip.
+/// * `GrpcCall` - The closure performing the gRPC round-trip.
+/// * `FutureType` - The `Send` future returned by `grpc_call`.
 ///
 /// # Returns
 ///
@@ -102,7 +106,8 @@ pub async fn execute_with_retry<
 ///   budget is exhausted.
 pub async fn call_with_retry<
     ResponseType,
-    GrpcCall: AsyncFnMut() -> Result<ResponseType, Status>,
+    GrpcCall: FnMut() -> FutureType,
+    FutureType: Future<Output = Result<ResponseType, Status>> + Send,
 >(
     retry_config: RetryConfig,
     grpc_call: GrpcCall,
@@ -164,7 +169,8 @@ fn backoff(retry: usize, max_backoff: Duration) -> Duration {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::Cell;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
     use std::time::Duration;
 
     use tonic::Code;
@@ -180,12 +186,12 @@ mod tests {
 
     #[tokio::test]
     async fn succeeds_on_first_attempt() {
-        let calls = Cell::new(0usize);
+        let calls = AtomicUsize::new(0);
         let result: Result<i32, i32> = execute_with_retry(
             3,
             TEST_MAX_BACKOFF,
             async || {
-                calls.set(calls.get() + 1);
+                calls.fetch_add(1, Ordering::Relaxed);
                 Ok(42)
             },
             |_error| true,
@@ -193,18 +199,17 @@ mod tests {
         .await;
 
         assert_eq!(result, Ok(42));
-        assert_eq!(calls.get(), 1);
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
     }
 
     #[tokio::test]
     async fn succeeds_after_retriable_failures() {
-        let calls = Cell::new(0usize);
+        let calls = AtomicUsize::new(0);
         let result: Result<i32, i32> = execute_with_retry(
             5,
             TEST_MAX_BACKOFF,
             async || {
-                let attempt = calls.get();
-                calls.set(attempt + 1);
+                let attempt = calls.fetch_add(1, Ordering::Relaxed);
                 if attempt < 2 { Err(-1) } else { Ok(7) }
             },
             |_error| true,
@@ -212,17 +217,17 @@ mod tests {
         .await;
 
         assert_eq!(result, Ok(7));
-        assert_eq!(calls.get(), 3);
+        assert_eq!(calls.load(Ordering::Relaxed), 3);
     }
 
     #[tokio::test]
     async fn non_retriable_error_returns_immediately() {
-        let calls = Cell::new(0usize);
+        let calls = AtomicUsize::new(0);
         let result: Result<i32, i32> = execute_with_retry(
             3,
             TEST_MAX_BACKOFF,
             async || {
-                calls.set(calls.get() + 1);
+                calls.fetch_add(1, Ordering::Relaxed);
                 Err(99)
             },
             |error| *error != 99,
@@ -230,18 +235,18 @@ mod tests {
         .await;
 
         assert_eq!(result, Err(99));
-        assert_eq!(calls.get(), 1);
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
     }
 
     #[tokio::test]
     async fn retries_are_exhausted() {
         let max_retries = 4usize;
-        let calls = Cell::new(0usize);
+        let calls = AtomicUsize::new(0);
         let result: Result<i32, i32> = execute_with_retry(
             max_retries,
             TEST_MAX_BACKOFF,
             async || {
-                calls.set(calls.get() + 1);
+                calls.fetch_add(1, Ordering::Relaxed);
                 Err(-7)
             },
             |_error| true,
@@ -249,7 +254,7 @@ mod tests {
         .await;
 
         assert_eq!(result, Err(-7));
-        assert_eq!(calls.get(), max_retries + 1);
+        assert_eq!(calls.load(Ordering::Relaxed), max_retries + 1);
     }
 
     #[tokio::test]
@@ -258,10 +263,9 @@ mod tests {
             max_retries: 5,
             max_backoff: TEST_MAX_BACKOFF,
         };
-        let calls = Cell::new(0usize);
+        let calls = AtomicUsize::new(0);
         let result: Result<i32, Status> = call_with_retry(config, async || {
-            let attempt = calls.get();
-            calls.set(attempt + 1);
+            let attempt = calls.fetch_add(1, Ordering::Relaxed);
             if attempt < 2 {
                 Err(Status::unavailable("connection lost"))
             } else {
@@ -274,7 +278,7 @@ mod tests {
             result.expect("call_with_retry should succeed after retriable failures"),
             11
         );
-        assert_eq!(calls.get(), 3);
+        assert_eq!(calls.load(Ordering::Relaxed), 3);
     }
 
     #[tokio::test]
@@ -283,9 +287,9 @@ mod tests {
             max_retries: 5,
             max_backoff: TEST_MAX_BACKOFF,
         };
-        let calls = Cell::new(0usize);
+        let calls = AtomicUsize::new(0);
         let result: Result<i32, Status> = call_with_retry(config, async || {
-            calls.set(calls.get() + 1);
+            calls.fetch_add(1, Ordering::Relaxed);
             Err(Status::not_found("missing"))
         })
         .await;
@@ -296,7 +300,7 @@ mod tests {
                 .code(),
             Code::NotFound
         );
-        assert_eq!(calls.get(), 1);
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
     }
 
     #[test]


### PR DESCRIPTION

<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Since #396 routed the client's gRPC calls through the `spider-utils` retry helper, each call site passed an `async` closure (`AsyncFnMut`) to `call_with_retry`. The future such a closure returns is an anonymous, unnameable type, so there was no way to require it to be `Send` — and in practice it wasn't. As a result, a `SpiderClient` call could not be `tokio::spawn`ed on a multi-threaded runtime, which is the common way callers drive concurrent jobs.

This PR makes every future returned by the `spider-client` public API `Send`, and adds compile-time assertions so the guarantee cannot silently regress.

The change has three parts:

**1. `spider-utils` retry helper — bound the returned future as `Send`.** `execute_with_retry` and `call_with_retry` now take `GrpcCall: FnMut() -> FutureType` with `FutureType: Future<Output = ...> + Send`, replacing the previous `AsyncFnMut() -> Result<...>`. Naming the future via an explicit type parameter is what lets us attach the `+ Send` bound; an `async` closure's future cannot be named, so it cannot be bounded. This is the mechanism behind the whole PR. The retry loop still reconstructs a fresh future per attempt — the closure is a future *producer*, not a single future — so retry semantics are unchanged. The helper's only callers are the two `spider-client` files updated in this same PR, so no other code is affected.

**2. `spider-client` call sites — plain closures returning owned futures.** Each gRPC call now uses a plain `move ||` closure that acquires a pooled client, builds the request, and returns an owned `async move { ... }` future, rather than an `async` closure that borrows captured state. Request construction was additionally moved *inside* the closure for every call so each retry attempt mints its own owned request; `Copy` id fields (`JobId`, `ResourceGroupId`) are used directly, while owned fields (`Vec<u8>`, `String`) are cloned per attempt — the same per-attempt clone the previous code already performed, just relocated. This keeps the produced futures free of borrowed, non-`Send` state.

**3. `SpiderClient`-level compile-time assertions.** `client.rs` now asserts, at compile time and zero runtime cost, that `SpiderClient` and `SpiderClientBuilder` are `Send + Sync`, and that every public async method (`submit_job`, `start_job`, `cancel_job`, `get_job_state`, `get_job_outputs`, `get_job_error`, `add_resource_group`, `verify_resource_group`) returns a `Send` future. The type-level check alone does not cover the futures, so both are needed: a future that captures a non-`Send` value across an `.await` would break spawnability while the handle stays `Send + Sync`.

Note on the retry unit tests: they switched their shared invocation counter from `Cell<usize>` to `AtomicUsize`. This is a direct consequence of the new `FutureType: Send` bound — the test closures capture the counter by shared reference across an `.await`, and `&T` is `Send` only when `T: Sync`. `Cell` is `!Sync`, so it no longer satisfies the bound; `AtomicUsize` is `Sync` and is the minimal fix.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
- [x] Ensure all workflows pass.
- [x] Add compile-time assertion to make sure the request APIs are `Send`.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability for job submission, starting, cancellation, status checks, outputs, and error retrieval by re-establishing gRPC call context on retries.
  - Resource group creation and verification now handle transient connection issues more consistently during retries.
- **Tests**
  - Expanded and strengthened retry unit tests to confirm the expected number of retry attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->