### PR TITLE
feat(helm)!: Add env/volume injection hooks to the worker Deployment.

### DIFF
--- a/tools/deployment/spider-helm/Chart.yaml
+++ b/tools/deployment/spider-helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: "v2"
 name: "spider"
 description: "A Helm chart for the Spider Huntsman deployment"
 type: "application"
-version: "0.1.3"
+version: "0.1.4"
 appVersion: "0.1.0"
 home: "https://github.com/y-scope/spider"
 sources: ["https://github.com/y-scope/spider"]

--- a/tools/deployment/spider-helm/templates/worker-deployment.yaml
+++ b/tools/deployment/spider-helm/templates/worker-deployment.yaml
@@ -24,17 +24,20 @@ spec:
           command: ["spider-execution-manager", "--config", "/etc/spider/execution-manager.yaml"]
           {{- with .Values.spiderConfig.worker.extra_envs }}
           env:
-            {{- range $name, $value := . }}
-            - name: {{ $name | quote }}
-              value: {{ $value | quote }}
-            {{- end }}
+            {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: "config"
               mountPath: "/etc/spider/execution-manager.yaml"
               subPath: "execution-manager.yaml"
               readOnly: true
+            {{- with .Values.spiderConfig.worker.extra_volume_mounts }}
+            {{- tpl (toYaml .) $ | nindent 12 }}
+            {{- end }}
       volumes:
         - name: "config"
           configMap:
             name: {{ include "spider.componentFullname" (dict "root" . "component" "config") }}
+        {{- with .Values.spiderConfig.worker.extra_volumes }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}

--- a/tools/deployment/spider-helm/values.yaml
+++ b/tools/deployment/spider-helm/values.yaml
@@ -75,5 +75,7 @@ spiderConfig:
         task_capacity: 1048576
 
   worker:
-    extra_envs: {}
+    extra_envs: []
+    extra_volume_mounts: []
+    extra_volumes: []
     replicas: 4


### PR DESCRIPTION
# Description

When this chart is consumed as a subchart, the worker container often needs consumer-specific runtime env vars, volumes, and volume mounts. This PR adds the wiring for such configuration to be passed to the worker Deployment through values at install time (the validation section below shows an example of what a user may supply):
 * `spiderConfig.worker.extra_envs` becomes a list of raw `EnvVar` objects.
    * The previous map form could only render literal `name: value` string pairs, which limits the semantic, structured fields like `valueFrom.secretKeyRef` cannot be expressed.
  * New `spiderConfig.worker.extra_volume_mounts` / `extra_volumes` hooks accept raw `VolumeMount` / `Volume` objects.


> [!NOTE]
> This is a breaking change because `spiderConfig.worker.extra_envs` changes from a map (`name: value`) to a list of raw `EnvVar` objects, so values written against chart `0.1.3` would render an invalid Deployment after upgrading.



# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

## 1. The hooks render `valueFrom` env vars, extra mounts, and extra volumes

1. Render the worker Deployment with all three hooks populated.

   ```bash
   cat > /tmp/hook-test-values.yaml <<'VALUES'
   spiderConfig:
     worker:
       extra_envs:
         - name: "CLP_DB_USER"
           valueFrom:
             secretKeyRef:
               name: "test-clp-database"
               key: "username"
       extra_volume_mounts:
         - name: "staged-archives"
           mountPath: "/var/data/staged-archives"
       extra_volumes:
         - name: "staged-archives"
           emptyDir: {}
   VALUES
   helm template test tools/deployment/spider-helm -f /tmp/hook-test-values.yaml --show-only templates/worker-deployment.yaml
   ```

   Expected: the container gets the env var with `valueFrom.secretKeyRef` and the `/var/data/staged-archives` mount, and the pod gets the `emptyDir` volume, each appended after the existing `config` entries.

## 2. Default values render an unchanged worker Deployment

1. Render with default values and diff against the chart before this change.

   ```bash
   helm template test tools/deployment/spider-helm --show-only templates/worker-deployment.yaml
   ```

   Expected: byte-identical to the `0.1.3` render except the `helm.sh/chart: spider-0.1.4` labels — no `env:` key, no empty list items.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable extra environment variables, volume mounts, and volumes for worker deployments.
  * Improved flexibility for customizing worker container and pod settings.

* **Bug Fixes**
  * Corrected the expected configuration format for additional environment variables.

* **Chores**
  * Updated the deployment chart version to 0.1.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->