### PR TITLE
feat(docker-compose): Remove top level folder in published Docker Compose artifact.

### DIFF
--- a/taskfiles/docker.yaml
+++ b/taskfiles/docker.yaml
@@ -31,14 +31,14 @@ tasks:
     requires:
       vars: ["OCI_REFERENCE"]
     deps: ["compose:validate"]
-    dir: "{{.G_SPIDER_COMPOSE_DIR}}/.."
+    dir: "{{.G_SPIDER_COMPOSE_DIR}}"
     cmd: >-
       oras push
       --artifact-type "application/vnd.yscope.spider.compose"
       '{{.OCI_REFERENCE}}'
-      "spider-compose/compose.yaml:application/yaml"
-      "spider-compose/configs/:application/vnd.yscope.spider.compose.configs.tar"
-      "spider-compose/.env.example:text/plain"
+      "compose.yaml:application/yaml"
+      "configs/:application/vnd.yscope.spider.compose.configs.tar"
+      ".env.example:text/plain"
 
   compose:up:
     dir: "{{.G_SPIDER_COMPOSE_DIR}}"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
## Background
As pointed out in https://github.com/y-scope/clp/pull/2481#discussion_r3816284036, the Docker Compose artifact puts everything under a `spider-compose` directory. This might be a surprise to users.

## Solution
This PR removes the top level `spider-compose` folder in the Docker Compose artifact.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* [x] Test publication in my own repo show that the top level directory no longer exists.
  Check https://github.com/sitaowang1998/spider/pkgs/container/spider%2Fcompose/1150648531?tag=main, sha256: 0404e0647d53573f29add0cff78cef925eb3c90a67ea2f2b735070f39adcefb0.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Compose artifact publishing to use the correct working directory and file paths.
  * Publishing now reliably includes the Compose file, configuration directory, and environment template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->