### PR TITLE
build(huntsman): Manage crate dependency versions centrally through the Cargo workspace; Set all crates' version to `0.1.0-dev`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "async-channel"
@@ -87,13 +87,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -213,9 +213,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
@@ -237,9 +237,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -259,14 +259,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -443,7 +443,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -454,7 +454,7 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "e2e"
-version = "0.1.0"
+version = "0.1.0-dev"
 dependencies = [
  "anyhow",
  "spider-client",
@@ -474,7 +474,7 @@ dependencies = [
 
 [[package]]
 name = "em-runtime-tests"
-version = "0.1.0"
+version = "0.1.0-dev"
 dependencies = [
  "anyhow",
  "spider-core",
@@ -604,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
@@ -632,38 +632,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -845,7 +845,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "huntsman-complex"
-version = "0.1.0"
+version = "0.1.0-dev"
 dependencies = [
  "huntsman-complex-types",
  "serde",
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "huntsman-complex-types"
-version = "0.1.0"
+version = "0.1.0-dev"
 dependencies = [
  "serde",
  "spider-tdl",
@@ -862,11 +862,11 @@ dependencies = [
 
 [[package]]
 name = "huntsman-nn-core"
-version = "0.1.0"
+version = "0.1.0-dev"
 
 [[package]]
 name = "huntsman-nn-tasks"
-version = "0.1.0"
+version = "0.1.0-dev"
 dependencies = [
  "huntsman-nn-core",
  "serde",
@@ -1043,7 +1043,7 @@ dependencies = [
 
 [[package]]
 name = "integration-test-tasks"
-version = "0.1.0"
+version = "0.1.0-dev"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -1393,7 +1393,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1466,7 +1466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1488,14 +1488,14 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1527,7 +1527,7 @@ dependencies = [
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn 2.0.117",
+ "syn 2.0.119",
  "tempfile",
 ]
 
@@ -1541,7 +1541,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1575,9 +1575,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -1601,9 +1601,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -1776,9 +1776,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1786,29 +1786,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -1852,7 +1852,7 @@ checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "spider-client"
-version = "0.1.0"
+version = "0.1.0-dev"
 dependencies = [
  "spider-core",
  "spider-proto-rust",
@@ -1951,11 +1951,11 @@ dependencies = [
 
 [[package]]
 name = "spider-core"
-version = "0.1.0"
+version = "0.1.0-dev"
 dependencies = [
  "anyhow",
  "non-empty-string",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rmp-serde",
  "semver",
  "serde",
@@ -1972,17 +1972,17 @@ dependencies = [
 
 [[package]]
 name = "spider-derive"
-version = "0.1.0"
+version = "0.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
  "sqlx",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "spider-execution-manager"
-version = "0.1.0"
+version = "0.1.0-dev"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2006,7 +2006,7 @@ dependencies = [
 
 [[package]]
 name = "spider-proto-rust"
-version = "0.1.0"
+version = "0.1.0-dev"
 dependencies = [
  "prost",
  "spider-core",
@@ -2020,14 +2020,14 @@ dependencies = [
 
 [[package]]
 name = "spider-scheduler"
-version = "0.1.0"
+version = "0.1.0-dev"
 dependencies = [
  "anyhow",
  "async-channel",
  "async-trait",
  "clap",
  "dashmap",
- "rand 0.9.4",
+ "rand 0.9.5",
  "serde",
  "spider-core",
  "spider-proto-rust",
@@ -2041,7 +2041,7 @@ dependencies = [
 
 [[package]]
 name = "spider-storage"
-version = "0.1.0"
+version = "0.1.0-dev"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2049,7 +2049,7 @@ dependencies = [
  "clap",
  "const_format",
  "dashmap",
- "rand 0.9.4",
+ "rand 0.9.5",
  "secrecy",
  "serde",
  "serde_json",
@@ -2071,7 +2071,7 @@ dependencies = [
 
 [[package]]
 name = "spider-task-executor"
-version = "0.1.0"
+version = "0.1.0-dev"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2091,7 +2091,7 @@ dependencies = [
 
 [[package]]
 name = "spider-tdl"
-version = "0.1.0"
+version = "0.1.0-dev"
 dependencies = [
  "anyhow",
  "const-str",
@@ -2104,19 +2104,19 @@ dependencies = [
 
 [[package]]
 name = "spider-tdl-derive"
-version = "0.1.0"
+version = "0.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "spider-utils"
-version = "0.1.0"
+version = "0.1.0-dev"
 dependencies = [
  "non-empty-string",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rmp-serde",
  "serde",
  "thiserror",
@@ -2203,7 +2203,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2226,7 +2226,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.117",
+ "syn 2.0.119",
  "tokio",
  "url",
 ]
@@ -2375,7 +2375,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2403,9 +2403,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2426,7 +2437,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2450,12 +2461,12 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "task-executor-tests"
-version = "0.1.0"
+version = "0.1.0-dev"
 dependencies = [
  "integration-test-tasks",
  "rmp-serde",
@@ -2471,7 +2482,7 @@ dependencies = [
 
 [[package]]
 name = "tdl-integration"
-version = "0.1.0"
+version = "0.1.0-dev"
 dependencies = [
  "anyhow",
  "huntsman-complex-types",
@@ -2496,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.1.0"
+version = "0.1.0-dev"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2524,22 +2535,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2608,9 +2619,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -2630,7 +2641,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2646,14 +2657,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "futures-util",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -2696,7 +2708,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2721,7 +2733,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "tempfile",
  "tonic-build",
 ]
@@ -2790,7 +2802,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3117,7 +3129,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -3138,7 +3150,7 @@ checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3158,7 +3170,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -3198,7 +3210,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,68 @@ default-members = [
   "components/spider-tdl-derive",
   "components/spider-utils",
 ]
+
+[workspace.package]
+version = "0.1.0-dev"
+edition = "2024"
+
+[workspace.dependencies]
+anyhow = "1.0.104"
+async-channel = "2.5.0"
+async-trait = "0.1.91"
+bincode = "1.3.3"
+bytes = "1.12.1"
+clap = { version = "4.6.4", features = ["derive"] }
+const_format = "0.2.36"
+const-str = "1.1.0"
+dashmap = "6.2.1"
+futures-util = {
+  version = "0.3.33",
+  default-features = false,
+  features = ["sink", "std"]
+}
+huntsman-complex-types = { path = "examples/huntsman/complex/types" }
+huntsman-nn-core = { path = "examples/huntsman/nn/core" }
+integration-test-tasks = { path = "tests/huntsman/integration-test-tasks" }
+libloading = "0.8.9"
+non-empty-string = { version = "0.2.6", features = ["serde"] }
+proc-macro2 = "1.0.107"
+prost = "0.14.4"
+quote = "1.0.47"
+rand = "0.9.5"
+rmp-serde = "1.3.1"
+secrecy = { version = "0.10.3", features = ["serde"] }
+semver = "1.0.28"
+serde = { version = "1.0.229", features = ["derive"] }
+serde_json = "1.0.151"
+serial_test = { version = "3.5.0", features = ["file_locks"] }
+spider-client = { path = "components/spider-client" }
+spider-core = { path = "components/spider-core" }
+spider-derive = { path = "components/spider-derive" }
+spider-execution-manager = { path = "components/spider-execution-manager" }
+spider-proto-rust = { path = "components/spider-proto-rust" }
+spider-task-executor = { path = "components/spider-task-executor" }
+spider-tdl = { path = "components/spider-tdl" }
+spider-tdl-derive = { path = "components/spider-tdl-derive" }
+spider-utils = { path = "components/spider-utils" }
+sqlx = { version = "0.8.6", features = ["mysql"] }
+strum = { version = "0.28.0", features = ["derive"] }
+subtle = "2.6.1"
+syn = "2.0.119"
+tabled = "0.20.0"
+test-utils = { path = "tests/huntsman/test-utils" }
+thiserror = "2.0.19"
+tokio = "1.53.1"
+tokio-util = "0.7.19"
+tonic = "0.14.6"
+tonic-prost = "0.14.6"
+tonic-prost-build = "0.14.6"
+tracing = { version = "0.1.44", default-features = false, features = ["std"] }
+tracing-appender = "0.2.5"
+tracing-subscriber = {
+  version = "0.3.23",
+  default-features = false,
+  features = ["env-filter", "fmt", "json"]
+}
+yaml_serde = "0.10.4"
+zstd = "0.13.3"

--- a/components/spider-client/Cargo.toml
+++ b/components/spider-client/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "spider-client"
-version = "0.1.0"
-edition = "2024"
+version = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 name = "spider_client"
 path = "src/lib.rs"
 
 [dependencies]
-spider-core = { path = "../spider-core" }
-spider-proto-rust = { path = "../spider-proto-rust" }
-spider-utils = { path = "../spider-utils" }
-thiserror = "2.0.18"
-tokio = { version = "1.52.3", features = ["macros"] }
-tonic = "0.14.6"
+spider-core = { workspace = true }
+spider-proto-rust = { workspace = true }
+spider-utils = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["macros"] }
+tonic = { workspace = true }

--- a/components/spider-core/Cargo.toml
+++ b/components/spider-core/Cargo.toml
@@ -1,27 +1,27 @@
 [package]
 name = "spider-core"
-version = "0.1.0"
-edition = "2024"
+version = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 name = "spider_core"
 path = "src/lib.rs"
 
 [dependencies]
-non-empty-string = { version = "0.2.6", features = ["serde"] }
-rand = "0.9.1"
-rmp-serde = "1.3.1"
-semver = "1.0.27"
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
-spider-derive = { path = "../spider-derive" }
-spider-utils = { path = "../spider-utils" }
-sqlx = { version = "0.8.6", features = ["mysql"] }
-strum = { version = "0.28.0", features = ["derive"] }
-thiserror = "2.0.18"
-zstd = "0.13.3"
+non-empty-string = { workspace = true }
+rand = { workspace = true }
+rmp-serde = { workspace = true }
+semver = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+spider-derive = { workspace = true }
+spider-utils = { workspace = true }
+sqlx = { workspace = true }
+strum = { workspace = true }
+thiserror = { workspace = true }
+zstd = { workspace = true }
 
 [dev-dependencies]
-anyhow = "1.0.98"
-tokio = { version = "1.50.0", features = ["macros", "rt-multi-thread"] }
-tokio-util = { version = "0.7", features = ["rt"] }
+anyhow = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio-util = { workspace = true, features = ["rt"] }

--- a/components/spider-derive/Cargo.toml
+++ b/components/spider-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spider-derive"
-version = "0.1.0"
-edition = "2024"
+version = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 name = "spider_derive"
@@ -9,9 +9,9 @@ path = "src/lib.rs"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.106"
-quote = "1.0.45"
-syn = "2.0.117"
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }
 
 [dev-dependencies]
-sqlx = { version = "0.8.6", features = ["mysql"] }
+sqlx = { workspace = true }

--- a/components/spider-execution-manager/Cargo.toml
+++ b/components/spider-execution-manager/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spider-execution-manager"
-version = "0.1.0"
-edition = "2024"
+version = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 name = "spider_execution_manager"
@@ -12,25 +12,21 @@ name = "spider-execution-manager"
 path = "src/bin/execution_manager.rs"
 
 [dependencies]
-async-trait = "0.1.89"
-bincode = "1.3.3"
-bytes = "1.10"
-clap = { version = "4.6.1", features = ["derive"] }
-futures-util = {
-  version = "0.3.31",
-  default-features = false,
-  features = ["sink", "std"]
-}
-rmp-serde = "1.3.1"
-serde = { version = "1.0.228", features = ["derive"] }
-spider-core = { path = "../spider-core" }
-spider-proto-rust = { path = "../spider-proto-rust" }
-spider-task-executor = { path = "../spider-task-executor" }
-spider-tdl = { path = "../spider-tdl" }
-spider-utils = { path = "../spider-utils" }
-thiserror = "2.0.18"
+async-trait = { workspace = true }
+bincode = { workspace = true }
+bytes = { workspace = true }
+clap = { workspace = true }
+futures-util = { workspace = true }
+rmp-serde = { workspace = true }
+serde = { workspace = true }
+spider-core = { workspace = true }
+spider-proto-rust = { workspace = true }
+spider-task-executor = { workspace = true }
+spider-tdl = { workspace = true }
+spider-utils = { workspace = true }
+thiserror = { workspace = true }
 tokio = {
-  version = "1.50.0",
+  workspace = true,
   features = [
     "io-std",
     "io-util",
@@ -43,9 +39,9 @@ tokio = {
     "time"
   ]
 }
-tokio-util = { version = "0.7", features = ["codec", "rt"] }
-tonic = "0.14.6"
-tracing = { version = "0.1.41", default-features = false, features = ["std"] }
+tokio-util = { workspace = true, features = ["codec", "rt"] }
+tonic = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
-anyhow = "1.0.98"
+anyhow = { workspace = true }

--- a/components/spider-proto-rust/Cargo.toml
+++ b/components/spider-proto-rust/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "spider-proto-rust"
-version = "0.1.0"
-edition = "2024"
+version = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 name = "spider_proto_rust"
 path = "src/lib.rs"
 
 [dependencies]
-prost = "0.14.4"
-spider-core = { path = "../spider-core" }
-spider-utils = { path = "../spider-utils" }
-thiserror = "2.0.18"
-tonic = "0.14.6"
-tonic-prost = "0.14.6"
-tracing = { version = "0.1.41", default-features = false, features = ["std"] }
+prost = { workspace = true }
+spider-core = { workspace = true }
+spider-utils = { workspace = true }
+thiserror = { workspace = true }
+tonic = { workspace = true }
+tonic-prost = { workspace = true }
+tracing = { workspace = true }
 
 [build-dependencies]
-tonic-prost-build = "0.14.6"
+tonic-prost-build = { workspace = true }

--- a/components/spider-scheduler/Cargo.toml
+++ b/components/spider-scheduler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spider-scheduler"
-version = "0.1.0"
-edition = "2024"
+version = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 name = "spider_scheduler"
@@ -12,25 +12,25 @@ name = "spider-scheduler"
 path = "src/bin/grpc_server.rs"
 
 [dependencies]
-async-channel = "2.3.1"
-async-trait = "0.1.89"
-clap = { version = "4.6.1", features = ["derive"] }
-serde = { version = "1.0.228", features = ["derive"] }
-spider-core = { path = "../spider-core" }
-spider-proto-rust = { path = "../spider-proto-rust" }
-spider-utils = { path = "../spider-utils" }
-thiserror = "2.0.18"
+async-channel = { workspace = true }
+async-trait = { workspace = true }
+clap = { workspace = true }
+serde = { workspace = true }
+spider-core = { workspace = true }
+spider-proto-rust = { workspace = true }
+spider-utils = { workspace = true }
+thiserror = { workspace = true }
 tokio = {
-  version = "1.52.3",
+  workspace = true,
   features = ["macros", "net", "rt-multi-thread", "signal", "sync", "time"]
 }
-tokio-util = "0.7.18"
-tonic = "0.14.6"
-tracing = { version = "0.1.41", default-features = false, features = ["std"] }
+tokio-util = { workspace = true }
+tonic = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
-anyhow = "1.0.102"
-dashmap = "6.1.0"
-rand = "0.9.1"
-tokio = { version = "1.52.3", features = ["macros", "rt-multi-thread"] }
-tokio-util = { version = "0.7.18", features = ["rt"] }
+anyhow = { workspace = true }
+dashmap = { workspace = true }
+rand = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio-util = { workspace = true, features = ["rt"] }

--- a/components/spider-storage/Cargo.toml
+++ b/components/spider-storage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spider-storage"
-version = "0.1.0"
-edition = "2024"
+version = { workspace = true }
+edition = { workspace = true }
 autotests = false
 
 [lib]
@@ -17,33 +17,33 @@ name = "test_spider_storage"
 path = "tests/test_spider_storage.rs"
 
 [dependencies]
-async-channel = "2.3.1"
-async-trait = "0.1.89"
-clap = { version = "4.6.1", features = ["derive"] }
-const_format = "0.2.35"
-dashmap = "6.1.0"
-secrecy = { version = "0.10.3", features = ["serde"] }
-serde = { version = "1.0.228", features = ["derive"] }
-spider-core = { path = "../spider-core" }
-spider-derive = { path = "../spider-derive" }
-spider-proto-rust = { path = "../spider-proto-rust" }
-spider-tdl = { path = "../spider-tdl" }
-spider-utils = { path = "../spider-utils" }
-sqlx = { version = "0.8.6", features = ["mysql", "runtime-tokio"] }
-subtle = "2.6.1"
-thiserror = "2.0.18"
+async-channel = { workspace = true }
+async-trait = { workspace = true }
+clap = { workspace = true }
+const_format = { workspace = true }
+dashmap = { workspace = true }
+secrecy = { workspace = true }
+serde = { workspace = true }
+spider-core = { workspace = true }
+spider-derive = { workspace = true }
+spider-proto-rust = { workspace = true }
+spider-tdl = { workspace = true }
+spider-utils = { workspace = true }
+sqlx = { workspace = true, features = ["runtime-tokio"] }
+subtle = { workspace = true }
+thiserror = { workspace = true }
 tokio = {
-  version = "1.50.0",
+  workspace = true,
   features = ["macros", "net", "rt-multi-thread", "signal", "sync", "time"]
 }
-tokio-util = { version = "0.7.18", features = ["rt"] }
-tonic = "0.14.6"
-tracing = { version = "0.1.44", features = ["attributes"] }
+tokio-util = { workspace = true, features = ["rt"] }
+tonic = { workspace = true }
+tracing = { workspace = true, features = ["attributes"] }
 
 [dev-dependencies]
-anyhow = "1.0.98"
-rand = "0.9.1"
-serde_json = "1.0.149"
-serial_test = { version = "3.2.0", features = ["file_locks"] }
-tabled = "0.20.0"
-tokio = { version = "1.50.0", features = ["macros", "rt-multi-thread", "sync"] }
+anyhow = { workspace = true }
+rand = { workspace = true }
+serde_json = { workspace = true }
+serial_test = { workspace = true }
+tabled = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }

--- a/components/spider-task-executor/Cargo.toml
+++ b/components/spider-task-executor/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spider-task-executor"
-version = "0.1.0"
-edition = "2024"
+version = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 name = "spider_task_executor"
@@ -12,28 +12,20 @@ name = "spider-task-executor"
 path = "src/bin/spider_task_executor.rs"
 
 [dependencies]
-anyhow = "1.0.98"
-bincode = "1.3.3"
-bytes = "1.10"
-futures-util = {
-  version = "0.3.31",
-  default-features = false,
-  features = ["sink", "std"]
-}
-libloading = "0.8.5"
-rmp-serde = "1.3.1"
-serde = { version = "1.0.228", features = ["derive"] }
-spider-core = { path = "../spider-core" }
-spider-tdl = { path = "../spider-tdl" }
-thiserror = "2.0.18"
+anyhow = { workspace = true }
+bincode = { workspace = true }
+bytes = { workspace = true }
+futures-util = { workspace = true }
+libloading = { workspace = true }
+rmp-serde = { workspace = true }
+serde = { workspace = true }
+spider-core = { workspace = true }
+spider-tdl = { workspace = true }
+thiserror = { workspace = true }
 tokio = {
-  version = "1.50.0",
+  workspace = true,
   features = ["io-std", "io-util", "macros", "rt", "sync", "time"]
 }
-tokio-util = { version = "0.7", features = ["codec"] }
-tracing = { version = "0.1.41", default-features = false, features = ["std"] }
-tracing-subscriber = {
-  version = "0.3.19",
-  default-features = false,
-  features = ["env-filter", "fmt", "json"]
-}
+tokio-util = { workspace = true, features = ["codec"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/components/spider-tdl-derive/Cargo.toml
+++ b/components/spider-tdl-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spider-tdl-derive"
-version = "0.1.0"
-edition = "2024"
+version = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 name = "spider_tdl_derive"
@@ -9,6 +9,6 @@ path = "src/lib.rs"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.106"
-quote = "1.0.45"
-syn = { version = "2.0.117", features = ["full"] }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true, features = ["full"] }

--- a/components/spider-tdl/Cargo.toml
+++ b/components/spider-tdl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spider-tdl"
-version = "0.1.0"
-edition = "2024"
+version = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 name = "spider_tdl"
@@ -13,18 +13,18 @@ path = "tests/test_task_macro.rs"
 required-features = ["derive"]
 
 [dependencies]
-const-str = "1.1.0"
-rmp-serde = "1.3.1"
-serde = { version = "1.0.228", features = ["derive"] }
-spider-core = { path = "../spider-core" }
-spider-tdl-derive = { path = "../spider-tdl-derive", optional = true }
-thiserror = "2.0.18"
+const-str = { workspace = true }
+rmp-serde = { workspace = true }
+serde = { workspace = true }
+spider-core = { workspace = true }
+spider-tdl-derive = { workspace = true, optional = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
-anyhow = "1.0.98"
-rmp-serde = "1.3.1"
-serde = { version = "1.0.228", features = ["derive"] }
-spider-core = { path = "../spider-core" }
+anyhow = { workspace = true }
+rmp-serde = { workspace = true }
+serde = { workspace = true }
+spider-core = { workspace = true }
 
 [features]
 default = []

--- a/components/spider-utils/Cargo.toml
+++ b/components/spider-utils/Cargo.toml
@@ -1,27 +1,23 @@
 [package]
 name = "spider-utils"
-version = "0.1.0"
-edition = "2024"
+version = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 name = "spider_utils"
 path = "src/lib.rs"
 
 [dependencies]
-non-empty-string = { version = "0.2.6", features = ["serde"] }
-rand = "0.9.1"
-rmp-serde = "1.3.1"
-serde = { version = "1.0.228", features = ["derive"] }
-thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["time"] }
-tonic = "0.14.6"
-tracing-appender = "0.2.5"
-tracing-subscriber = {
-  version = "0.3.23",
-  default-features = false,
-  features = ["env-filter", "fmt", "json"]
-}
-yaml_serde = "0.10.4"
+non-empty-string = { workspace = true }
+rand = { workspace = true }
+rmp-serde = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["time"] }
+tonic = { workspace = true }
+tracing-appender = { workspace = true }
+tracing-subscriber = { workspace = true }
+yaml_serde = { workspace = true }
 
 [dev-dependencies]
-tokio = { version = "1.50.0", features = ["macros", "rt", "time"] }
+tokio = { workspace = true, features = ["macros", "rt", "time"] }

--- a/examples/huntsman/complex/tasks/Cargo.toml
+++ b/examples/huntsman/complex/tasks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "huntsman-complex"
-version = "0.1.0"
-edition = "2024"
+version = { workspace = true }
+edition = { workspace = true }
 publish = false
 
 [lib]
@@ -10,9 +10,6 @@ name = "huntsman_complex"
 path = "src/lib.rs"
 
 [dependencies]
-huntsman-complex-types = { path = "../types" }
-serde = { version = "1.0.228", features = ["derive"] }
-spider-tdl = {
-  path = "../../../../components/spider-tdl",
-  features = ["derive"]
-}
+huntsman-complex-types = { workspace = true }
+serde = { workspace = true }
+spider-tdl = { workspace = true, features = ["derive"] }

--- a/examples/huntsman/complex/types/Cargo.toml
+++ b/examples/huntsman/complex/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "huntsman-complex-types"
-version = "0.1.0"
-edition = "2024"
+version = { workspace = true }
+edition = { workspace = true }
 publish = false
 
 [lib]
@@ -9,5 +9,5 @@ name = "huntsman_complex_types"
 path = "src/lib.rs"
 
 [dependencies]
-serde = { version = "1.0.228", features = ["derive"] }
-spider-tdl = { path = "../../../../components/spider-tdl" }
+serde = { workspace = true }
+spider-tdl = { workspace = true }

--- a/examples/huntsman/nn/core/Cargo.toml
+++ b/examples/huntsman/nn/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "huntsman-nn-core"
-version = "0.1.0"
-edition = "2024"
+version = { workspace = true }
+edition = { workspace = true }
 publish = false
 
 [lib]

--- a/examples/huntsman/nn/tasks/Cargo.toml
+++ b/examples/huntsman/nn/tasks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "huntsman-nn-tasks"
-version = "0.1.0"
-edition = "2024"
+version = { workspace = true }
+edition = { workspace = true }
 publish = false
 
 [lib]
@@ -10,9 +10,6 @@ name = "nn"
 path = "src/lib.rs"
 
 [dependencies]
-huntsman-nn-core = { path = "../core" }
-serde = { version = "1.0.228", features = ["derive"] }
-spider-tdl = {
-  path = "../../../../components/spider-tdl",
-  features = ["derive"]
-}
+huntsman-nn-core = { workspace = true }
+serde = { workspace = true }
+spider-tdl = { workspace = true, features = ["derive"] }

--- a/tests/huntsman/e2e/Cargo.toml
+++ b/tests/huntsman/e2e/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "e2e"
-version = "0.1.0"
-edition = "2024"
+version = { workspace = true }
+edition = { workspace = true }
 publish = false
 
 [dependencies]
-anyhow = "1.0.98"
-spider-client = { path = "../../../components/spider-client" }
-spider-core = { path = "../../../components/spider-core" }
+anyhow = { workspace = true }
+spider-client = { workspace = true }
+spider-core = { workspace = true }
 tokio = {
-  version = "1.52.3",
+  workspace = true,
   features = ["macros", "rt-multi-thread", "sync", "time"]
 }
-tonic = "0.14.6"
+tonic = { workspace = true }

--- a/tests/huntsman/em-runtime/Cargo.toml
+++ b/tests/huntsman/em-runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "em-runtime-tests"
-version = "0.1.0"
-edition = "2024"
+version = { workspace = true }
+edition = { workspace = true }
 publish = false
 
 [lib]
@@ -13,14 +13,12 @@ name = "runtime"
 path = "tests/test_runtime.rs"
 
 [dev-dependencies]
-anyhow = "1.0.98"
-spider-core = { path = "../../../components/spider-core" }
-spider-execution-manager = {
-  path = "../../../components/spider-execution-manager"
-}
-spider-tdl = { path = "../../../components/spider-tdl" }
-test-utils = { path = "../test-utils" }
+anyhow = { workspace = true }
+spider-core = { workspace = true }
+spider-execution-manager = { workspace = true }
+spider-tdl = { workspace = true }
+test-utils = { workspace = true }
 tokio = {
-  version = "1.50.0",
+  workspace = true,
   features = ["macros", "rt", "rt-multi-thread", "time"]
 }

--- a/tests/huntsman/integration-test-tasks/Cargo.toml
+++ b/tests/huntsman/integration-test-tasks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "integration-test-tasks"
-version = "0.1.0"
-edition = "2024"
+version = { workspace = true }
+edition = { workspace = true }
 publish = false
 
 [lib]
@@ -12,6 +12,6 @@ name = "integration_test_tasks"
 path = "src/lib.rs"
 
 [dependencies]
-rmp-serde = "1.3.1"
-serde = { version = "1.0.228", features = ["derive"] }
-spider-tdl = { path = "../../../components/spider-tdl", features = ["derive"] }
+rmp-serde = { workspace = true }
+serde = { workspace = true }
+spider-tdl = { workspace = true, features = ["derive"] }

--- a/tests/huntsman/task-executor/Cargo.toml
+++ b/tests/huntsman/task-executor/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "task-executor-tests"
-version = "0.1.0"
-edition = "2024"
+version = { workspace = true }
+edition = { workspace = true }
 publish = false
 
 [lib]
@@ -21,18 +21,16 @@ name = "process_pool"
 path = "tests/test_process_pool.rs"
 
 [dev-dependencies]
-integration-test-tasks = { path = "../integration-test-tasks" }
-rmp-serde = "1.3.1"
-spider-core = { path = "../../../components/spider-core" }
-spider-execution-manager = {
-  path = "../../../components/spider-execution-manager"
-}
-spider-task-executor = { path = "../../../components/spider-task-executor" }
-spider-tdl = { path = "../../../components/spider-tdl" }
-tabled = "0.20.0"
-test-utils = { path = "../test-utils" }
+integration-test-tasks = { workspace = true }
+rmp-serde = { workspace = true }
+spider-core = { workspace = true }
+spider-execution-manager = { workspace = true }
+spider-task-executor = { workspace = true }
+spider-tdl = { workspace = true }
+tabled = { workspace = true }
+test-utils = { workspace = true }
 tokio = {
-  version = "1.50.0",
+  workspace = true,
   features = ["io-util", "macros", "rt", "rt-multi-thread", "time"]
 }
-tokio-util = "0.7"
+tokio-util = { workspace = true }

--- a/tests/huntsman/tdl-integration/Cargo.toml
+++ b/tests/huntsman/tdl-integration/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tdl-integration"
-version = "0.1.0"
-edition = "2024"
+version = { workspace = true }
+edition = { workspace = true }
 publish = false
 
 [lib]
@@ -17,9 +17,9 @@ name = "init"
 path = "tests/init.rs"
 
 [dev-dependencies]
-anyhow = "1.0.98"
-huntsman-complex-types = { path = "../../../examples/huntsman/complex/types" }
-rmp-serde = "1.3.1"
-spider-core = { path = "../../../components/spider-core" }
-spider-task-executor = { path = "../../../components/spider-task-executor" }
-spider-tdl = { path = "../../../components/spider-tdl" }
+anyhow = { workspace = true }
+huntsman-complex-types = { workspace = true }
+rmp-serde = { workspace = true }
+spider-core = { workspace = true }
+spider-task-executor = { workspace = true }
+spider-tdl = { workspace = true }

--- a/tests/huntsman/test-utils/Cargo.toml
+++ b/tests/huntsman/test-utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test-utils"
-version = "0.1.0"
-edition = "2024"
+version = { workspace = true }
+edition = { workspace = true }
 publish = false
 
 [lib]
@@ -9,25 +9,19 @@ name = "test_utils"
 path = "src/lib.rs"
 
 [dependencies]
-async-trait = "0.1.89"
-bincode = "1.3.3"
-bytes = "1.10"
-dashmap = "6.1.0"
-futures-util = {
-  version = "0.3.31",
-  default-features = false,
-  features = ["sink", "std"]
-}
-rmp-serde = "1.3.1"
-serde = "1.0.228"
-spider-core = { path = "../../../components/spider-core" }
-spider-execution-manager = {
-  path = "../../../components/spider-execution-manager"
-}
-spider-task-executor = { path = "../../../components/spider-task-executor" }
-spider-tdl = { path = "../../../components/spider-tdl" }
+async-trait = { workspace = true }
+bincode = { workspace = true }
+bytes = { workspace = true }
+dashmap = { workspace = true }
+futures-util = { workspace = true }
+rmp-serde = { workspace = true }
+serde = { workspace = true }
+spider-core = { workspace = true }
+spider-execution-manager = { workspace = true }
+spider-task-executor = { workspace = true }
+spider-tdl = { workspace = true }
 tokio = {
-  version = "1.50.0",
+  workspace = true,
   features = ["io-util", "macros", "process", "rt", "sync", "time"]
 }
-tokio-util = { version = "0.7", features = ["codec"] }
+tokio-util = { workspace = true, features = ["codec"] }

--- a/tools/deployment/spider-helm/Chart.yaml
+++ b/tools/deployment/spider-helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: "v2"
 name: "spider"
 description: "A Helm chart for the Spider Huntsman deployment"
 type: "application"
-version: "0.1.5"
-appVersion: "0.1.0"
+version: "0.1.6"
+appVersion: "0.1.0-dev"
 home: "https://github.com/y-scope/spider"
 sources: ["https://github.com/y-scope/spider"]
 maintainers: [{name: "y-scope", email: "dev@yscope.com", url: "https://yscope.com"}]


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

## Summary

This PR introduces workspace-level dependency and package inheritance so that every external crate is declared exactly once, in the root `Cargo.toml`, instead of being pinned independently in each of the 21 member manifests. Before this change a version bump was an N-file edit, and five crates had already drifted apart across members (`tokio` was simultaneously `1.50.0` and `1.52.3`, `anyhow` `1.0.98` and `1.0.102`, `tokio-util` `0.7` and `0.7.18`, `tracing` `0.1.41` and `0.1.44`, `tracing-subscriber` `0.3.19` and `0.3.23`). All drift is resolved and every dependency is aligned to the newest semver-compatible release.

Every bump stays within its crate's current major, so **no Rust source file is modified by this PR** — it is confined to manifests and `Cargo.lock`. Where a crate has a breaking major available, it is pinned to the last release before that break rather than upgraded; those upgrades are deferred to individual PRs (see below).

The change is intended to be behavior-neutral. It was verified as such by diffing the fully resolved feature graph (`cargo metadata`) before and after: of roughly 318 packages common to both graphs, exactly one differs, and that difference comes from an upstream manifest change rather than from this migration (see Notes).

All member crates additionally move from `version = "0.1.0"` to a shared `version = "0.1.0-dev"`, and the Helm chart's `appVersion` is updated to match.

## Workspace inheritance (root `Cargo.toml`)

- Adds `[workspace.package]` holding the two fields every member repeated identically: `version = "0.1.0-dev"` and `edition = "2024"`.
- Adds `[workspace.dependencies]` with 39 external crates and the 13 internal path dependencies. Internal crates are now referenced by name rather than by a relative path, which removes path spellings like `../../../../components/spider-tdl` from the example crates.
- `resolver`, `members`, and `default-members` are unchanged.

## Member manifests (21 crates)

- `[package]` now uses `version = { workspace = true }` and `edition = { workspace = true }`.
- Every entry in `[dependencies]`, `[dev-dependencies]`, and `[build-dependencies]` becomes `{ workspace = true }`. Members retain only the features they need *in addition* to what the workspace entry already provides, so the common case collapses to a single bare inheritance.
- The `{ workspace = true }` inline-table form is used throughout rather than the dotted `dep.workspace = true` form, for consistency and to avoid tripping the `dotted-keys-out-of-order` lint rule configured in `tombi.toml`.
- Features that remain member-local: `sqlx` adds `runtime-tokio` in `spider-storage`; `syn` adds `full` in `spider-tdl-derive`; `tracing` adds `attributes` in `spider-storage`; `spider-tdl` adds `derive` in `huntsman-complex`, `huntsman-nn-tasks`, and `integration-test-tasks`. The `tokio` and `tokio-util` workspace entries deliberately carry no features, because the per-member feature sets differ substantially, so each member keeps its full list.
- `spider-tdl-derive` remains an optional dependency of `spider-tdl` (`{ workspace = true, optional = true }`).

## `default-features = false` moves up to the workspace

`futures-util`, `tracing`, and `tracing-subscriber` were each declared with `default-features = false` in individual members. Cargo ignores a member's `default-features = false` when the workspace entry leaves defaults enabled, so this key now lives on the workspace entry instead; leaving it in the members would have silently re-enabled default features.

For `tracing` this meant restating the intent slightly: the workspace entry is `default-features = false, features = ["std"]`, and `spider-storage` — which previously took defaults plus `attributes` — now declares `attributes` explicitly. The resolved feature set is unchanged (verified below).

## Dependency version alignment

### Aligned to the newest compatible release

Where a crate had drifted, the drifted requirements are listed together in "Before".

| Crate | Before | After | Note |
| --- | --- | --- | --- |
| `anyhow` | `1.0.98`, `1.0.102` | `1.0.104` | Drift resolved |
| `async-channel` | `2.3.1` | `2.5.0` | |
| `async-trait` | `0.1.89` | `0.1.91` | |
| `bytes` | `1.10` | `1.12.1` | Requirement was not patch-exact |
| `clap` | `4.6.1` | `4.6.4` | |
| `const_format` | `0.2.35` | `0.2.36` | |
| `dashmap` | `6.1.0` | `6.2.1` | |
| `futures-util` | `0.3.31` | `0.3.33` | |
| `libloading` | `0.8.5` | `0.8.9` | Major deferred |
| `proc-macro2` | `1.0.106` | `1.0.107` | |
| `quote` | `1.0.45` | `1.0.47` | |
| `rand` | `0.9.1` | `0.9.5` | Major deferred |
| `semver` | `1.0.27` | `1.0.28` | |
| `serde` | `1.0.228` | `1.0.229` | |
| `serde_json` | `1.0.149` | `1.0.151` | |
| `serial_test` | `3.2.0` | `3.5.0` | Major deferred |
| `syn` | `2.0.117` | `2.0.119` | Major deferred |
| `thiserror` | `2.0.18` | `2.0.19` | |
| `tokio` | `1.50.0`, `1.52.3` | `1.53.1` | Drift resolved |
| `tokio-util` | `0.7`, `0.7.18` | `0.7.19` | Drift resolved; requirement was not patch-exact |
| `tracing` | `0.1.41`, `0.1.44` | `0.1.44` | Drift resolved |
| `tracing-subscriber` | `0.3.19`, `0.3.23` | `0.3.23` | Drift resolved |

Every entry in `[workspace.dependencies]` is now patch-exact, per the repository convention. `bytes` and `tokio-util` previously named no patch version, and those two pre-existing deviations are corrected here.

### Breaking major available, deliberately not taken

Each of these is pinned to the newest release within its current major — the last version before the API break — so that this PR needs no source changes. Each upgrade is deferred to its own PR so it can be reviewed against its own migration guide.

| Crate | Pinned at | Major available | Why deferred |
| --- | --- | --- | --- |
| `bincode` | `1.3.3` | `3.0.0` | `3.0.0` is a tombstone, not a usable release; crate is unmaintained |
| `libloading` | `0.8.9` | `0.9.0` | `dlerror` text moves out of `Display`, degrading load-failure diagnostics |
| `rand` | `0.9.5` | `0.10.2` | `Rng` renamed to `RngExt`; `SeedableRng::from_os_rng` removed |
| `serial_test` | `3.5.0` | `4.0.1` | MSRV bump and internal `syn` 3 only; no user-facing API change |
| `sqlx` | `0.8.6` | `0.9.0` | `ArgumentBuffer` loses its lifetime; `query*()` narrowed; MySQL behavior changes |
| `syn` | `2.0.119` | `3.0.3` | Workspace stays on `syn` 2.x deliberately; see Notes |
| `tabled` | `0.20.0` | `0.21.0` | `Charset`, `TabSize`, and `ColumnNames` reworked; none used here |

`sqlx` and `libloading` are worth calling out, because their majors would each require code changes that this pinning avoids:

- `sqlx` `0.9.0` removes the lifetime parameter from `ArgumentBuffer` (which the `Encode` impls in `spider-core/src/types/id.rs` and the `MySqlEnum` derive in `spider-derive/src/mysql.rs` both name) and narrows `query*()` to `impl SqlSafeStr` (which the dynamically built statements in `spider-storage/src/db/mariadb.rs` would need to opt out of). It also changes MySQL connection behavior — `SET NAMES utf8mb4 COLLATE utf8_general_ci` is no longer sent by default — and touches how database errors are surfaced, which matters here because duplicate-key and foreign-key handling in `mariadb.rs` classifies errors by downcasting to `MySqlDatabaseError` and matching on the error number. Staying on `0.8.6` keeps all of that as-is.
- `libloading` `0.9.0` moves the underlying `dlerror` text out of `Error`'s `Display` implementation and behind `Error::source()`. Because `ExecutorError`'s `From<libloading::Error>` impl formats via `to_string()`, taking that major without also rewriting the conversion would silently reduce every TDL package load failure to `"dlopen failed"`. Staying on `0.8.9` preserves the current diagnostics.

`bincode` is a special case in that table: it is not merely deferred. The crate is unmaintained, and its `3.0.0` release is a deliberate tombstone whose `src/lib.rs` is a bare `compile_error!`, so it cannot be depended on at all — `2.0.1` is the last functional release. Migrating off `bincode` entirely is tracked separately; this repo already uses `rmp-serde` for every other serialization path.

## Crate version scheme

All 21 members now report `0.1.0-dev` through workspace inheritance. `0.1.0-dev` is a valid SemVer 2.0.0 pre-release (`dev` is a well-formed alphanumeric identifier) and orders below `0.1.0`. No member declares a version requirement on another member — internal dependencies are path-only — so the suffix has no effect on resolution.

## Helm chart (`tools/deployment/spider-helm/Chart.yaml`)

- `appVersion` moves from `"0.1.0"` to `"0.1.0-dev"` so the deployed application version tracks the workspace crate version. `appVersion` is surfaced only as the `app.kubernetes.io/version` label via `spider.labels` in `_helpers.tpl`; container image tags come from `values.yaml` through `spider.imageRef` and are unaffected.
- The chart `version` is bumped `0.1.5` → `0.1.6`, matching the convention that every change to the chart carries a patch bump.

## Notes

- Resolved-feature verification: comparing `cargo metadata` output between a pristine checkout and this branch, exactly one package's feature set differs. `tokio-util` gains `libc`, because `tokio-util` `0.7.19` declares `codec = ["libc"]` where `0.7.18` did not; the workspace already enabled `codec`, so this follows mechanically from the upstream bump. No package loses a feature. `futures-util`, `tracing`, `tracing-subscriber`, `tokio`, `sqlx`, `serde`, `clap`, `syn`, and `spider-tdl` all resolve to byte-identical feature sets.
- `Cargo.lock` gains exactly one package, `syn 3.0.3`, pulled in by the bumped `async-trait`, `clap_derive`, `serde_derive`, and `thiserror-impl`. It resolves only as a host dependency, so it adds one proc-macro-side compilation unit and contributes nothing to the target artifact. `syn 2.x` is unaffected and still required by 23 crates in the graph, including this repo's two proc-macro crates, and `syn 1.0.109` remains reachable through `non-empty-string` → `delegate`, so a single syn version is not achievable at present and the workspace intentionally stays on `syn 2.x`.
- `default-features = false` on `tracing` is effectively inert in this workspace, since `sqlx-core` enables tracing's default features regardless. It is declared for correctness of intent rather than for effect. The same is true of `futures-util`, whose defaults are enabled transitively by `serial_test`, `hyper-util`, `sqlx`, and `tonic`.
- `test-utils` previously declared `serde` with no features and now inherits `derive` from the workspace entry. This is inherent to Cargo's feature unioning and has no resolved effect, as `serde/derive` is already enabled by 12 other members. Avoiding it would mean removing `derive` from the workspace entry and repeating it in those 12 members.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Ensure all workflows pass.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Centralized package versions, editions, and dependency management across the project.
  - Updated components, examples, and test packages to use shared workspace configuration.
  - Preserved existing dependency features while simplifying project configuration.

- **Deployment**
  - Bumped the Helm chart version to 0.1.6.
  - Updated the application version label to 0.1.0-dev.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->