### PR TITLE
fix(huntsman): Update async-trait to 0.1.92 for latest nightly clippy changes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ edition = "2024"
 [workspace.dependencies]
 anyhow = "1.0.104"
 async-channel = "2.5.0"
-async-trait = "0.1.91"
+async-trait = "0.1.92"
 bincode = "1.3.3"
 bytes = "1.12.1"
 clap = { version = "4.6.4", features = ["derive"] }

--- a/components/spider-core/src/types/io.rs
+++ b/components/spider-core/src/types/io.rs
@@ -671,7 +671,7 @@ mod tests {
         assert_eq!(wire, 0u32.to_le_bytes());
 
         let decoded: Vec<TaskOutput> = TaskOutputsSerializer::deserialize(&wire)?;
-        assert!(decoded.is_empty());
+        assert_eq!(decoded, [] as [std::vec::Vec<u8>; 0]);
         Ok(())
     }
 
@@ -801,7 +801,7 @@ mod tests {
     fn serialize_from_empty_tuple() -> anyhow::Result<()> {
         let wire = TaskOutputsSerializer::from_tuple(&())?;
         let payloads: Vec<TaskOutput> = TaskOutputsSerializer::deserialize(&wire)?;
-        assert!(payloads.is_empty());
+        assert_eq!(payloads, [] as [std::vec::Vec<u8>; 0]);
         Ok(())
     }
 

--- a/components/spider-storage/src/ready_queue.rs
+++ b/components/spider-storage/src/ready_queue.rs
@@ -438,7 +438,7 @@ mod tests {
         let entries = receiver.recv_tasks(5, wait).await?;
         let elapsed = start.elapsed();
 
-        assert!(entries.is_empty());
+        assert_eq!(entries, [] as [ReadyQueueEntry<TaskIndex>; 0]);
         assert!(
             elapsed >= wait,
             "recv should block for the full wait duration when no entries arrive",

--- a/components/spider-storage/tests/scheduling_infra.rs
+++ b/components/spider-storage/tests/scheduling_infra.rs
@@ -230,7 +230,6 @@ where
 }
 
 /// Creates a [`NoopDbConnector`] with default [`JobId`] and [`ResourceGroupId`].
-#[must_use]
 pub fn noop_db_connector_factory() -> impl DbConnectorFactory<NoopDbConnector> {
     async |_: &ValidatedJobSubmission| {
         (
@@ -458,7 +457,6 @@ pub async fn run_workload<DbConnectorType: InternalJobOrchestration + 'static>(
 /// # Panics
 ///
 /// Panics if job registration fails.
-#[must_use]
 pub fn mariadb_db_connector_factory(
     storage: MariaDbStorageConnector,
     rg_id: ResourceGroupId,


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

The current Rust linting workflow fails due to a clippy nightly version upgrade: https://github.com/y-scope/spider/actions/runs/31350091869

This PR fixes the problem by:

* Upgrade `async-trait` to 0.1.92.
* Accept auto-fixes introduced by clippy.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Ensure all workflows pass.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refined empty-result assertions to make test expectations clearer and more consistent.
  * Simplified test helper declarations without changing their behaviour.

* **Chores**
  * Updated an internal dependency to the latest patch version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->