### PR TITLE
feat(spider-storage): Release task control blocks when a job leaves the `Running` state.

### DIFF
--- a/components/spider-storage/src/cache/job.rs
+++ b/components/spider-storage/src/cache/job.rs
@@ -424,6 +424,7 @@ impl<
                 .send_commit_ready(jcb.owner_id, jcb.id)
                 .await?;
         }
+        job.task_graph.finalize();
         Ok(job.state)
     }
 
@@ -635,6 +636,7 @@ impl<
                 .send_cleanup_ready(jcb.owner_id, jcb.id)
                 .await?;
         }
+        job.task_graph.finalize();
         Ok(job.state)
     }
 

--- a/components/spider-storage/src/cache/task.rs
+++ b/components/spider-storage/src/cache/task.rs
@@ -169,6 +169,15 @@ impl TaskGraph {
         }
     }
 
+    /// Finalizes the task graph, indicating the job state has transitioned from
+    /// [`JobState::Running`] to the next state.
+    ///
+    /// At this stage, all TCBs are explicitly removed. This implies the internal data dependencies
+    /// are also removed if they are no longer referenced by any TCB(s).
+    pub fn finalize(&mut self) {
+        self.tasks.clear();
+    }
+
     /// Marks all TCBs and commit TCB as cancelled, if not terminated.
     pub async fn cancel_non_terminal(&mut self) {
         for tcb in &self.tasks {


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

A job's `TaskGraph` holds one TCB per task, and each TCB transitively holds the shared data-dependency payloads that flow between tasks. Once a job leaves `JobState::Running`, none of these regular TCBs are needed anymore: the remaining work is driven by the commit or cleanup task, and any outputs required downstream have already been captured separately. Until now, however, the full TCB vector (and everything it kept alive) was retained for the lifetime of the JCB, so a completed or cancelled job kept holding onto its entire task graph in memory.

This PR adds `TaskGraph::finalize`, which clears the regular TCBs at each transition out of `Running`, releasing the TCBs and — because the data dependencies are only reachable through them — the associated dataflow payloads as well. This aligns the in-memory representation of a finalized job with what the recovery paths already produce, where `tasks` is initialized empty.

## Add `TaskGraph::finalize` (`cache/task.rs`)

- Clears the `tasks` vector, dropping every regular TCB. The `outputs`, commit TCB, and cleanup TCB are left untouched, since the post-`Running` states still depend on them.

## Finalize on transitions out of `Running` (`cache/job.rs`)

- After the success path commits job outputs and transitions to `CommitReady`/`Succeeded`, the task graph is finalized.
- After the cancellation path transitions to `CleanupReady`/`Cancelled`, the task graph is finalized. This runs after `cancel_non_terminal`, so any non-terminal TCBs are still marked cancelled before being released.
- The failure path (transition to `Failed`) deliberately does **not** finalize. A failed job's task graph is retained so that its internal data remains available for future investigation of what went wrong.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Ensure all workflows pass.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job completion and cancellation handling by finalizing task state transitions consistently.
  * Cleared cached task data after jobs reach a final state, helping prevent stale task information from persisting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->