### PR TITLE
feat(spider-execution-manager)!: Forward task executor logs to the execution manager's stdout instead of per-executor log files.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2466,6 +2466,7 @@ dependencies = [
  "tabled",
  "test-utils",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/components/spider-execution-manager/Cargo.toml
+++ b/components/spider-execution-manager/Cargo.toml
@@ -32,6 +32,7 @@ thiserror = "2.0.18"
 tokio = {
   version = "1.50.0",
   features = [
+    "io-std",
     "io-util",
     "macros",
     "process",

--- a/components/spider-execution-manager/src/config.rs
+++ b/components/spider-execution-manager/src/config.rs
@@ -50,7 +50,7 @@ impl Config {
             scheduler_poll_wait_ms: self.scheduler_poll_wait_ms,
             executor_binary_path: self.task_executor.bin_path.clone(),
             package_dir: self.task_executor.package_dir.clone(),
-            log_dir: self.task_executor.log_dir.clone(),
+            max_log_line_bytes: self.task_executor.max_log_line_bytes,
             inherited_env: self.task_executor.inherited_env.clone(),
         }
     }
@@ -77,12 +77,30 @@ pub struct TaskExecutorConfig {
     /// Directory of TDL packages exposed to executors via `SPIDER_TDL_PACKAGE_DIR`.
     pub package_dir: PathBuf,
 
-    /// Directory the process pool writes per-executor stderr logs into.
-    pub log_dir: PathBuf,
+    /// Maximum length, in bytes, of a single log line captured from an executor's stderr and
+    /// forwarded to the execution manager's stdout. A longer line is dropped.
+    ///
+    /// Must be greater than zero.
+    #[serde(default = "default_max_log_line_bytes")]
+    pub max_log_line_bytes: NonZeroUsize,
 
     /// Names of environment variables forwarded from the execution manager's process into each
     /// spawned `spider-task-executor`. Their values are read from this process's environment at
     /// spawn time.
     #[serde(default)]
     pub inherited_env: Vec<String>,
+}
+
+/// Default value of [`TaskExecutorConfig::max_log_line_bytes`].
+const DEFAULT_MAX_LOG_LINE_BYTES: usize = 64 * 1024;
+
+/// # Returns
+///
+/// The default value of [`TaskExecutorConfig::max_log_line_bytes`].
+///
+/// # Panics
+///
+/// Panics if [`DEFAULT_MAX_LOG_LINE_BYTES`] is zero.
+const fn default_max_log_line_bytes() -> NonZeroUsize {
+    NonZeroUsize::new(DEFAULT_MAX_LOG_LINE_BYTES).expect("default max log line bytes is non-zero")
 }

--- a/components/spider-execution-manager/src/executor_log.rs
+++ b/components/spider-execution-manager/src/executor_log.rs
@@ -1,0 +1,283 @@
+//! Executor log actor.
+//!
+//! Every spawned `spider-task-executor` subprocess has its own coroutine forwarding the
+//! subprocess's log output, so writes to the stream are concurrent and may overlap across executor
+//! respawns. A single actor task owns the stream and appends one line at a time, which is what
+//! makes each forwarded line land whole.
+
+use std::io;
+
+use tokio::io::AsyncWrite;
+use tokio::io::AsyncWriteExt;
+use tokio::io::BufWriter;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+/// Cloneable handle for sending log lines into the running actor.
+#[derive(Clone)]
+pub struct ExecutorLogHandle {
+    sender: mpsc::Sender<String>,
+}
+
+impl ExecutorLogHandle {
+    /// Sends one log line to the actor in a fire-and-forget manner.
+    ///
+    /// `line` should not carry a trailing newline: the actor appends one.
+    pub async fn write_line(&self, line: String) {
+        let _ = self.sender.send(line).await;
+    }
+}
+
+/// Spawns the executor log actor on the current tokio runtime.
+///
+/// The actor exits once every [`ExecutorLogHandle`] has been dropped and the lines they queued have
+/// been written out, or earlier if the output stream fails. Both paths cancel `cancellation_token`,
+/// so a completed [`JoinHandle`] does not by itself mean the shutdown was a clean one.
+///
+/// `cancellation_token` is fire-only: the actor never awaits it, since stopping on cancellation
+/// would discard the lines still queued behind it.
+///
+/// # Type Parameters
+///
+/// * `WriterType` - The output stream that the actor takes ownership of and appends log lines to.
+///
+/// # Returns
+///
+/// A pair containing:
+///
+/// * A handle for sending log lines to the actor.
+/// * The spawned actor's [`JoinHandle`].
+pub fn spawn<WriterType: AsyncWrite + Unpin + Send + 'static>(
+    writer: WriterType,
+    cancellation_token: CancellationToken,
+) -> (ExecutorLogHandle, JoinHandle<()>) {
+    let (sender, receiver) = mpsc::channel(LINE_CHANNEL_CAP);
+    let actor = ExecutorLogActor {
+        receiver,
+        writer: BufWriter::new(writer),
+        cancellation_token,
+    };
+    let join = tokio::spawn(actor.run());
+    (ExecutorLogHandle { sender }, join)
+}
+
+/// Capacity of the log line channel between the producers and the actor.
+///
+/// The channel is deliberately bounded: once it fills, producers block instead of dropping lines,
+/// and the resulting backpressure propagates into the executors' log pipes.
+const LINE_CHANNEL_CAP: usize = 1024;
+
+/// The actor's owned state. Lives entirely inside the spawned task.
+struct ExecutorLogActor<WriterType: AsyncWrite + Unpin> {
+    receiver: mpsc::Receiver<String>,
+    writer: BufWriter<WriterType>,
+    cancellation_token: CancellationToken,
+}
+
+impl<WriterType: AsyncWrite + Unpin> ExecutorLogActor<WriterType> {
+    /// Drives the actor until the log line channel closes or the output stream fails, then cancels
+    /// the runtime.
+    ///
+    /// Cancelling unconditionally is safe because the process pool holds an [`ExecutorLogHandle`]
+    /// for its whole lifetime: the channel cannot close while the runtime is live, and a normal
+    /// shutdown drops the pool first, so the token is already cancelled by the time the actor
+    /// exits.
+    async fn run(mut self) {
+        // Channel closure is the actor's only shutdown signal: `recv` yields `None` only once every
+        // sender is gone and the queue is drained, so no queued line can be lost.
+        while let Some(line) = self.receiver.recv().await {
+            if let Err(e) = self.append_line(&line).await {
+                tracing::error!(
+                    err = % e,
+                    "Failed to write an executor log line. Executor log actor shutting down."
+                );
+                break;
+            }
+        }
+
+        if let Err(e) = self.writer.flush().await {
+            tracing::error!(err = % e, "Failed to flush the final executor log lines.");
+        }
+
+        tracing::info!("Executor log actor exited. Cancelling the runtime.");
+        self.cancellation_token.cancel();
+    }
+
+    /// Appends one newline-terminated line to the output stream.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * Forwards [`AsyncWriteExt::write_all`]'s return values on failure.
+    /// * Forwards [`AsyncWriteExt::flush`]'s return values on failure.
+    async fn append_line(&mut self, line: &str) -> io::Result<()> {
+        self.writer.write_all(line.as_bytes()).await?;
+        self.writer.write_all(b"\n").await?;
+
+        // NOTE: Flushing only once the queue runs dry coalesces a burst into a single syscall while
+        // still writing a lone line out immediately. The size-based flushing is implicitly enforced
+        // by [`BufWriter`].
+        if self.receiver.is_empty() {
+            self.writer.flush().await?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+    use std::pin::Pin;
+    use std::task::Context;
+    use std::task::Poll;
+    use std::time::Duration;
+
+    use tokio::io::AsyncBufReadExt;
+    use tokio::io::AsyncWrite;
+    use tokio::io::BufReader;
+    use tokio::io::DuplexStream;
+    use tokio::task::JoinHandle;
+    use tokio_util::sync::CancellationToken;
+
+    use super::spawn;
+
+    /// Buffer capacity of the in-memory stream standing in for the actor's output.
+    ///
+    /// Deliberately smaller than the payload of the tests that write many lines, so that the actor
+    /// has to interleave with the reader instead of writing everything into the buffer at once.
+    const DUPLEX_BUF_CAP: usize = 32;
+
+    /// Output stream standing in for broken stdout, which fails every operation intentionally.
+    struct BrokenWriter;
+
+    impl AsyncWrite for BrokenWriter {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            Poll::Ready(Err(io::Error::from(io::ErrorKind::BrokenPipe)))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Err(io::Error::from(io::ErrorKind::BrokenPipe)))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Err(io::Error::from(io::ErrorKind::BrokenPipe)))
+        }
+    }
+
+    /// Spawns a task draining `reader` line by line until the actor drops its end of the stream.
+    ///
+    /// The drain has to run concurrently with the actor, otherwise a full stream buffer would
+    /// deadlock the test.
+    ///
+    /// # Returns
+    ///
+    /// The spawned task's [`JoinHandle`], resolving to every line read.
+    fn spawn_line_collector(reader: DuplexStream) -> JoinHandle<Vec<String>> {
+        tokio::spawn(async move {
+            let mut lines = BufReader::new(reader).lines();
+            let mut collected = Vec::new();
+            while let Some(line) = lines.next_line().await.expect("failed to read a line") {
+                collected.push(line);
+            }
+            collected
+        })
+    }
+
+    /// Joins the actor with a short upper bound so a stuck task surfaces as a test failure instead
+    /// of an infinite hang.
+    async fn join_actor(join: JoinHandle<()>) {
+        tokio::time::timeout(Duration::from_secs(1), join)
+            .await
+            .expect("actor did not exit within 1s")
+            .expect("actor task panicked");
+    }
+
+    /// Joins the collector spawned by [`spawn_line_collector`] with a short upper bound.
+    ///
+    /// # Returns
+    ///
+    /// Every line the collector read.
+    async fn join_collector(collector: JoinHandle<Vec<String>>) -> Vec<String> {
+        tokio::time::timeout(Duration::from_secs(1), collector)
+            .await
+            .expect("collector did not exit within 1s")
+            .expect("collector task panicked")
+    }
+
+    #[tokio::test]
+    async fn lines_are_written_in_order() {
+        const LINE_COUNT: usize = 64;
+
+        let (writer, reader) = tokio::io::duplex(DUPLEX_BUF_CAP);
+        let collector = spawn_line_collector(reader);
+        let (handle, join) = spawn(writer, CancellationToken::new());
+
+        let expected: Vec<String> = (0..LINE_COUNT)
+            .map(|i| format!("executor line {i}"))
+            .collect();
+        for line in &expected {
+            handle.write_line(line.clone()).await;
+        }
+        drop(handle);
+
+        join_actor(join).await;
+        assert_eq!(join_collector(collector).await, expected);
+    }
+
+    #[tokio::test]
+    async fn queued_lines_are_written_before_exit() {
+        let (writer, reader) = tokio::io::duplex(DUPLEX_BUF_CAP);
+        let collector = spawn_line_collector(reader);
+        let cancellation_token = CancellationToken::new();
+        let (handle, join) = spawn(writer, cancellation_token.clone());
+
+        let expected = vec!["first".to_owned(), "second".to_owned(), "third".to_owned()];
+        for line in &expected {
+            handle.write_line(line.clone()).await;
+        }
+        drop(handle);
+
+        join_actor(join).await;
+        assert_eq!(join_collector(collector).await, expected);
+        assert!(cancellation_token.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn cloned_handles_share_the_writer() {
+        let (writer, reader) = tokio::io::duplex(DUPLEX_BUF_CAP);
+        let collector = spawn_line_collector(reader);
+        let (handle, join) = spawn(writer, CancellationToken::new());
+        let cloned_handle = handle.clone();
+
+        handle.write_line("from the original".to_owned()).await;
+        cloned_handle.write_line("from the clone".to_owned()).await;
+        drop(handle);
+        drop(cloned_handle);
+
+        join_actor(join).await;
+        assert_eq!(
+            join_collector(collector).await,
+            vec!["from the original".to_owned(), "from the clone".to_owned()]
+        );
+    }
+
+    #[tokio::test]
+    async fn write_error_exits_and_cancels_runtime() {
+        let cancellation_token = CancellationToken::new();
+        let (handle, join) = spawn(BrokenWriter, cancellation_token.clone());
+
+        handle.write_line("into the void".to_owned()).await;
+
+        // `handle` is deliberately still alive: the actor must exit on the broken stream alone,
+        // without the channel closing.
+        join_actor(join).await;
+        assert!(cancellation_token.is_cancelled());
+        drop(handle);
+    }
+}

--- a/components/spider-execution-manager/src/executor_log_collection.rs
+++ b/components/spider-execution-manager/src/executor_log_collection.rs
@@ -7,15 +7,21 @@
 
 use std::io;
 
+#[cfg(test)]
+use tokio::io::AsyncBufReadExt;
+#[cfg(test)]
+use tokio::io::AsyncRead;
 use tokio::io::AsyncWrite;
 use tokio::io::AsyncWriteExt;
+#[cfg(test)]
+use tokio::io::BufReader;
 use tokio::io::BufWriter;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 /// Cloneable handle for sending log lines into the running actor.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ExecutorLogHandle {
     sender: mpsc::Sender<String>,
 }
@@ -60,6 +66,36 @@ pub fn spawn<WriterType: AsyncWrite + Unpin + Send + 'static>(
     };
     let join = tokio::spawn(actor.run());
     (ExecutorLogHandle { sender }, join)
+}
+
+/// Spawns a task draining `reader` line by line until the writing end of the stream is dropped.
+///
+/// The drain has to run concurrently with the actor, otherwise a full stream buffer would deadlock
+/// the caller.
+///
+/// # Type Parameters
+///
+/// * `ReaderType` - The stream the collector takes ownership of and reads lines from.
+///
+/// # Returns
+///
+/// The spawned task's [`JoinHandle`], resolving to every line read.
+///
+/// # Panics
+///
+/// The spawned task panics if reading from `reader` fails.
+#[cfg(test)]
+pub fn spawn_line_collector<ReaderType: AsyncRead + Unpin + Send + 'static>(
+    reader: ReaderType,
+) -> JoinHandle<Vec<String>> {
+    tokio::spawn(async move {
+        let mut lines = BufReader::new(reader).lines();
+        let mut collected = Vec::new();
+        while let Some(line) = lines.next_line().await.expect("failed to read a line") {
+            collected.push(line);
+        }
+        collected
+    })
 }
 
 /// Capacity of the log line channel between the producers and the actor.
@@ -134,14 +170,12 @@ mod tests {
     use std::task::Poll;
     use std::time::Duration;
 
-    use tokio::io::AsyncBufReadExt;
     use tokio::io::AsyncWrite;
-    use tokio::io::BufReader;
-    use tokio::io::DuplexStream;
     use tokio::task::JoinHandle;
     use tokio_util::sync::CancellationToken;
 
     use super::spawn;
+    use super::spawn_line_collector;
 
     /// Buffer capacity of the in-memory stream standing in for the actor's output.
     ///
@@ -168,25 +202,6 @@ mod tests {
         fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
             Poll::Ready(Err(io::Error::from(io::ErrorKind::BrokenPipe)))
         }
-    }
-
-    /// Spawns a task draining `reader` line by line until the actor drops its end of the stream.
-    ///
-    /// The drain has to run concurrently with the actor, otherwise a full stream buffer would
-    /// deadlock the test.
-    ///
-    /// # Returns
-    ///
-    /// The spawned task's [`JoinHandle`], resolving to every line read.
-    fn spawn_line_collector(reader: DuplexStream) -> JoinHandle<Vec<String>> {
-        tokio::spawn(async move {
-            let mut lines = BufReader::new(reader).lines();
-            let mut collected = Vec::new();
-            while let Some(line) = lines.next_line().await.expect("failed to read a line") {
-                collected.push(line);
-            }
-            collected
-        })
     }
 
     /// Joins the actor with a short upper bound so a stuck task surfaces as a test failure instead

--- a/components/spider-execution-manager/src/lib.rs
+++ b/components/spider-execution-manager/src/lib.rs
@@ -3,7 +3,7 @@
 
 pub mod client;
 mod config;
-pub mod executor_log;
+pub mod executor_log_collection;
 pub mod liveness;
 pub mod process_pool;
 pub mod runtime;

--- a/components/spider-execution-manager/src/lib.rs
+++ b/components/spider-execution-manager/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod client;
 mod config;
+pub mod executor_log;
 pub mod liveness;
 pub mod process_pool;
 pub mod runtime;

--- a/components/spider-execution-manager/src/process_pool.rs
+++ b/components/spider-execution-manager/src/process_pool.rs
@@ -1,6 +1,6 @@
 //! Process supervisor for `spider-task-executor` subprocesses.
 
-use std::fs::File;
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::atomic::AtomicU64;
@@ -10,7 +10,6 @@ use std::time::Duration;
 use bytes::Bytes;
 use futures_util::SinkExt;
 use futures_util::StreamExt;
-use spider_core::types::id::ExecutionManagerId;
 use spider_core::types::id::JobId;
 use spider_core::types::id::ResourceGroupId;
 use spider_core::types::id::TaskId;
@@ -21,6 +20,7 @@ use spider_task_executor::protocol::Response;
 use spider_tdl::TaskContext;
 use spider_tdl::TdlError;
 use spider_utils::wire::WireError;
+use tokio::io::AsyncRead;
 use tokio::process::Child;
 use tokio::process::ChildStdin;
 use tokio::process::ChildStdout;
@@ -29,13 +29,14 @@ use tokio::sync::Mutex;
 use tokio_util::codec::FramedRead;
 use tokio_util::codec::FramedWrite;
 use tokio_util::codec::LengthDelimitedCodec;
+use tokio_util::codec::LinesCodec;
+use tokio_util::codec::LinesCodecError;
+
+use crate::executor_log_collection::ExecutorLogHandle;
 
 /// Pool configuration. Supplied once at construction time and never mutated.
 #[derive(Debug, Clone)]
 pub struct ProcessPoolConfig {
-    /// Identity of the owning execution manager.
-    pub em_id: ExecutionManagerId,
-
     /// Absolute path to the `spider-task-executor` binary the pool will spawn.
     pub executor_binary_path: PathBuf,
 
@@ -43,13 +44,9 @@ pub struct ProcessPoolConfig {
     /// `${dir}/<package>/lib<package>.so` for each package it dispatches.
     pub package_dir: PathBuf,
 
-    /// Directory the pool writes per-executor stderr log files into. Each spawn opens
-    /// `<log_dir>/<em_id>-<executor_id>.log` in create-or-append mode and routes the child's
-    /// stderr there.
-    ///
-    /// Per-spawn filenames mean each respawn naturally rotates onto a fresh file; a long-lived
-    /// healthy executor accumulates into one file.
-    pub log_dir: PathBuf,
+    /// Maximum length, in bytes, of a single log line captured from an executor's stderr. A longer
+    /// line is dropped with a warning, and capture resumes at the next line boundary.
+    pub max_log_line_bytes: NonZeroUsize,
 
     /// Names of environment variables forwarded from the execution manager's process into each
     /// spawned executor. For each key, the value is read from this process's environment at spawn
@@ -96,8 +93,7 @@ pub enum InternalError {
     #[error("task executor process is not running")]
     NotRunning,
 
-    /// Failed to spawn the executor (any I/O step during spawn — `create_dir_all`, log-file open,
-    /// [`Command::spawn`], or claiming the piped stdio handles).
+    /// Failed to spawn the executor on any I/O step during spawn.
     #[error("failed to create an executor process: {0}")]
     ExecutorCreationFailure(#[from] std::io::Error),
 
@@ -118,6 +114,7 @@ pub enum InternalError {
 pub struct ProcessPool {
     config: ProcessPoolConfig,
     next_executor_id: AtomicU64,
+    log_handle: ExecutorLogHandle,
     /// Lock-serializes concurrent [`Self::execute`] callers. The single executor means each caller
     /// takes the lock for the whole call, so the mutex is the entire concurrency gate.
     handle: Mutex<Option<ExecutorHandle>>,
@@ -137,10 +134,14 @@ impl ProcessPool {
     /// Returns an error if:
     ///
     /// * Forwards [`Self::spawn_executor`]'s return values on failure.
-    pub fn new(config: ProcessPoolConfig) -> Result<Self, InternalError> {
+    pub fn new(
+        config: ProcessPoolConfig,
+        log_handle: ExecutorLogHandle,
+    ) -> Result<Self, InternalError> {
         let mut this = Self {
             config,
             handle: Mutex::new(None),
+            log_handle,
             next_executor_id: AtomicU64::new(0),
         };
         let handle = this.spawn_executor().inspect_err(|err| {
@@ -209,12 +210,12 @@ impl ProcessPool {
         Ok(outcome)
     }
 
-    /// Spawns the executor binary, allocates the next monotonic executor-id, opens the per-executor
-    /// log file, and wraps the child's stdin/stdout in length-delimited codec frames.
+    /// Spawns the executor binary, allocates the next monotonic executor-id, starts the detached
+    /// forwarder draining the child's stderr into the pool's log sink, and wraps the child's
+    /// stdin/stdout in length-delimited codec frames.
     ///
-    /// The child's stderr is redirected to `<log_dir>/<em_id>-<executor_id>.log` in
-    /// create-or-append mode. `RUST_LOG`, if set, is forwarded to the spawned task executor to make
-    /// the child process' log level match the current execution manager.
+    /// `RUST_LOG`, if set, is forwarded to the spawned task executor to make the child process' log
+    /// level match the current execution manager.
     ///
     /// # Returns
     ///
@@ -224,26 +225,18 @@ impl ProcessPool {
     ///
     /// Returns an error if:
     ///
-    /// * [`InternalError::ExecutorCreationFailure`] if the piped stdin or stdout handles cannot be
-    ///   claimed after spawn.
-    /// * Forwards [`std::fs::create_dir_all`]'s return values on failure.
-    /// * Forwards [`std::fs::OpenOptions::open`]'s return values on failure.
+    /// * [`InternalError::ExecutorCreationFailure`] if the piped stdin, stdout, or stderr handles
+    ///   cannot be claimed after spawn.
     /// * Forwards [`Command::spawn`]'s return values on failure.
     fn spawn_executor(&self) -> Result<ExecutorHandle, InternalError> {
         let executor_id = self.next_executor_id.fetch_add(1, Ordering::Relaxed);
-        std::fs::create_dir_all(&self.config.log_dir)?;
-        let log_path = self
-            .config
-            .log_dir
-            .join(format!("{}-{executor_id}.log", self.config.em_id));
-        let log_file = File::options().create(true).append(true).open(&log_path)?;
 
         let mut command = Command::new(&self.config.executor_binary_path);
         command
             .env("SPIDER_TDL_PACKAGE_DIR", &self.config.package_dir)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::from(log_file))
+            .stderr(Stdio::piped())
             .kill_on_drop(true);
 
         if let Ok(rust_log) = std::env::var("RUST_LOG") {
@@ -276,6 +269,16 @@ impl ProcessPool {
             .stdout
             .take()
             .ok_or_else(|| std::io::Error::other("executor stdout not piped"))?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| std::io::Error::other("executor stderr not piped"))?;
+        tokio::spawn(forward_executor_logs(
+            executor_id,
+            stderr,
+            self.log_handle.clone(),
+            self.config.max_log_line_bytes,
+        ));
         tracing::info!(executor_id, "Executor spawned.");
         Ok(ExecutorHandle {
             executor_id,
@@ -430,14 +433,111 @@ fn build_request(request: ExecuteRequest) -> Result<Request, InternalError> {
     })
 }
 
+/// Forwards every line read from one executor's stderr into `log_handle`.
+///
+/// Designed to run as a detached background task spawned by [`ProcessPool::spawn_executor`], which
+/// keeps `kill_on_drop` set on the child: dropping the executor handle kills the child, closing the
+/// pipe and ending this task.
+///
+/// # Type Parameters
+///
+/// * `ReaderType` - The executor's stderr stream.
+async fn forward_executor_logs<ReaderType: AsyncRead + Unpin>(
+    executor_id: u64,
+    reader: ReaderType,
+    log_handle: ExecutorLogHandle,
+    max_line_bytes: NonZeroUsize,
+) {
+    let mut lines = FramedRead::new(
+        reader,
+        LinesCodec::new_with_max_length(max_line_bytes.get()),
+    );
+
+    // `FramedRead` yields one `None` after a decoding error before it resumes reading. Without this
+    // flag, an oversized line would be indistinguishable from end-of-stream.
+    let mut resuming_after_oversized_line = false;
+    loop {
+        match lines.next().await {
+            Some(Ok(line)) => {
+                log_handle.write_line(line).await;
+            }
+            Some(Err(LinesCodecError::MaxLineLengthExceeded)) => {
+                tracing::warn!(
+                    executor_id,
+                    max_line_bytes = max_line_bytes.get(),
+                    "Executor log line exceeded the maximum length. Dropping it."
+                );
+                resuming_after_oversized_line = true;
+            }
+            Some(Err(LinesCodecError::Io(e))) => {
+                tracing::warn!(
+                    executor_id,
+                    err = % e,
+                    "Failed to read the executor's log stream. Stopping the forwarder."
+                );
+                break;
+            }
+            None => {
+                if resuming_after_oversized_line {
+                    resuming_after_oversized_line = false;
+                    continue;
+                }
+                break;
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use spider_core::task::TdlContext;
     use spider_core::task::TimeoutPolicy;
     use spider_core::types::io::SerializedTaskOutputs;
     use spider_core::types::io::TaskOutput;
+    use tokio_util::sync::CancellationToken;
 
     use super::*;
+    use crate::executor_log_collection;
+
+    /// Buffer capacity of the in-memory stream standing in for the log actor's output.
+    const DUPLEX_BUF_CAP: usize = 64;
+
+    /// Runs [`forward_executor_logs`] to completion over `input`, with a real log actor behind an
+    /// in-memory stream, and collects everything the actor wrote out.
+    ///
+    /// # Returns
+    ///
+    /// The forwarded lines, in the order the actor wrote them.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `max_line_bytes` is zero, or if the log actor or the collector does not finish
+    /// within one second.
+    async fn forward_and_collect(input: &[u8], max_line_bytes: usize) -> Vec<String> {
+        let (writer, reader) = tokio::io::duplex(DUPLEX_BUF_CAP);
+        let collector = executor_log_collection::spawn_line_collector(reader);
+        let (log_handle, log_join) =
+            executor_log_collection::spawn(writer, CancellationToken::new());
+
+        // `forward_executor_logs` owns `log_handle`, so returning here drops the last sender and
+        // lets the actor drain and exit.
+        forward_executor_logs(
+            0,
+            input,
+            log_handle,
+            NonZeroUsize::new(max_line_bytes).expect("max line bytes must be non-zero"),
+        )
+        .await;
+
+        tokio::time::timeout(Duration::from_secs(1), log_join)
+            .await
+            .expect("log actor did not exit within 1s")
+            .expect("log actor panicked");
+        tokio::time::timeout(Duration::from_secs(1), collector)
+            .await
+            .expect("collector did not exit within 1s")
+            .expect("collector panicked")
+    }
 
     /// Builds an [`ExecutionContext`] with dummy TDL and timeout metadata wrapping the given task
     /// IO buffer.
@@ -540,5 +640,17 @@ mod tests {
         let ctx: TaskContext = rmp_serde::from_slice(&raw_ctx)?;
         assert!(ctx.get_task_graph_outputs()?.is_none());
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn forward_executor_logs_preserves_line_order() {
+        let forwarded = forward_and_collect(b"first\nsecond\nthird\n", 1_024).await;
+        assert_eq!(forwarded, vec!["first", "second", "third"]);
+    }
+
+    #[tokio::test]
+    async fn forward_executor_logs_recovers_after_an_oversized_line() {
+        let forwarded = forward_and_collect(b"short\nfar-too-long-to-capture\nnext\n", 8).await;
+        assert_eq!(forwarded, vec!["short", "next"]);
     }
 }

--- a/components/spider-execution-manager/src/runtime.rs
+++ b/components/spider-execution-manager/src/runtime.rs
@@ -2,6 +2,7 @@
 
 use std::collections::VecDeque;
 use std::net::Ipv4Addr;
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -14,6 +15,7 @@ use spider_core::types::id::TaskInstanceId;
 use spider_core::types::io::ExecutionContext;
 use spider_core::types::scheduler::TaskAssignmentRecord;
 use tokio::task::JoinHandle;
+use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
 use tokio_util::sync::DropGuard;
 
@@ -23,6 +25,7 @@ use crate::client::SchedulerClient;
 use crate::client::SchedulerResponse;
 use crate::client::StorageClient;
 use crate::client::StorageResponseError;
+use crate::executor_log_collection::{self};
 use crate::liveness::LivenessHandle;
 use crate::liveness::{self};
 use crate::process_pool::ExecuteRequest;
@@ -51,8 +54,9 @@ pub struct RuntimeConfig {
     /// Directory of TDL packages exposed to executors via `SPIDER_TDL_PACKAGE_DIR`.
     pub package_dir: PathBuf,
 
-    /// Directory the process pool writes per-executor stderr logs into.
-    pub log_dir: PathBuf,
+    /// Maximum length, in bytes, of a single log line captured from an executor's stderr. A longer
+    /// line is dropped rather than forwarded.
+    pub max_log_line_bytes: NonZeroUsize,
 
     /// Names of environment variables forwarded from the execution manager's process into each
     /// spawned `spider-task-executor` (values read from this process's environment at spawn time).
@@ -95,6 +99,7 @@ pub struct Runtime<
     liveness_handle: LivenessHandle,
     liveness_join: JoinHandle<()>,
     scheduler_heartbeat_join: JoinHandle<()>,
+    log_join: JoinHandle<()>,
     scheduler_poll_wait_ms: u64,
     prev_assignments: VecDeque<TaskAssignmentRecord>,
     cancellation_token: CancellationToken,
@@ -109,9 +114,9 @@ impl<
     /// Factory function.
     ///
     /// Registers the execution manager with storage, seeds the [`SessionTracker`] with the session
-    /// ID returned by registration, spawns the initial executor [`ProcessPool`] and the liveness
-    /// actor, then assembles a ready-to-run runtime. The liveness actor sends the first heartbeat
-    /// by the time this returns.
+    /// ID returned by registration, spawns the executor log actor, the initial executor
+    /// [`ProcessPool`], and the liveness actor, then assembles a ready-to-run runtime. The liveness
+    /// actor sends the first heartbeat by the time this returns.
     ///
     /// # Type Parameters
     ///
@@ -150,15 +155,20 @@ impl<
             "Execution manager registered with storage."
         );
 
-        let process_pool = ProcessPool::new(ProcessPoolConfig {
-            em_id,
-            executor_binary_path: config.executor_binary_path,
-            package_dir: config.package_dir,
-            log_dir: config.log_dir,
-            inherited_env: config.inherited_env,
-        })?;
-
         let cancellation_token = CancellationToken::new();
+        let (log_handle, log_join) =
+            executor_log_collection::spawn(tokio::io::stdout(), cancellation_token.clone());
+
+        let process_pool = ProcessPool::new(
+            ProcessPoolConfig {
+                executor_binary_path: config.executor_binary_path,
+                package_dir: config.package_dir,
+                max_log_line_bytes: config.max_log_line_bytes,
+                inherited_env: config.inherited_env,
+            },
+            log_handle,
+        )?;
+
         let (liveness_handle, liveness_join) = liveness::spawn(
             em_id,
             liveness_client,
@@ -203,6 +213,7 @@ impl<
             liveness_handle,
             liveness_join,
             scheduler_heartbeat_join,
+            log_join,
             scheduler_poll_wait_ms: config.scheduler_poll_wait_ms,
             prev_assignments: VecDeque::new(),
             cancellation_token: cancellation_token.clone(),
@@ -236,6 +247,11 @@ impl<
         tracing::info!(em_id = ? self.em_id, "Runtime main loop exited. Shutting down.");
         self.cancellation_token.cancel();
 
+        // NOTE: The process pool is dropped before the executor log actor is joined: the pool holds
+        // an [`executor_log_collection::ExecutorLogHandle`], which must be closed to terminate the
+        // log actor.
+        drop(self.process_pool);
+
         let join_liveness_actor = async {
             match self.liveness_join.await {
                 Ok(()) => {
@@ -258,9 +274,32 @@ impl<
             }
         };
 
+        let log_join = self.log_join;
+        let join_log_actor = async {
+            // Upper bound on how long the shutdown path waits for the executor log actor to drain.
+            // This timeout is conservative enough to allow the actor to flush all the buffered
+            // messages.
+            const LOG_ACTOR_JOIN_TIMEOUT: Duration = Duration::from_secs(5);
+
+            let Ok(join_result) = timeout(LOG_ACTOR_JOIN_TIMEOUT, log_join).await else {
+                tracing::warn!("Executor log actor join timed out. Dropping the actor.");
+                return;
+            };
+
+            match join_result {
+                Ok(()) => {
+                    tracing::info!("Executor log actor stopped.");
+                }
+                Err(e) => {
+                    tracing::error!(error = ? e, "Executor log actor exited on panic.");
+                }
+            }
+        };
+
         tokio::join!(
             join_liveness_actor,
             join_scheduler_heartbeat,
+            join_log_actor,
             self.scheduler_client
                 .shutdown(self.em_id, self.prev_assignments.into())
         );

--- a/tests/huntsman/em-runtime/tests/test_runtime.rs
+++ b/tests/huntsman/em-runtime/tests/test_runtime.rs
@@ -7,6 +7,7 @@
 //!
 //! All tests are `#[ignore]` so the workspace's plain `cargo test` doesn't run them.
 
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -14,7 +15,6 @@ use std::time::Duration;
 use anyhow::Context;
 use spider_core::task::TdlContext;
 use spider_core::task::TimeoutPolicy;
-use spider_core::types::id::ExecutionManagerId;
 use spider_core::types::id::JobId;
 use spider_core::types::id::ResourceGroupId;
 use spider_core::types::id::SchedulerId;
@@ -46,6 +46,9 @@ const SLOW_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 const BOUNDED_WAIT: Duration = Duration::from_secs(2);
 const TIGHT_WAIT: Duration = Duration::from_millis(500);
 const SCHEDULER_POLL_WAIT_MS: u64 = 2_000;
+
+/// Maximum length, in bytes, of a captured executor log line.
+const MAX_LOG_LINE_BYTES: usize = 64 * 1024;
 
 /// Builds a [`SchedulerResponse`] tagged with `session_id` and fresh ids for the rest.
 ///
@@ -112,22 +115,24 @@ async fn wait_until(predicate: impl Fn() -> bool, timeout: Duration) -> bool {
     true
 }
 
-/// Builds a fresh [`RuntimeConfig`] pointing at the real executor binary, with a unique per-test
-/// log directory and the requested `heartbeat_interval`.
+/// Builds a fresh [`RuntimeConfig`] pointing at the real executor binary with the requested
+/// `heartbeat_interval`.
 ///
 /// # Returns
 ///
 /// A [`RuntimeConfig`] ready to hand to [`Runtime::create`].
+///
+/// # Panics
+///
+/// Panics if [`MAX_LOG_LINE_BYTES`] is zero.
 fn runtime_config(heartbeat_interval: Duration) -> RuntimeConfig {
-    let unique = ExecutionManagerId::random();
-    let log_dir = std::env::temp_dir().join(format!("spider-em-runtime-test-{unique}"));
     RuntimeConfig {
         heartbeat_interval,
         scheduler_heartbeat_interval: heartbeat_interval,
         scheduler_poll_wait_ms: SCHEDULER_POLL_WAIT_MS,
         executor_binary_path: task_executor_bin(),
         package_dir: tdl_package_dir(),
-        log_dir,
+        max_log_line_bytes: NonZeroUsize::new(MAX_LOG_LINE_BYTES).expect("non-zero line cap"),
         inherited_env: Vec::new(),
     }
 }

--- a/tests/huntsman/task-executor/Cargo.toml
+++ b/tests/huntsman/task-executor/Cargo.toml
@@ -33,5 +33,6 @@ tabled = "0.20.0"
 test-utils = { path = "../test-utils" }
 tokio = {
   version = "1.50.0",
-  features = ["macros", "rt", "rt-multi-thread", "time"]
+  features = ["io-util", "macros", "rt", "rt-multi-thread", "time"]
 }
+tokio-util = "0.7"

--- a/tests/huntsman/task-executor/tests/test_process_pool.rs
+++ b/tests/huntsman/task-executor/tests/test_process_pool.rs
@@ -11,17 +11,18 @@
 //! Each of those paths is followed by a second `execute` that asserts the pool transparently
 //! respawned the child and is ready to serve again.
 
+use std::num::NonZeroUsize;
 use std::time::Duration;
 
 use spider_core::task::TdlContext;
 use spider_core::task::TimeoutPolicy;
-use spider_core::types::id::ExecutionManagerId;
 use spider_core::types::id::JobId;
 use spider_core::types::id::ResourceGroupId;
 use spider_core::types::id::TaskId;
 use spider_core::types::io::ExecutionContext;
 use spider_core::types::io::TaskInput;
 use spider_core::types::io::TaskInputsSerializer;
+use spider_execution_manager::executor_log_collection::{self};
 use spider_execution_manager::process_pool::ExecuteRequest;
 use spider_execution_manager::process_pool::Outcome;
 use spider_execution_manager::process_pool::ProcessPool;
@@ -33,9 +34,13 @@ use test_utils::decode_single_output;
 use test_utils::single_input;
 use test_utils::task_executor_bin;
 use test_utils::tdl_package_dir;
+use tokio_util::sync::CancellationToken;
 
 /// Generous timeout for tasks expected to finish quickly.
 const NORMAL_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Maximum length, in bytes, of a captured executor log line.
+const MAX_LOG_LINE_BYTES: usize = 64 * 1024;
 
 /// Hard timeout chosen to fire well before [`SLOW_FIB_INDEX`] can complete even on a fast host.
 /// Tokio's sleep granularity is comfortably below this value.
@@ -45,8 +50,11 @@ const SHORT_TIMEOUT: Duration = Duration::from_millis(200);
 /// realistic host (`fib(45)` ~= 1.1×10^9 recursive calls — about a second in release mode).
 const SLOW_FIB_INDEX: u64 = 45;
 
-/// Builds a fresh [`ProcessPool`] wired to the test-harness env (executor binary + package dir)
-/// with a unique temp log directory.
+/// Builds a fresh [`ProcessPool`] wired to the test-harness env (executor binary + package dir),
+/// with the executors' logs forwarded into a sink.
+///
+/// Must be called from within a tokio runtime: both the log actor and the pool's first executor are
+/// spawned on the current runtime.
 ///
 /// # Returns
 ///
@@ -56,16 +64,15 @@ const SLOW_FIB_INDEX: u64 = 45;
 ///
 /// Panics if [`ProcessPool::new`] fails — i.e., the task-executor binary cannot be spawned.
 fn build_pool() -> ProcessPool {
-    let em_id = ExecutionManagerId::random();
-    let log_dir = std::env::temp_dir().join(format!("spider-em-pool-test-{em_id}"));
+    let (log_handle, _log_join) =
+        executor_log_collection::spawn(tokio::io::sink(), CancellationToken::new());
     let config = ProcessPoolConfig {
-        em_id,
         executor_binary_path: task_executor_bin(),
         package_dir: tdl_package_dir(),
-        log_dir,
+        max_log_line_bytes: NonZeroUsize::new(MAX_LOG_LINE_BYTES).expect("non-zero line cap"),
         inherited_env: Vec::new(),
     };
-    ProcessPool::new(config).expect("construct pool")
+    ProcessPool::new(config, log_handle).expect("construct pool")
 }
 
 /// Builds an [`ExecuteRequest`] targeting `task_func` in the integration package.

--- a/tools/deployment/spider-helm/Chart.yaml
+++ b/tools/deployment/spider-helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: "v2"
 name: "spider"
 description: "A Helm chart for the Spider Huntsman deployment"
 type: "application"
-version: "0.1.4"
+version: "0.1.5"
 appVersion: "0.1.0"
 home: "https://github.com/y-scope/spider"
 sources: ["https://github.com/y-scope/spider"]

--- a/tools/deployment/spider-helm/values.yaml
+++ b/tools/deployment/spider-helm/values.yaml
@@ -47,7 +47,7 @@ spiderConfig:
     task_executor:
       bin_path: "/usr/local/bin/spider-task-executor"
       inherited_env: []
-      log_dir: "/tmp/spider/task-executor"
+      max_log_line_bytes: 65536
       package_dir: "/opt/spider/packages"
 
   scheduler:


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

The execution manager used to write each spawned `spider-task-executor`'s stderr into its own file under a configured `log_dir`, which meant a containerized deployment had to mount and collect a log directory in addition to the container's own logs. This PR removes that entirely: the pool now pipes each executor's stderr, reads it line by line, and forwards every line to a single background actor that appends it to the execution manager's **stdout**. Collecting the execution manager's container logs is now sufficient to see everything its executors emit.

The two streams are deliberately split. The execution manager's own `tracing` output continues to go to **stderr** (`spider_utils::logging::set_up_logging`), while executor lines are written to **stdout** verbatim — no re-encoding through the execution manager's subscriber, which would nest each executor's JSON record inside a JSON string. Both streams are captured by the container runtime, and each remains independently parseable.

## Executor log actor (`executor_log_collection.rs`, new)

- Adds `ExecutorLogHandle`, a cloneable fire-and-forget handle whose `write_line` pushes one line into a bounded (1024-slot) channel, and `spawn(writer, cancellation_token)`, which starts the actor and returns the handle plus the actor's `JoinHandle`.
- A single actor task owns the output stream, which is what guarantees each forwarded line lands whole: concurrent writes to `tokio::io::Stdout` are not atomic across await points, and an executor respawn can leave two forwarders writing at once.
- The actor is generic over `AsyncWrite` so tests can inject an in-memory stream; the runtime passes `tokio::io::stdout()`.
- Channel closure is the actor's only *input* shutdown signal. `recv()` returns `None` only once every sender has been dropped and the queue is drained, which gives drain-then-exit for free. The actor deliberately never awaits the cancellation token, since stopping on cancellation would discard lines still queued behind it.
- The token is *fire-only*: the actor cancels it when it exits, so a broken output stream tears the runtime down rather than leaving the execution manager running blind. This mirrors `LivenessActor`, which cancels the runtime on `MarkedDead`/`IllegalId`.
- Output is buffered through a `BufWriter` and flushed once the channel drains, coalescing a burst into a single write while still emitting a lone line immediately. Sustained load is bounded by the `BufWriter`'s own capacity-triggered flush.

## Stderr capture in the process pool (`process_pool.rs`)

- `spawn_executor` now sets `Stdio::piped()` on the child's stderr, claims the handle, and spawns a detached forwarder for it. `kill_on_drop` is what makes detaching safe: dropping the executor handle kills the child, the kernel closes the pipe, the forwarder hits EOF and ends, and its cloned `ExecutorLogHandle` is released.
- Adds `forward_executor_logs`, which reads through `LinesCodec::new_with_max_length(max_log_line_bytes)`. A line over the cap is dropped with a `warn` and capture resumes at the next line boundary, so one runaway line cannot silence an executor's logs. An I/O error stops the forwarder.
- `FramedRead` yields one `None` after any decode error before it resumes reading (see tokio-rs/tokio#3976), so the forwarder distinguishes that resume point from a genuine end-of-stream. Without this, every line after an oversized one would be silently lost.
- `ProcessPoolConfig` drops `log_dir` and gains `max_log_line_bytes`. The log handle is passed to `ProcessPool::new` as a separate argument rather than living in the config, since a log sink is a collaborator rather than a configuration value.
- Removes `ProcessPoolConfig::em_id`, whose only consumer was the per-executor log filename.

## Runtime wiring (`runtime.rs`)

- `Runtime::create` spawns the log actor on `tokio::io::stdout()` before building the process pool and hands it the resulting handle. The actor receives a clone of the runtime's cancellation token, not a child token, so that its cancellation propagates up to the main loop.
- `Runtime::run` drops the process pool before joining the actor. The pool holds an `ExecutorLogHandle` for its lifetime, so the channel cannot close — and the actor cannot drain and exit — while the pool is alive. The join is bounded by a five-second timeout.
- Because the forwarders drain until EOF, stderr already buffered by a killed executor still reaches stdout during shutdown rather than being lost.

## Configuration (`config.rs`, `values.yaml`)

- `TaskExecutorConfig` drops `log_dir` and gains `max_log_line_bytes: NonZeroUsize`, `#[serde(default)]` at 64 KiB, capping a single captured stderr line.
- The Helm chart's `task_executor` block replaces `log_dir` with `max_log_line_bytes: 65536`, and `Chart.yaml` is bumped to `0.1.5`. The bump is required, not cosmetic: the publish workflow skips when a chart version's `.tgz` already exists on `gh-pages`, so without it the change would never reach the published chart while CI still reported success.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Ensure all workflows pass.
* [x] Add basic unit tests to cover the executor log aggregation behavior.
* [x]  Verified by hand that a real `Runtime` captures stderr from both the executor binary and the TDL task, and that both land on the execution manager's real stdout. A harness drives a `Runtime` built the same way the `execution_manager` binary builds it — mock scheduler, storage, and liveness clients, but a real `spider-task-executor` subprocess and a real `dlopen`ed TDL package — and executes one task that logs to stderr. The harness process is run with piped stdio so its actual fd 1 and fd 2 are captured.
    The harness writes nothing to stdout itself; its own diagnostics go through `spider_utils::logging::set_up_logging()`, the same function the real binary uses. Every byte observed on stdout therefore arrived through the forwarding path.
    Run with `RUST_LOG=info`, the captured stdout is exactly three lines:
    ```json
    {"timestamp":"…","level":"INFO","fields":{"message":"Executor starts."},"filename":"components/spider-task-executor/src/bin/spider_task_executor.rs","line_number":99}
    {"timestamp":"…","level":"INFO","fields":{"message":"stderr-marker-before-oversized"},"filename":"tests/huntsman/integration-test-tasks/src/lib.rs","line_number":176}
    {"timestamp":"…","level":"INFO","fields":{"message":"stderr-marker-after-oversized"},"filename":"tests/huntsman/integration-test-tasks/src/lib.rs","line_number":178}
    ```
    This confirms four things:
    - Both log sources reach stdout: the executor binary's own records (`"Executor starts."`) and the TDL task's records.
    - The two streams are disjoint. Zero records naming a `components/spider-execution-manager` source file appear on stdout, while 14 appear on stderr, including `"Execution manager registered with storage."` — the execution manager's own logging is unaffected and does not leak into the forwarded stream.
    - The cap is enforced against a real pipe. The task's 128 KiB line never reaches stdout (the longest stdout line is 192 bytes), and the forwarder's own `"Executor log line exceeded the maximum length."` warning goes to stderr rather than contaminating the pass-through stream.
    - Pass-through is verbatim. Running the executor standalone and diffing its own `"Executor starts."` record against the one that arrived on the execution manager's stdout shows them byte-for-byte identical once the timestamp is masked, confirming records are forwarded rather than re-encoded.

    Also verified: shutdown drains rather than truncates. The harness exits cleanly with the log actor reporting `"Executor log actor exited. Cancelling the runtime."`, and the task's log lines — emitted before the executor was killed — are all present, so the drop-the-pool-before-joining-the-actor ordering behaves as intended.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Executor error output is now collected through a shared logging pipeline.
  - Added configurable maximum log-line size, defaulting to 65,536 bytes.
  - Log output preserves ordering and continues safely after oversized lines.

- **Bug Fixes**
  - Improved runtime shutdown handling to ensure pending executor logs are processed before termination.
  - Updated deployment configuration and chart version to support the new logging settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->