### PR TITLE
fix(huntsman): Add `SIGTERM` listener for storage server, scheduler server, and execution manager (fixes #393). 

### DIFF
--- a/components/spider-execution-manager/src/bin/execution_manager.rs
+++ b/components/spider-execution-manager/src/bin/execution_manager.rs
@@ -11,6 +11,8 @@ use spider_execution_manager::client::grpc::GrpcStorageClient;
 use spider_execution_manager::runtime::Runtime;
 use spider_utils::config::YamlConfig;
 use spider_utils::logging::set_up_logging;
+use tokio::signal::unix::SignalKind;
+use tokio::signal::unix::signal;
 
 /// Command-line arguments for the execution manager.
 #[derive(Debug, Parser)]
@@ -63,6 +65,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     tracing::info!(em_id, "Execution manager started.");
     let mut run_handle = tokio::spawn(runtime.run());
+    let mut sigterm = signal(SignalKind::terminate()).inspect_err(
+        |error| tracing::error!(em_id, error = % error, "Failed to register SIGTERM handler."),
+    )?;
 
     let () = tokio::select! {
         result = tokio::signal::ctrl_c() => {
@@ -70,6 +75,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 tracing::error!(em_id, error = % error, "Failed to listen for Ctrl-C.");
             }
             tracing::info!(em_id, "Received Ctrl-C. Shutting down execution manager.");
+            cancellation_token.cancel();
+            run_handle.await
+        }
+        _ = sigterm.recv() => {
+            tracing::info!(em_id, "Received SIGTERM. Shutting down execution manager.");
             cancellation_token.cancel();
             run_handle.await
         }

--- a/components/spider-scheduler/src/bin/grpc_server.rs
+++ b/components/spider-scheduler/src/bin/grpc_server.rs
@@ -14,6 +14,8 @@ use spider_utils::config::YamlConfig;
 use spider_utils::logging::set_up_logging;
 use tokio::net::TcpListener;
 use tokio::select;
+use tokio::signal::unix::SignalKind;
+use tokio::signal::unix::signal;
 use tonic::transport::Server;
 use tonic::transport::server::TcpIncoming;
 
@@ -58,6 +60,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         |error| tracing::error!(error = % error, "Failed to bind scheduler listen address."),
     )?;
     let incoming = TcpIncoming::from(listener);
+    let mut sigterm = signal(SignalKind::terminate()).inspect_err(
+        |error| tracing::error!(error = % error, "Failed to register SIGTERM handler."),
+    )?;
 
     Server::builder()
         .add_service(SchedulerServiceServer::new(grpc_service))
@@ -71,6 +76,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         tracing::error!(error = % error, "Failed to listen for Ctrl-C.");
                     }
                     tracing::info!("Received Ctrl-C. Shutting down scheduler gRPC server.");
+                    cancellation_token.cancel();
+                }
+                _ = sigterm.recv() => {
+                    tracing::info!("Received SIGTERM. Shutting down scheduler gRPC server.");
                     cancellation_token.cancel();
                 }
             }

--- a/components/spider-storage/src/bin/grpc_server.rs
+++ b/components/spider-storage/src/bin/grpc_server.rs
@@ -19,6 +19,8 @@ use spider_utils::config::YamlConfig;
 use spider_utils::logging::set_up_logging;
 use tokio::net::TcpListener;
 use tokio::select;
+use tokio::signal::unix::SignalKind;
+use tokio::signal::unix::signal;
 use tonic::transport::Server;
 use tonic::transport::server::TcpIncoming;
 
@@ -53,6 +55,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         |error| tracing::error!(error = % error, "Failed to bind storage listen address."),
     )?;
     let incoming = TcpIncoming::from(listener);
+    let mut sigterm = signal(SignalKind::terminate()).inspect_err(
+        |error| tracing::error!(error = % error, "Failed to register SIGTERM handler."),
+    )?;
     let server_cancellation_token = cancellation_token.clone();
     let server = tokio::spawn(
         Server::builder()
@@ -80,6 +85,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         if let Err(error) = result {
                             tracing::error!(error = % error, "Failed to listen for Ctrl-C.");
                         }
+                        server_cancellation_token.cancel();
+                    }
+                    _ = sigterm.recv() => {
+                        tracing::info!("Received SIGTERM. Shutting down storage gRPC server.");
                         server_cancellation_token.cancel();
                     }
                 }


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR resolves #393 by adding `SIGTERM` signal handler for storage server, scheduler and execution manager, so the k8s termination can be handled gracefully.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
- [x] GitHub workflows pass.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added graceful shutdown handling for Unix `SIGTERM` signals across execution management, scheduling, and storage services.
  - Services now cancel active operations and complete shutdown cleanly when terminated by the operating system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->