### PR TITLE
fix(spider-execution-manager): Frame a commit task's empty inputs as a valid wire frame.

### DIFF
--- a/components/spider-execution-manager/src/process_pool.rs
+++ b/components/spider-execution-manager/src/process_pool.rs
@@ -406,7 +406,13 @@ fn build_request(request: ExecuteRequest) -> Result<Request, InternalError> {
         serialized_task_io,
     } = ctx;
     let (raw_inputs, serialized_task_graph_outputs) = if task_id == TaskId::Commit {
-        (Vec::new(), Some(serialized_task_io))
+        // A commit task takes no value-params, but the executor still unframes `raw_inputs` as a
+        // wire-format stream. Therefore, it must be a valid empty frame (a zero-count header), not
+        // an empty byte buffer.
+        (
+            spider_core::types::io::TaskInputsSerializer::new().release(),
+            Some(serialized_task_io)
+        )
     } else {
         (serialized_task_io, None)
     };

--- a/components/spider-execution-manager/src/process_pool.rs
+++ b/components/spider-execution-manager/src/process_pool.rs
@@ -480,7 +480,10 @@ mod tests {
             panic!("build_request must produce a Request::Execute");
         };
 
-        assert!(raw_inputs.is_empty());
+        assert_eq!(
+            raw_inputs,
+            spider_core::types::io::TaskInputsSerializer::new().release()
+        );
         let ctx: TaskContext = rmp_serde::from_slice(&raw_ctx)?;
         assert_eq!(ctx.get_task_graph_outputs()?, Some(outputs));
         Ok(())
@@ -506,7 +509,10 @@ mod tests {
             panic!("build_request must produce a Request::Execute");
         };
 
-        assert!(raw_inputs.is_empty());
+        assert_eq!(
+            raw_inputs,
+            spider_core::types::io::TaskInputsSerializer::new().release()
+        );
         let ctx: TaskContext = rmp_serde::from_slice(&raw_ctx)?;
         assert_eq!(ctx.get_task_graph_outputs()?, Some(Vec::new()));
         Ok(())

--- a/components/spider-execution-manager/src/process_pool.rs
+++ b/components/spider-execution-manager/src/process_pool.rs
@@ -411,7 +411,7 @@ fn build_request(request: ExecuteRequest) -> Result<Request, InternalError> {
         // an empty byte buffer.
         (
             spider_core::types::io::TaskInputsSerializer::new().release(),
-            Some(serialized_task_io)
+            Some(serialized_task_io),
         )
     } else {
         (serialized_task_io, None)


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Task executor expects the task inputs to be a valid wire-framed byte buffer. In #390, we simply set this to an empty buffer, causing the task executor to fail on a commit task.

This PR fixes this problem by setting the input buffer to a valid wire-framed sequence with 0 frames.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Ensure all workflows pass.
* [x] Ensure CLP integration's commit task worked as expected with this fix. Branch: https://github.com/LinZhihao-723/clp/tree/compression-coordinator-e2e-dev

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved commit task request handling by sending a valid empty input frame.
  * Prevented potential input decoding issues during commit task execution.
  * Updated commit-task tests to match the new empty-frame behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->