### PR TITLE
feat(helm): Add workflow for publishing the Helm chart to GitHub Pages.

### DIFF
--- a/.github/workflows/code-linting-checks.yaml
+++ b/.github/workflows/code-linting-checks.yaml
@@ -36,7 +36,7 @@ jobs:
   lint-common:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
+      - uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"  # v7.0.1
         with:
           submodules: "recursive"
 

--- a/.github/workflows/code-linting-checks.yaml
+++ b/.github/workflows/code-linting-checks.yaml
@@ -38,7 +38,6 @@ jobs:
     steps:
       - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
         with:
-          fetch-depth: 0
           submodules: "recursive"
 
       - uses: "./tools/yscope-dev-utils/exports/github/actions/install-python"
@@ -53,8 +52,6 @@ jobs:
       - run: "task lint:toml-check"
 
       - run: "task lint:yml-check"
-
-      - run: "task lint:check-helm"
 
   lint-cpp:
     needs: "filter-relevant-changes"

--- a/.github/workflows/spider-helm.yaml
+++ b/.github/workflows/spider-helm.yaml
@@ -67,7 +67,6 @@ jobs:
       - uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"  # v7.0.1
         with:
           persist-credentials: false
-          persist-credentials: false
           submodules: "recursive"
 
       - uses: "./tools/yscope-dev-utils/exports/github/actions/install-go-task"

--- a/.github/workflows/spider-helm.yaml
+++ b/.github/workflows/spider-helm.yaml
@@ -1,0 +1,120 @@
+name: "spider-helm"
+
+on:
+  pull_request:
+    paths: &monitored_paths
+      - ".github/workflows/spider-helm.yaml"
+      - "taskfile.yaml"
+      - "taskfiles/**"
+      - "tools/deployment/spider-helm/**"
+      - "tools/yscope-dev-utils"
+  push:
+    paths: *monitored_paths
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+
+  # Cancel in-progress jobs for efficiency. Exclude the `main` branch to allow uninterrupted
+  # publishing of Helm charts.
+  cancel-in-progress: "${{github.ref != 'refs/heads/main'}}"
+
+jobs:
+  lint:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
+        with:
+          submodules: "recursive"
+
+          # Fetch all history for all branches; otherwise, `helm lint` would complain about not
+          # finding the `origin/main` branch.
+          fetch-depth: 0
+
+      - uses: "./tools/yscope-dev-utils/exports/github/actions/install-python"
+        with:
+          version: "3.10"
+
+      - uses: "./tools/yscope-dev-utils/exports/github/actions/install-go-task"
+        with:
+          version: "3.48.0"
+
+      - name: "Lint Helm charts"
+        shell: "bash"
+        run: "task lint:check-helm"
+
+  publish:
+    # Publish from `main` and `spider-huntsman-vA.B.C` release branches.
+    if: >-
+      github.event_name != 'pull_request'
+      && (github.ref == 'refs/heads/main'
+      || startsWith(github.ref, 'refs/heads/spider-huntsman-v'))
+    needs: "lint"
+    runs-on: "ubuntu-latest"
+    permissions:
+      # To push to the `gh-pages` branch.
+      contents: "write"
+    steps:
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
+        with:
+          persist-credentials: false
+          submodules: "recursive"
+
+      - uses: "./tools/yscope-dev-utils/exports/github/actions/install-go-task"
+        with:
+          version: "3.48.0"
+
+      - name: "Package Helm chart"
+        shell: "bash"
+        run: "task helm:package"
+
+      - name: "Checkout branch `gh-pages`"
+        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
+        with:
+          path: "gh-pages"
+          ref: "gh-pages"
+
+      - name: "Get chart version"
+        id: "get-chart-version"
+        uses: "mikefarah/yq@065b200af9851db0d5132f50bc10b1406ea5c0a8"  # v4.50.1
+        with:
+          cmd: "yq '.version' 'tools/deployment/spider-helm/Chart.yaml'"
+
+      - name: "Update Helm repository"
+        id: "update-helm-repo"
+        shell: "bash"
+        run: |-
+          chart_tgz="spider-${{steps.get-chart-version.outputs.result}}.tgz"
+
+          # Skip if this chart version already exists.
+          if [[ -f "gh-pages/${chart_tgz}" ]]; then
+            echo "Chart ${chart_tgz} already exists, skipping publish."
+            echo "skip_publish=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          cp "build/spider-helm"/*.tgz "gh-pages/"
+
+          # Update index.yaml, merging with existing index if present.
+          . "build/toolchains/helm/env"
+          url="${{github.server_url}}/${{github.repository}}/raw/gh-pages"
+          if [[ -f "gh-pages/index.yaml" ]]; then
+            helm repo index "gh-pages" --merge "gh-pages/index.yaml" --url "${url}"
+          else
+            helm repo index "gh-pages" --url "${url}"
+          fi
+
+      - name: "Push to gh-pages branch"
+        if: "steps.update-helm-repo.outputs.skip_publish != 'true'"
+        shell: "bash"
+        working-directory: "gh-pages"
+        run: |-
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git add "*.tgz" "index.yaml"
+          commit_message="ci(helm): Publish spider-${{steps.get-chart-version.outputs.result}}"
+          commit_message+=" from ${{github.ref_name}} (${{github.sha}})."
+          git commit -m "$commit_message"
+          git push

--- a/.github/workflows/spider-helm.yaml
+++ b/.github/workflows/spider-helm.yaml
@@ -19,13 +19,17 @@ concurrency:
 
   # Cancel in-progress jobs for efficiency. Exclude the `main` branch to allow uninterrupted
   # publishing of Helm charts.
-  cancel-in-progress: "${{github.ref != 'refs/heads/main'}}"
+  cancel-in-progress: >-
+    ${{
+      github.ref != 'refs/heads/main'
+      && !startsWith(github.ref, 'refs/heads/spider-huntsman-v')
+    }}
 
 jobs:
   lint:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
+      - uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"  # v7.0.1
         with:
           submodules: "recursive"
 
@@ -53,12 +57,16 @@ jobs:
       || startsWith(github.ref, 'refs/heads/spider-huntsman-v'))
     needs: "lint"
     runs-on: "ubuntu-latest"
+    concurrency:
+      group: "${{github.workflow}}-gh-pages"
+      cancel-in-progress: false
     permissions:
       # To push to the `gh-pages` branch.
       contents: "write"
     steps:
-      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
+      - uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"  # v7.0.1
         with:
+          persist-credentials: false
           persist-credentials: false
           submodules: "recursive"
 
@@ -71,14 +79,14 @@ jobs:
         run: "task helm:package"
 
       - name: "Checkout branch `gh-pages`"
-        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"  # v7.0.1
         with:
           path: "gh-pages"
           ref: "gh-pages"
 
       - name: "Get chart version"
         id: "get-chart-version"
-        uses: "mikefarah/yq@065b200af9851db0d5132f50bc10b1406ea5c0a8"  # v4.50.1
+        uses: "mikefarah/yq@1b9b4ac5187171d2e5e3129be0cfa827c7f9d53d"  # v4.53.3
         with:
           cmd: "yq '.version' 'tools/deployment/spider-helm/Chart.yaml'"
 

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -7,6 +7,7 @@ includes:
   deps: "taskfiles/deps.yaml"
   docker: "taskfiles/docker.yaml"
   docs: "taskfiles/docs.yaml"
+  helm: "taskfiles/helm.yaml"
   lint: "taskfiles/lint.yaml"
   test: "taskfiles/test.yaml"
   utils: "tools/yscope-dev-utils/exports/taskfiles/utils/utils.yaml"

--- a/taskfiles/helm.yaml
+++ b/taskfiles/helm.yaml
@@ -1,0 +1,19 @@
+version: "3"
+
+includes:
+  toolchains: "toolchains.yaml"
+
+vars:
+  G_SPIDER_HELM_BUILD_DIR: "{{.G_BUILD_DIR}}/spider-helm"
+
+tasks:
+  package:
+    vars:
+      OUTPUT_DIR: "{{.G_SPIDER_HELM_BUILD_DIR}}"
+    deps: ["toolchains:helm"]
+    cmds:
+      - "rm -rf '{{.OUTPUT_DIR}}'"
+      - "mkdir -p '{{.OUTPUT_DIR}}'"
+      - |-
+        . "{{.G_HELM_TOOLCHAIN_ENV_FILE}}"
+        helm package "{{.ROOT_DIR}}/tools/deployment/spider-helm" --destination "{{.OUTPUT_DIR}}"


### PR DESCRIPTION
# Description

This PR adds a GitHub Actions workflow to lint and publish the Spider Helm chart to a GitHub Pages-backed Helm repository (`https://github.com/y-scope/spider/raw/gh-pages`), so that downstream charts (e.g., CLP's) can consume it as a dependency via `helm dependency update` instead of vendoring a copy of the chart through http download.


## Note for reviewer:
The implementation mirrors CLP's proven chart-publishing workflow: [`clp-package-helm.yaml`](https://github.com/y-scope/clp/blob/main/.github/workflows/clp-package-helm.yaml) but adapted to this repo's conventions. The change is mostly following y-scope/clp#1891's implementation.


## Note for Spider maintainers: 

### One-time setup required:

The `publish` job checks out the `gh-pages` branch, which doesn't exist yet. It must be created once (as an empty orphan branch) before the first publish:

```bash
git switch --orphan gh-pages
git commit --allow-empty -m "ci(helm): Initialize Helm repository branch."
git push origin gh-pages
```

After the first publish, the repository is consumable via:

```bash
helm repo add spider https://github.com/y-scope/spider/raw/gh-pages
helm search repo spider --versions
```

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

> [!NOTE]
> The checks below were run against the [fork `20001020ycx/spider`](https://github.com/20001020ycx/spider) at this PR's head commit, with `gh-pages` created there per the maintainers' note above.

## 1. Pushing to `main` publishes the chart to `gh-pages`

1. Create the one-time `gh-pages` branch, then fast-forward the fork's `main` to this PR's head commit.

   ```bash
   git switch --orphan gh-pages
   git commit --allow-empty -m "ci(helm): Initialize Helm repository branch."
   git push origin gh-pages
   git push origin <this PR's head commit>:main
   ```

   Expected: the push triggers a `spider-helm` run on `main` in which `lint` and `publish` both succeed ([fork run](https://github.com/20001020ycx/spider/actions/runs/30028892033)).

## 2. `helm dependency update` downloads the chart from the repository 

1. Declare the published chart as a dependency of a scratch parent chart, then resolve it.

   ```bash
   mkdir fake-parent && cat > fake-parent/Chart.yaml <<'EOF'
   apiVersion: "v2"
   name: "fake-parent"
   version: "0.1.0"
   dependencies:
     - name: "spider"
       version: "0.1.2"
       repository: "https://github.com/20001020ycx/spider/raw/gh-pages"
       condition: "spider.enabled"
   EOF
   helm dependency update fake-parent
   ```

   Expected: `Downloading spider from repo https://github.com/20001020ycx/spider/raw/gh-pages`; `fake-parent/charts/spider-0.1.2.tgz` appears; `fake-parent/Chart.lock` pins `digest: sha256:f12a4bd42da43a0e4a89acef7d3f879891127fb8b2e42f6ea1b74b88243eefe4`.

2. Verify the downloaded subchart renders through the parent and honors its `condition` gate.

   ```bash
   helm template test fake-parent --set spider.enabled=true | grep -c '^# Source: fake-parent/charts/spider/'   # -> 8
   helm template test fake-parent --set spider.enabled=false | grep -c '^# Source:'   # -> 0
   ```

3. Verify `helm dependency build` reproduces `charts/` from `Chart.lock` alone.

   ```bash
   rm -rf fake-parent/charts
   helm dependency build fake-parent
   ls fake-parent/charts   # -> spider-0.1.2.tgz
   ```

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated workflow to lint, package, and publish the Spider Helm chart.
  * Added Helm chart packaging automation and publishing to the chart repository (including index updates) for eligible releases.

* **Bug Fixes**
  * Updated CI linting flow so Helm validation runs via the dedicated Helm workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


