### PR TITLE
chore(helm): Bump chart version to 0.2.0-dev.0 to adopt the standard Helm chart versioning scheme.

### DIFF
--- a/tools/deployment/spider-helm/Chart.yaml
+++ b/tools/deployment/spider-helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: "v2"
 name: "spider"
 description: "A Helm chart for the Spider Huntsman deployment"
 type: "application"
-version: "0.1.12"
+version: "0.2.0-dev.0"
 appVersion: "0.1.0-dev"
 home: "https://github.com/y-scope/spider"
 sources: ["https://github.com/y-scope/spider"]


### PR DESCRIPTION
# Description

This PR moves the Helm chart's `version` from `0.1.12` to `0.2.0-dev.0`, adopting the standard Helm chart versioning scheme.

The previously published `0.1.X` versions predate this scheme and had no formal `0.1.0` release, so `main` starts at `0.2.0-dev.0` targeting `0.2.0` as the chart's first formal release.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

No manual validation was performed.
The change is metadata-only (the chart's `version` field); the `spider-helm` workflow's `ct lint` job validates the version format and the bump against `main` on every PR, and on merge the publish job will publish `spider-0.2.0-dev.0` to the Helm repository.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the deployment package version to `0.2.0-dev.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->