### PR TITLE
refactor(spider-storage)!: Remove the redundant `_config` suffix from `RuntimeConfig`'s fields.

### DIFF
--- a/components/spider-storage/src/state/runtime.rs
+++ b/components/spider-storage/src/state/runtime.rs
@@ -29,13 +29,13 @@ use crate::task_instance_pool::create_task_instance_pool;
 /// Runtime configuration for the storage service.
 #[derive(Clone, Debug, Deserialize)]
 pub struct RuntimeConfig {
-    pub db_config: DatabaseConfig,
+    pub db: DatabaseConfig,
     #[serde(default)]
-    pub ready_queue_config: ReadyQueueConfig,
+    pub ready_queue: ReadyQueueConfig,
     #[serde(default)]
-    pub task_instance_pool_config: TaskInstancePoolConfig,
+    pub task_instance_pool: TaskInstancePoolConfig,
     #[serde(default)]
-    pub job_cache_gc_config: JobCacheGcConfig,
+    pub job_cache_gc: JobCacheGcConfig,
 }
 
 /// Runtime state for the storage service.
@@ -153,15 +153,15 @@ pub async fn create_runtime(
     StorageServerError,
 > {
     let cancellation_token = CancellationToken::new();
-    let db = MariaDbStorageConnector::connect(&config.db_config).await?;
+    let db = MariaDbStorageConnector::connect(&config.db).await?;
     let session_id = db.session_id();
     let (ready_queue_sender, ready_queue_receiver) =
-        create_ready_queue(&config.ready_queue_config).map_err(CacheError::from)?;
+        create_ready_queue(&config.ready_queue).map_err(CacheError::from)?;
     let (task_instance_pool_connector, task_instance_pool_join_handle) = create_task_instance_pool(
         ready_queue_sender.clone(),
         db.clone(),
         cancellation_token.clone(),
-        &config.task_instance_pool_config,
+        &config.task_instance_pool,
     )
     .map_err(CacheError::from)?;
 
@@ -174,7 +174,7 @@ pub async fn create_runtime(
     let (job_cache_gc_handle, job_cache_gc_join_handle) = create_job_cache_gc(
         job_cache.clone(),
         cancellation_token.clone(),
-        &config.job_cache_gc_config,
+        &config.job_cache_gc,
     )
     .map_err(CacheError::from)?;
     let service_state = ServiceState::new(ServiceStateParams {

--- a/components/spider-storage/tests/runtime_recovery_test.rs
+++ b/components/spider-storage/tests/runtime_recovery_test.rs
@@ -201,10 +201,10 @@ async fn restarted_storage_cache_recovers_cleanup_ready_job() -> anyhow::Result<
 /// while other configurations set to default.
 fn create_runtime_config() -> RuntimeConfig {
     RuntimeConfig {
-        db_config: create_mariadb_config(),
-        ready_queue_config: ReadyQueueConfig::default(),
-        task_instance_pool_config: TaskInstancePoolConfig::default(),
-        job_cache_gc_config: JobCacheGcConfig::default(),
+        db: create_mariadb_config(),
+        ready_queue: ReadyQueueConfig::default(),
+        task_instance_pool: TaskInstancePoolConfig::default(),
+        job_cache_gc: JobCacheGcConfig::default(),
     }
 }
 

--- a/tools/deployment/spider-helm/Chart.yaml
+++ b/tools/deployment/spider-helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: "v2"
 name: "spider"
 description: "A Helm chart for the Spider Huntsman deployment"
 type: "application"
-version: "0.1.9"
+version: "0.1.10"
 appVersion: "0.1.0-dev"
 home: "https://github.com/y-scope/spider"
 sources: ["https://github.com/y-scope/spider"]

--- a/tools/deployment/spider-helm/Chart.yaml
+++ b/tools/deployment/spider-helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: "v2"
 name: "spider"
 description: "A Helm chart for the Spider Huntsman deployment"
 type: "application"
-version: "0.1.8"
+version: "0.1.9"
 appVersion: "0.1.0-dev"
 home: "https://github.com/y-scope/spider"
 sources: ["https://github.com/y-scope/spider"]

--- a/tools/deployment/spider-helm/templates/configmap.yaml
+++ b/tools/deployment/spider-helm/templates/configmap.yaml
@@ -37,7 +37,7 @@ data:
     host: "0.0.0.0"
     port: {{ .Values.spiderConfig.storage.port }}
     runtime:
-      db_config:
+      db:
         host: {{ include "spider.databaseHost" . | quote }}
         max_connections: {{ .Values.spiderConfig.database.max_connections }}
         name: {{ .Values.spiderConfig.database.name | quote }}

--- a/tools/deployment/spider-helm/values.yaml
+++ b/tools/deployment/spider-helm/values.yaml
@@ -41,8 +41,8 @@ spiderConfig:
   execution_manager:
     connection_pool_size: 4
     liveness:
-      scheduler_heartbeat_interval_sec: 10
-      storage_heartbeat_interval_sec: 10
+      scheduler_heartbeat_interval_sec: 1
+      storage_heartbeat_interval_sec: 1
     log_level: "INFO"
     scheduler_poll_wait_ms: 1000
     task_executor:
@@ -59,12 +59,12 @@ spiderConfig:
       scheduler:
         policy: "round_robin"
         config:
-          active_job_queue_capacity: 64
+          active_job_queue_capacity: 16
           cleanup_ready_task_capacity: 256
           commit_ready_task_capacity: 256
-          dispatch_queue_capacity: 64
+          dispatch_queue_capacity: 16
           finalizing_job_expiration_timeout_sec: 300
-          ready_task_capacity: 65536
+          ready_task_capacity: 1048576
           storage_poll_timeout_ms: 10
           tick_interval_ms: 5
 

--- a/tools/deployment/spider-helm/values.yaml
+++ b/tools/deployment/spider-helm/values.yaml
@@ -72,7 +72,7 @@ spiderConfig:
     log_level: "INFO"
     port: 50051
     runtime:
-      ready_queue_config:
+      ready_queue:
         cleanup_capacity: 256
         commit_capacity: 256
         task_capacity: 1048576


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Every field in spider-storage's `RuntimeConfig` carries a `_config` suffix. The suffix is redundant: the struct is already named `RuntimeConfig`, each field's type is already a `*Config`, and the fields are reached as `config.db_config`, `config.ready_queue_config`, and so on. The suffix also leaks into the YAML configuration schema, making the keys under `runtime:` needlessly verbose.

This PR drops the suffix from all four fields:

| Before | After |
| --- | --- |
| `db_config` | `db` |
| `ready_queue_config` | `ready_queue` |
| `task_instance_pool_config` | `task_instance_pool` |
| `job_cache_gc_config` | `job_cache_gc` |

Since these fields are deserialized from `storage.yaml`, the configuration keys change accordingly:

```yaml
runtime:
  db:
    host: "spider-database"
    max_connections: 64
    name: "spider-db"
    port: 3306
  ready_queue:
    cleanup_capacity: 256
    commit_capacity: 256
    task_capacity: 1048576
```

The Helm chart is updated in lockstep: `templates/configmap.yaml` renders `db:` instead of `db_config:`, and `values.yaml` exposes `spiderConfig.storage.runtime.ready_queue` instead of `ready_queue_config`. The chart version is bumped to satisfy the chart linting workflow.

Existing storage configuration files must rename these four keys. This applies to custom Helm values as well: the chart passes `spiderConfig.storage.runtime` through with `toYaml`, so a stale `ready_queue_config` (or any other old key) in a user's overrides lands in the rendered config and is rejected by Serde when the storage server starts.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [ ] Ensure all workflows pass.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Updated storage runtime configuration names for database, ready queue, task instance pool, and job cache settings.
  - Deployment configurations must use the updated key names to ensure runtime settings continue to load correctly.

- **Deployment**
  - Updated the Helm chart version to 0.1.10.
  - Aligned Helm defaults and generated configuration with the revised runtime setting names.

- **Bug Fixes**
  - Updated runtime recovery configuration to remain compatible with the renamed settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->