### PR TITLE
fix(lint): Add explicit line width for `toml` files (fixes #437).

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,7 @@ clap = { version = "4.6.4", features = ["derive"] }
 const_format = "0.2.36"
 const-str = "1.1.0"
 dashmap = "6.2.1"
-futures-util = {
-  version = "0.3.33",
-  default-features = false,
-  features = ["sink", "std"]
-}
+futures-util = { version = "0.3.33", default-features = false, features = ["sink", "std"] }
 huntsman-complex-types = { path = "examples/huntsman/complex/types" }
 huntsman-nn-core = { path = "examples/huntsman/nn/core" }
 integration-test-tasks = { path = "tests/huntsman/integration-test-tasks" }

--- a/components/spider-task-executor/Cargo.toml
+++ b/components/spider-task-executor/Cargo.toml
@@ -22,10 +22,7 @@ serde = { workspace = true }
 spider-core = { workspace = true }
 spider-tdl = { workspace = true }
 thiserror = { workspace = true }
-tokio = {
-  workspace = true,
-  features = ["io-std", "io-util", "macros", "rt", "sync", "time"]
-}
+tokio = { workspace = true, features = ["io-std", "io-util", "macros", "rt", "sync", "time"] }
 tokio-util = { workspace = true, features = ["codec"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/tests/huntsman/e2e/Cargo.toml
+++ b/tests/huntsman/e2e/Cargo.toml
@@ -8,8 +8,5 @@ publish = false
 anyhow = { workspace = true }
 spider-client = { workspace = true }
 spider-core = { workspace = true }
-tokio = {
-  workspace = true,
-  features = ["macros", "rt-multi-thread", "sync", "time"]
-}
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
 tonic = { workspace = true }

--- a/tests/huntsman/em-runtime/Cargo.toml
+++ b/tests/huntsman/em-runtime/Cargo.toml
@@ -18,7 +18,4 @@ spider-core = { workspace = true }
 spider-execution-manager = { workspace = true }
 spider-tdl = { workspace = true }
 test-utils = { workspace = true }
-tokio = {
-  workspace = true,
-  features = ["macros", "rt", "rt-multi-thread", "time"]
-}
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "time"] }

--- a/tests/huntsman/task-executor/Cargo.toml
+++ b/tests/huntsman/task-executor/Cargo.toml
@@ -29,8 +29,5 @@ spider-task-executor = { workspace = true }
 spider-tdl = { workspace = true }
 tabled = { workspace = true }
 test-utils = { workspace = true }
-tokio = {
-  workspace = true,
-  features = ["io-util", "macros", "rt", "rt-multi-thread", "time"]
-}
+tokio = { workspace = true, features = ["io-util", "macros", "rt", "rt-multi-thread", "time"] }
 tokio-util = { workspace = true }

--- a/tests/huntsman/test-utils/Cargo.toml
+++ b/tests/huntsman/test-utils/Cargo.toml
@@ -20,8 +20,5 @@ spider-core = { workspace = true }
 spider-execution-manager = { workspace = true }
 spider-task-executor = { workspace = true }
 spider-tdl = { workspace = true }
-tokio = {
-  workspace = true,
-  features = ["io-util", "macros", "process", "rt", "sync", "time"]
-}
+tokio = { workspace = true, features = ["io-util", "macros", "process", "rt", "sync", "time"] }
 tokio-util = { workspace = true, features = ["codec"] }

--- a/tombi.toml
+++ b/tombi.toml
@@ -7,6 +7,8 @@ include = ["**/*.toml"]
 exclude = ["tools/yscope-dev-utils/**", "build/**", ".cargo/config.toml"]
 
 [format]
+[format.rules]
+line-width = 100
 
 [lint]
 [lint.rules]


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
As pointed out in #437, latest `tombi` update set default line width from 80 to unlimited, causing the workflow to fail.

This PR resolves this issue by explicitly setting the line with to 100. We choose 100 instead of 80 because this is the common line width setting for other files in the repo.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* [x] GitHub workflows pass.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Standardized dependency declarations for improved configuration consistency.
  - Set the configuration line width to 100 characters for more uniform formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->