### PR TITLE
fix(spider-execution-manager)!: Remove IP address from config; Use fixed IP address for storage-side registration.

### DIFF
--- a/components/spider-execution-manager/src/config.rs
+++ b/components/spider-execution-manager/src/config.rs
@@ -1,4 +1,3 @@
-use std::net::IpAddr;
 use std::num::NonZeroU64;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
@@ -11,9 +10,6 @@ use crate::runtime::RuntimeConfig;
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Config {
-    /// The IP address the execution manager hosts on.
-    pub host: IpAddr,
-
     /// The endpoint of the storage gRPC server.
     pub storage: EndpointConfig,
 
@@ -45,7 +41,6 @@ impl Config {
     #[must_use]
     pub fn runtime_config(&self) -> RuntimeConfig {
         RuntimeConfig {
-            em_ip: self.host,
             heartbeat_interval: Duration::from_secs(
                 self.liveness.storage_heartbeat_interval_sec.get(),
             ),

--- a/components/spider-execution-manager/src/runtime.rs
+++ b/components/spider-execution-manager/src/runtime.rs
@@ -1,7 +1,7 @@
 //! Runtime — the execution manager's main loop.
 
 use std::collections::VecDeque;
-use std::net::IpAddr;
+use std::net::Ipv4Addr;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -34,9 +34,6 @@ use crate::process_pool::{self};
 /// Static configuration for a [`Runtime`]. Supplied once at bootstrap and never mutated.
 #[derive(Debug, Clone)]
 pub struct RuntimeConfig {
-    /// IP address advertised to storage at registration.
-    pub em_ip: IpAddr,
-
     /// Interval between liveness heartbeats. Handed verbatim to the liveness actor.
     pub heartbeat_interval: Duration,
 
@@ -140,7 +137,11 @@ impl<
         liveness_client: LivenessClientType,
         config: RuntimeConfig,
     ) -> Result<(Self, CancellationToken), RuntimeError> {
-        let registration = liveness_client.register(config.em_ip).await?;
+        // Locality metadata is not available yet, so register a placeholder address.
+        // See https://github.com/y-scope/spider/issues/406 for detail.
+        let registration = liveness_client
+            .register(Ipv4Addr::UNSPECIFIED.into())
+            .await?;
         let em_id = registration.em_id;
         let session_tracker = SessionTracker::new(registration.session_id);
         tracing::info!(

--- a/components/spider-execution-manager/src/runtime.rs
+++ b/components/spider-execution-manager/src/runtime.rs
@@ -137,8 +137,8 @@ impl<
         liveness_client: LivenessClientType,
         config: RuntimeConfig,
     ) -> Result<(Self, CancellationToken), RuntimeError> {
-        // Locality metadata is not available yet, so register a placeholder address.
-        // See https://github.com/y-scope/spider/issues/406 for detail.
+        // TODO: Register with a placeholder address. This should be updated when the system needs
+        // to store locality metadata. See https://github.com/y-scope/spider/issues/406 for detail.
         let registration = liveness_client
             .register(Ipv4Addr::UNSPECIFIED.into())
             .await?;

--- a/tests/huntsman/em-runtime/tests/test_runtime.rs
+++ b/tests/huntsman/em-runtime/tests/test_runtime.rs
@@ -7,6 +7,8 @@
 //!
 //! All tests are `#[ignore]` so the workspace's plain `cargo test` doesn't run them.
 
+use std::net::IpAddr;
+use std::net::Ipv4Addr;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -118,15 +120,10 @@ async fn wait_until(predicate: impl Fn() -> bool, timeout: Duration) -> bool {
 /// # Returns
 ///
 /// A [`RuntimeConfig`] ready to hand to [`Runtime::create`].
-///
-/// # Panics
-///
-/// Panics if the hard-coded loopback ip fails to parse — never in practice.
 fn runtime_config(heartbeat_interval: Duration) -> RuntimeConfig {
     let unique = ExecutionManagerId::random();
     let log_dir = std::env::temp_dir().join(format!("spider-em-runtime-test-{unique}"));
     RuntimeConfig {
-        em_ip: "127.0.0.1".parse().expect("parse loopback"),
         heartbeat_interval,
         scheduler_heartbeat_interval: heartbeat_interval,
         scheduler_poll_wait_ms: SCHEDULER_POLL_WAIT_MS,

--- a/tests/huntsman/em-runtime/tests/test_runtime.rs
+++ b/tests/huntsman/em-runtime/tests/test_runtime.rs
@@ -7,8 +7,6 @@
 //!
 //! All tests are `#[ignore]` so the workspace's plain `cargo test` doesn't run them.
 
-use std::net::IpAddr;
-use std::net::Ipv4Addr;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

> [!Note]
> This PR is a breaking change because it change the configuration.

# Description

The execution manager currently requires an IP address in its configuration and stores that address
through the registration protocol. The address is reserved for future locality support and is not
used, causing confusion and extra complexity.

This PR:

* Removes `host` from the execution-manager configuration and `em_ip` from `RuntimeConfig`.
* Registers every execution manager with `0.0.0.0` as a temporary placeholder.
* Links the workaround to #406, which tracks replacing the placeholder with locality metadata.

The existing protobuf and database contracts remain unchanged.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* [x] GitHub workflows pass.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Improvements**
  * Simplified execution manager configuration by removing the requirement to provide a dedicated host IP address.
  * Updated service registration to use a flexible network address, improving compatibility across deployment environments.
  * Preserved existing heartbeat, scheduling, task execution, and logging behaviour.
* **Tests**
  * Adjusted runtime configuration test setup to stop requiring a loopback IP value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->