### PR TITLE
feat(helm): Expose `serviceAccountName` on the worker deployment template.

### DIFF
--- a/tools/deployment/spider-helm/Chart.yaml
+++ b/tools/deployment/spider-helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: "v2"
 name: "spider"
 description: "A Helm chart for the Spider Huntsman deployment"
 type: "application"
-version: "0.1.7"
+version: "0.1.8"
 appVersion: "0.1.0-dev"
 home: "https://github.com/y-scope/spider"
 sources: ["https://github.com/y-scope/spider"]

--- a/tools/deployment/spider-helm/templates/worker-deployment.yaml
+++ b/tools/deployment/spider-helm/templates/worker-deployment.yaml
@@ -17,6 +17,9 @@ spec:
         {{- include "spider.labels" . | nindent 8 }}
         app.kubernetes.io/component: "worker"
     spec:
+      {{- with .Values.spiderConfig.worker.service_account_name }}
+      serviceAccountName: {{ tpl . $ | quote }}
+      {{- end }}
       containers:
         - name: "execution-manager"
           image: {{ include "spider.imageRef" (dict "root" . "component" "worker") | quote }}

--- a/tools/deployment/spider-helm/values.yaml
+++ b/tools/deployment/spider-helm/values.yaml
@@ -82,3 +82,4 @@ spiderConfig:
     extra_volume_mounts: []
     extra_volumes: []
     replicas: 4
+    service_account_name: ""


### PR DESCRIPTION
# Description

The worker Deployment doesn't set a `serviceAccountName`, so worker pods always run under the namespace's default ServiceAccount. On cloud deployments this blocks identity-based auth — e.g., on EKS, IRSA grants an IAM role through annotations on a ServiceAccount, so a workload that can't select a ServiceAccount can't use keyless S3 access.

This exposes an optional `spiderConfig.worker.service_account_name` value, rendered through `tpl` like the existing `extra_envs`/`extra_volumes`/`extra_volume_mounts` hooks, so a parent chart can pass a templated name. The immediate consumer is CLP's chart, which embeds this chart as a subchart and needs the worker to run under the same ServiceAccount as its own workers ([compression-worker-deployment.yaml#L24](https://github.com/y-scope/clp/blob/main/tools/deployment/package-helm/templates/compression-worker-deployment.yaml#L24)); see the review discussion in [y-scope/clp#2418](https://github.com/y-scope/clp/pull/2418#discussion_r3677202220).

When the value is empty (the default), the field is omitted and the rendered Deployment is unchanged.

Also bumps the chart version to 0.1.6.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* `helm lint` passes.
* `helm template` with default values renders the worker Deployment without a `serviceAccountName` (unchanged behavior).
* `--set spiderConfig.worker.service_account_name=my-sa` renders `serviceAccountName: "my-sa"`.
* Setting the value to `{{ .Release.Name }}-clp-service-account` (as a parent chart would) renders `serviceAccountName: "test-clp-service-account"` for a release named `test`.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable ServiceAccount support for worker deployments (optionally set a specific ServiceAccount, otherwise the default is used).
  * Introduced configurable log level settings for liveness, scheduler, and storage components.

* **Chores**
  * Bumped the Helm chart metadata version to **0.1.8**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->