### PR TITLE
feat(docker-compose): Add Docker Compose stack that mounts a local directory.

### DIFF
--- a/taskfiles/docker.yaml
+++ b/taskfiles/docker.yaml
@@ -39,6 +39,23 @@ tasks:
     dir: "{{.G_SPIDER_COMPOSE_DIR}}"
     cmd: "docker compose --file compose.yaml down --volumes --remove-orphans"
 
+  # Builds Spider and its images, then starts a local deployment.
+  #
+  # @param {string} SPIDER_WORKER_LIBRARY_DIR The host directory containing the libraries.
+  compose:local:build-and-up:
+    cmds:
+      - task: ":build:rust"
+      - task: "build"
+      - task: "compose:local:up"
+        vars:
+          SPIDER_STORAGE_IMAGE_REF:
+            sh: "sed -n '1p' '{{.G_BUILD_DIR}}/spider-storage-image.id'"
+          SPIDER_SCHEDULER_IMAGE_REF:
+            sh: "sed -n '1p' '{{.G_BUILD_DIR}}/spider-scheduler-image.id'"
+          SPIDER_WORKER_IMAGE_REF:
+            sh: "sed -n '1p' '{{.G_BUILD_DIR}}/spider-worker-image.id'"
+          SPIDER_WORKER_LIBRARY_DIR: "{{.SPIDER_WORKER_LIBRARY_DIR}}"
+
   # Starts a local Spider deployment with libraries mounted into every worker.
   #
   # @param {string} SPIDER_STORAGE_IMAGE_REF The storage image reference.

--- a/taskfiles/docker.yaml
+++ b/taskfiles/docker.yaml
@@ -52,7 +52,8 @@ tasks:
     dir: "{{.G_SPIDER_COMPOSE_DIR}}"
     cmd: "docker compose --file compose.yaml down --volumes --remove-orphans"
 
-  # Builds Spider and its images, then starts a local deployment.
+  # Builds Spider's Rust binaries and container images, then starts a local Docker Compose
+  # deployment that uses the freshly built images.
   #
   # @param {string} SPIDER_WORKER_LIBRARY_DIR The host directory containing the libraries.
   compose:local:build-and-up:
@@ -69,7 +70,11 @@ tasks:
             sh: "sed -n '1p' '{{.G_BUILD_DIR}}/spider-worker-image.id'"
           SPIDER_WORKER_LIBRARY_DIR: "{{.SPIDER_WORKER_LIBRARY_DIR}}"
 
-  # Starts a local Spider deployment with libraries mounted into every worker.
+  # Starts a local Docker Compose deployment with the library directory mounted
+  # into every worker.
+  #
+  # NOTE: Users can override image refs for each service; when unset, each defaults to
+  # `ghcr.io/y-scope/spider/<service>:${SPIDER_IMAGE_TAG:-main}`.
   #
   # @param {string} SPIDER_STORAGE_IMAGE_REF The storage image reference.
   # @param {string} SPIDER_SCHEDULER_IMAGE_REF The scheduler image reference.

--- a/taskfiles/docker.yaml
+++ b/taskfiles/docker.yaml
@@ -41,9 +41,15 @@ tasks:
 
   # Starts a local Spider deployment with libraries mounted into every worker.
   #
+  # @param {string} SPIDER_STORAGE_IMAGE_REF The storage image reference.
+  # @param {string} SPIDER_SCHEDULER_IMAGE_REF The scheduler image reference.
+  # @param {string} SPIDER_WORKER_IMAGE_REF The worker image reference.
   # @param {string} SPIDER_WORKER_LIBRARY_DIR The host directory containing the libraries.
   compose:local:up:
     env:
+      SPIDER_STORAGE_IMAGE_REF: "{{.SPIDER_STORAGE_IMAGE_REF}}"
+      SPIDER_SCHEDULER_IMAGE_REF: "{{.SPIDER_SCHEDULER_IMAGE_REF}}"
+      SPIDER_WORKER_IMAGE_REF: "{{.SPIDER_WORKER_IMAGE_REF}}"
       SPIDER_WORKER_LIBRARY_DIR: >-
         {{- if .SPIDER_WORKER_LIBRARY_DIR}}
           {{- if osIsAbs .SPIDER_WORKER_LIBRARY_DIR}}

--- a/taskfiles/docker.yaml
+++ b/taskfiles/docker.yaml
@@ -38,3 +38,26 @@ tasks:
   compose:clean:
     dir: "{{.G_SPIDER_COMPOSE_DIR}}"
     cmd: "docker compose --file compose.yaml down --volumes --remove-orphans"
+
+  # Starts a local Spider deployment with libraries mounted into every worker.
+  #
+  # @param {string} SPIDER_WORKER_LIBRARY_DIR The host directory containing the libraries.
+  compose:local:up:
+    env:
+      SPIDER_WORKER_LIBRARY_DIR: "{{.SPIDER_WORKER_LIBRARY_DIR}}"
+    requires:
+      vars: ["SPIDER_WORKER_LIBRARY_DIR"]
+    dir: "{{.G_SPIDER_COMPOSE_DIR}}"
+    cmd: >-
+      docker compose --project-name spider-local --file compose.yaml
+      --file compose.local.yaml up --detach --wait --wait-timeout 300
+
+  compose:local:down:
+    dir: "{{.G_SPIDER_COMPOSE_DIR}}"
+    cmd: "docker compose --project-name spider-local --file compose.yaml down"
+
+  compose:local:clean:
+    dir: "{{.G_SPIDER_COMPOSE_DIR}}"
+    cmd: >-
+      docker compose --project-name spider-local --file compose.yaml down
+      --volumes --remove-orphans

--- a/taskfiles/docker.yaml
+++ b/taskfiles/docker.yaml
@@ -52,33 +52,13 @@ tasks:
     dir: "{{.G_SPIDER_COMPOSE_DIR}}"
     cmd: "docker compose --file compose.yaml down --volumes --remove-orphans"
 
-  # Builds Spider's Rust binaries and container images, then starts a local Docker Compose
-  # deployment that uses the freshly built images.
-  #
-  # @param {string} SPIDER_WORKER_LIBRARY_DIR The host directory containing the libraries.
-  compose:local:build-and-up:
-    env:
-    cmds:
-      - task: ":build:rust"
-      - task: ":docker:build"
-      - task: "compose:local:up"
-        vars:
-          SPIDER_PULL_POLICY: "never"
-          SPIDER_STORAGE_IMAGE_REF:
-            sh: "sed -n '1p' '{{.G_BUILD_DIR}}/spider-storage-image.id'"
-          SPIDER_SCHEDULER_IMAGE_REF:
-            sh: "sed -n '1p' '{{.G_BUILD_DIR}}/spider-scheduler-image.id'"
-          SPIDER_WORKER_IMAGE_REF:
-            sh: "sed -n '1p' '{{.G_BUILD_DIR}}/spider-worker-image.id'"
-          SPIDER_WORKER_LIBRARY_DIR: "{{.SPIDER_WORKER_LIBRARY_DIR}}"
-
   # Starts a local Docker Compose deployment with the library directory mounted
   # into every worker.
   #
   # NOTE: Users can override image refs for each service; when unset, each defaults to
   # `ghcr.io/y-scope/spider/<service>:${SPIDER_IMAGE_TAG:-main}`.
   #
-  # @param {string} SPIDER_PULL_POLICY The image pull policy.
+  # @param {string} SPIDER_PULL_POLICY The image pull policy. If not set, default to "always".
   # @param {string} SPIDER_STORAGE_IMAGE_REF The storage image reference.
   # @param {string} SPIDER_SCHEDULER_IMAGE_REF The scheduler image reference.
   # @param {string} SPIDER_WORKER_IMAGE_REF The worker image reference.

--- a/taskfiles/docker.yaml
+++ b/taskfiles/docker.yaml
@@ -58,7 +58,7 @@ tasks:
   compose:local:build-and-up:
     cmds:
       - task: ":build:rust"
-      - task: "build"
+      - task: ":docker:build"
       - task: "compose:local:up"
         vars:
           SPIDER_STORAGE_IMAGE_REF:

--- a/taskfiles/docker.yaml
+++ b/taskfiles/docker.yaml
@@ -57,11 +57,13 @@ tasks:
   #
   # @param {string} SPIDER_WORKER_LIBRARY_DIR The host directory containing the libraries.
   compose:local:build-and-up:
+    env:
     cmds:
       - task: ":build:rust"
       - task: ":docker:build"
       - task: "compose:local:up"
         vars:
+          SPIDER_PULL_POLICY: "never"
           SPIDER_STORAGE_IMAGE_REF:
             sh: "sed -n '1p' '{{.G_BUILD_DIR}}/spider-storage-image.id'"
           SPIDER_SCHEDULER_IMAGE_REF:
@@ -76,12 +78,14 @@ tasks:
   # NOTE: Users can override image refs for each service; when unset, each defaults to
   # `ghcr.io/y-scope/spider/<service>:${SPIDER_IMAGE_TAG:-main}`.
   #
+  # @param {string} SPIDER_PULL_POLICY The image pull policy.
   # @param {string} SPIDER_STORAGE_IMAGE_REF The storage image reference.
   # @param {string} SPIDER_SCHEDULER_IMAGE_REF The scheduler image reference.
   # @param {string} SPIDER_WORKER_IMAGE_REF The worker image reference.
   # @param {string} SPIDER_WORKER_LIBRARY_DIR The host directory containing the libraries.
   compose:local:up:
     env:
+      SPIDER_PULL_POLICY: "{{.SPIDER_PULL_POLICY}}"
       SPIDER_STORAGE_IMAGE_REF: "{{.SPIDER_STORAGE_IMAGE_REF}}"
       SPIDER_SCHEDULER_IMAGE_REF: "{{.SPIDER_SCHEDULER_IMAGE_REF}}"
       SPIDER_WORKER_IMAGE_REF: "{{.SPIDER_WORKER_IMAGE_REF}}"

--- a/taskfiles/docker.yaml
+++ b/taskfiles/docker.yaml
@@ -44,9 +44,14 @@ tasks:
   # @param {string} SPIDER_WORKER_LIBRARY_DIR The host directory containing the libraries.
   compose:local:up:
     env:
-      SPIDER_WORKER_LIBRARY_DIR: "{{.SPIDER_WORKER_LIBRARY_DIR}}"
-    requires:
-      vars: ["SPIDER_WORKER_LIBRARY_DIR"]
+      SPIDER_WORKER_LIBRARY_DIR: >-
+        {{- if .SPIDER_WORKER_LIBRARY_DIR}}
+          {{- if osIsAbs .SPIDER_WORKER_LIBRARY_DIR}}
+            {{- osClean .SPIDER_WORKER_LIBRARY_DIR}}
+          {{- else}}
+            {{- joinPath .ROOT_DIR .SPIDER_WORKER_LIBRARY_DIR}}
+          {{- end}}
+        {{- end}}
     dir: "{{.G_SPIDER_COMPOSE_DIR}}"
     cmd: >-
       docker compose --project-name spider-local --file compose.yaml

--- a/tools/deployment/spider-compose/.env.example
+++ b/tools/deployment/spider-compose/.env.example
@@ -14,6 +14,8 @@ SPIDER_STORAGE_DB_PASSWORD=spider-password
 SPIDER_STORAGE_DB_USERNAME=spider-user
 
 # Storage settings.
+# A complete storage image reference takes precedence over `SPIDER_IMAGE_TAG` when set.
+# SPIDER_STORAGE_IMAGE_REF=ghcr.io/y-scope/spider/storage:main
 SPIDER_STORAGE_LOG_LEVEL=INFO
 SPIDER_STORAGE_PORT=50051
 SPIDER_STORAGE_PUBLISHED_IP=127.0.0.1
@@ -29,6 +31,8 @@ SPIDER_STORAGE_TASK_INSTANCE_POOL_GC_INTERVAL_SEC=30
 SPIDER_STORAGE_TASK_INSTANCE_POOL_MESSAGE_CHANNEL_CAPACITY=128
 
 # Scheduler settings.
+# A complete scheduler image reference takes precedence over `SPIDER_IMAGE_TAG` when set.
+# SPIDER_SCHEDULER_IMAGE_REF=ghcr.io/y-scope/spider/scheduler:main
 SPIDER_SCHEDULER_LOG_LEVEL=INFO
 SPIDER_SCHEDULER_PORT=50052
 SPIDER_SCHEDULER_CONNECTION_POOL_SIZE=8

--- a/tools/deployment/spider-compose/compose.local.yaml
+++ b/tools/deployment/spider-compose/compose.local.yaml
@@ -1,0 +1,7 @@
+services:
+  spider-worker:
+    volumes:
+      - type: "bind"
+        source: "${SPIDER_WORKER_LIBRARY_DIR:?}"
+        target: "${SPIDER_WORKER_PACKAGE_DIR:-/opt/spider/packages}"
+        read_only: true

--- a/tools/deployment/spider-compose/compose.yaml
+++ b/tools/deployment/spider-compose/compose.yaml
@@ -51,7 +51,8 @@ services:
 
   spider-storage:
     <<: *service_defaults
-    image: "ghcr.io/y-scope/spider/storage:${SPIDER_IMAGE_TAG:-main}"
+    image: >-
+      ${SPIDER_STORAGE_IMAGE_REF:-ghcr.io/y-scope/spider/storage:${SPIDER_IMAGE_TAG:-main}}
     networks:
       - "default"
       - "spider-internal"
@@ -84,7 +85,8 @@ services:
 
   spider-scheduler:
     <<: *service_defaults
-    image: "ghcr.io/y-scope/spider/scheduler:${SPIDER_IMAGE_TAG:-main}"
+    image: >-
+      ${SPIDER_SCHEDULER_IMAGE_REF:-ghcr.io/y-scope/spider/scheduler:${SPIDER_IMAGE_TAG:-main}}
     networks:
       - "spider-internal"
     command: [


### PR DESCRIPTION


<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR adds support to start, stop and clean up Docker Compose cluster that mounts a local directory so the locally built libraries are available to the task executors. This PR:
- Adds a `compose.local.yaml` that adds a volume mount for `spider-worker` services.
- Adds tasks that starts a Docker Compose cluster with a special project name and with directory mount.
- Adds tasks that stop and cleans up the Docker Compose cluster started by previously described task.
- Adds image ref override for storage and scheduler, fixes #431.
- Adds a task that builds rust, builds images and starts the Docker Compose cluster. This is a single command that a developer can use to test the change in a Docker Compose cluster.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* [x] New tasks start, stop and cleans up a cluster, and the cluster has access to the expected libraries.
* [ ] GitHub workflows pass.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added local Docker Compose commands to start, stop, and clean up Spider services.
  * Local deployments now wait for services to become ready before completing startup.
  * Added support for mounting a local worker library into the Spider worker service.
  * Added optional image overrides for storage and scheduler services, while retaining existing defaults.
  * Added configuration examples for local worker library paths and service image references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->