### PR TITLE
refactor(spider-scheduler)!: Use explicit fields in scheduler config instead of YAML tags.

### DIFF
--- a/components/spider-scheduler/src/config.rs
+++ b/components/spider-scheduler/src/config.rs
@@ -33,10 +33,10 @@ pub struct ServerConfig {
     pub runtime: RuntimeConfig,
 }
 
-/// The configuration that selects and configures the scheduler core's scheduling algorithm.
+/// The configuration that selects and configures the scheduler core's scheduling policy.
 #[derive(Clone, Debug, Deserialize)]
 #[serde(
-    tag = "algorithm",
+    tag = "policy",
     content = "config",
     rename_all = "snake_case",
     deny_unknown_fields

--- a/components/spider-scheduler/src/config.rs
+++ b/components/spider-scheduler/src/config.rs
@@ -35,7 +35,12 @@ pub struct ServerConfig {
 
 /// The configuration that selects and configures the scheduler core's scheduling algorithm.
 #[derive(Clone, Debug, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[serde(
+    tag = "algorithm",
+    content = "config",
+    rename_all = "snake_case",
+    deny_unknown_fields
+)]
 pub enum SchedulerConfig {
     /// The round-robin scheduling algorithm.
     RoundRobin(RoundRobinConfig),


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

> [!Note]
> This PR is a breaking change because it changes the scheduler configuration schema.

# Description

The scheduler currently relies on Serde's externally tagged enum representation to select its scheduling algorithm. With the pinned `yaml_serde` version, that representation requires a YAML tag such as `!round_robin`; the nested-map form proposed for the Helm chart does not deserialize. YAML tags are also difficult to express and override through Helm, as discusses in #403.

This PR changes `SchedulerConfig` to Serde's adjacently tagged representation, giving the algorithm and its configuration explicit fields:

```yaml
scheduler:
  algorithm: "round_robin"
  config:
    active_job_queue_capacity: 64
    dispatch_queue_capacity: 64
    # ...
```

The new shape is supported directly by Serde, avoids custom algorithm-selection logic, and lets Helm users override the algorithm or an individual configuration value without encoding the algorithm as a map key. Unknown top-level scheduler fields are rejected to catch configuration mistakes early.

Existing scheduler configuration files must migrate from the YAML-tag representation to the `algorithm` and `config` fields.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title.
* [x] No documentation changes are included because the current documentation is outdated.

# Validation performed

* [ ] GitHub workflows pass.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened scheduler configuration validation to require an explicit policy and the expected configuration structure.
  * Deserialization is now stricter: any unknown or unexpected configuration fields are rejected instead of being silently ignored.
  * Overall, this helps surface misconfigurations earlier and reduces runtime surprises.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->