### PR TITLE
feat(helm): Adds `log_level` support for storage, scheduler and worker.

### DIFF
--- a/tools/deployment/spider-helm/Chart.yaml
+++ b/tools/deployment/spider-helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: "v2"
 name: "spider"
 description: "A Helm chart for the Spider Huntsman deployment"
 type: "application"
-version: "0.1.5"
+version: "0.1.6"
 appVersion: "0.1.0"
 home: "https://github.com/y-scope/spider"
 sources: ["https://github.com/y-scope/spider"]

--- a/tools/deployment/spider-helm/templates/scheduler-deployment.yaml
+++ b/tools/deployment/spider-helm/templates/scheduler-deployment.yaml
@@ -22,6 +22,9 @@ spec:
           image: {{ include "spider.imageRef" (dict "root" . "component" "scheduler") | quote }}
           imagePullPolicy: {{ .Values.image.scheduler.pullPolicy | quote }}
           command: ["spider-scheduler", "--config", "/etc/spider/scheduler.yaml"]
+          env:
+            - name: "RUST_LOG"
+              value: {{ .Values.spiderConfig.scheduler.log_level | quote }}
           ports:
             - name: "grpc"
               containerPort: {{ .Values.spiderConfig.scheduler.port }}

--- a/tools/deployment/spider-helm/templates/storage-deployment.yaml
+++ b/tools/deployment/spider-helm/templates/storage-deployment.yaml
@@ -23,6 +23,8 @@ spec:
           imagePullPolicy: {{ .Values.image.storage.pullPolicy | quote }}
           command: ["spider-storage", "--config", "/etc/spider/storage.yaml"]
           env:
+            - name: "RUST_LOG"
+              value: {{ .Values.spiderConfig.storage.log_level | quote }}
             - name: "SPIDER_STORAGE_DB_USERNAME"
               valueFrom:
                 secretKeyRef:

--- a/tools/deployment/spider-helm/templates/worker-deployment.yaml
+++ b/tools/deployment/spider-helm/templates/worker-deployment.yaml
@@ -22,10 +22,12 @@ spec:
           image: {{ include "spider.imageRef" (dict "root" . "component" "worker") | quote }}
           imagePullPolicy: {{ .Values.image.worker.pullPolicy | quote }}
           command: ["spider-execution-manager", "--config", "/etc/spider/execution-manager.yaml"]
-          {{- with .Values.spiderConfig.worker.extra_envs }}
           env:
+            - name: "RUST_LOG"
+              value: {{ .Values.spiderConfig.execution_manager.log_level | quote }}
+            {{- with .Values.spiderConfig.worker.extra_envs }}
             {{- tpl (toYaml .) $ | nindent 12 }}
-          {{- end }}
+            {{- end }}
           volumeMounts:
             - name: "config"
               mountPath: "/etc/spider/execution-manager.yaml"

--- a/tools/deployment/spider-helm/values.yaml
+++ b/tools/deployment/spider-helm/values.yaml
@@ -43,6 +43,7 @@ spiderConfig:
     liveness:
       scheduler_heartbeat_interval_sec: 10
       storage_heartbeat_interval_sec: 10
+    log_level: "INFO"
     scheduler_poll_wait_ms: 1000
     task_executor:
       bin_path: "/usr/local/bin/spider-task-executor"
@@ -52,6 +53,7 @@ spiderConfig:
 
   scheduler:
     connection_pool_size: 4
+    log_level: "INFO"
     port: 50052
     runtime:
       scheduler:
@@ -67,6 +69,7 @@ spiderConfig:
           tick_interval_ms: 5
 
   storage:
+    log_level: "INFO"
     port: 50051
     runtime:
       ready_queue_config:


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR adds support for setting log level in storage, scheduler and worker services by:
* Adding `log_level` field in `values.yaml` for all three services, default to `INFO`.
* Adding `RUST_LOG` in env for all three services using the corresponding `log_level`.
* Bumping chart version to satisfy chart linting workflow.




# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* [x] Run e2e test on [test branch](https://github.com/sitaowang1998/spider/tree/helm-dev-e2e) and observer that:
  * `RUST_LOG` set to `INFO` for all three pods by default.
  * Info level logs are available using `kubectl logs`.
* [x] GitHub workflows pass.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable log levels for scheduler, storage, and execution manager services.
  * Added default `INFO` log-level settings to the deployment configuration.
  * Preserved support for additional worker environment variables.

* **Chores**
  * Updated the deployment chart version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->