### PR TITLE
ci: Retarget the release workflows to the `v*-huntsman` tag scheme and suppress the `:latest` tag.

### DIFF
--- a/.github/workflows/spider-compose.yaml
+++ b/.github/workflows/spider-compose.yaml
@@ -11,7 +11,7 @@ on:
   push:
     branches: ["main"]
     paths: *monitored_paths
-    tags: ["spider-huntsman-v*"]
+    tags: ["v*-huntsman"]
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/spider-helm.yaml
+++ b/.github/workflows/spider-helm.yaml
@@ -22,7 +22,7 @@ concurrency:
   cancel-in-progress: >-
     ${{
       github.ref != 'refs/heads/main'
-      && !startsWith(github.ref, 'refs/heads/spider-huntsman-v')
+      && !startsWith(github.ref, 'refs/heads/release/')
     }}
 
 jobs:
@@ -50,11 +50,11 @@ jobs:
         run: "task lint:check-helm"
 
   publish:
-    # Publish from `main` and `spider-huntsman-vA.B.C` release branches.
+    # Publish from `main` and `release/*` release branches.
     if: >-
       github.event_name != 'pull_request'
       && (github.ref == 'refs/heads/main'
-      || startsWith(github.ref, 'refs/heads/spider-huntsman-v'))
+      || startsWith(github.ref, 'refs/heads/release/'))
     needs: "lint"
     runs-on: "ubuntu-latest"
     concurrency:

--- a/.github/workflows/spider-image-build.yaml
+++ b/.github/workflows/spider-image-build.yaml
@@ -17,7 +17,7 @@ on:
   push:
     branches: ["main"]
     paths: *monitored_paths
-    tags: ["spider-huntsman-v*"]
+    tags: ["v*-huntsman"]
   workflow_dispatch:
 
 permissions: {}
@@ -147,6 +147,7 @@ jobs:
         id: "meta"
         with:
           images: "ghcr.io/${{steps.repo.outputs.name}}/${{matrix.service}}"
+          flavor: "latest=false"
           tags: |
             type=ref,event=branch
             type=ref,event=tag


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

## Background

Spider has no released artifacts yet. The three publishing workflows react to tags matching `spider-huntsman-v*`, and no tag of that shape has ever been pushed — the only tags in the repository are `spider-py-v0.1.0` and `spider-py-v0.2.0`. The first Huntsman release will be tagged `v<version>-huntsman` (e.g. `v0.1.0-rc.0-huntsman`), so the workflows have to be retargeted before a release tag can trigger anything.

## Solution

### 1. Retarget the tag filters to `v*-huntsman`

`spider-image-build.yaml`, `spider-compose.yaml`.

The `-huntsman` suffix form was chosen because `v0.1.0-rc.0-huntsman` is already a legal OCI tag. That means the git tag, the three container image tags, and the Compose OCI artifact tag are all the *same string*, with no sanitization step anywhere: `docker/metadata-action`'s `sanitizeTag` (`tag.replace(/[^a-zA-Z0-9._-]+/g, '-')`) returns it byte-identical, and `spider-compose.yaml`'s existing `tag="${GITHUB_REF_NAME}"` needs no change.

A `+huntsman` build-metadata form was considered and rejected. `+` is forbidden by the OCI tag grammar, so `oras push` fails outright — while `docker/metadata-action` silently rewrites it to `-`. The two workflows would have disagreed on the published tag, with only one of them failing visibly.

Note that `-` is not a glob metacharacter in GitHub's ref filters (unlike `*`, `**`, `+`, `?`, `!`), so `v*-huntsman` matches literally and needs no escaping. It cannot match the existing `spider-py-v*` tags, which do not begin with `v`.

`paths:` is deliberately left untouched: per GitHub's documentation, path filters are not evaluated for pushes of tags, so they do not suppress tag-triggered runs.

### 2. Retarget the Helm publish gate to `refs/heads/release/`

`spider-helm.yaml`.

The chart publishes from a branch rather than a tag, and release branches are now named `release/<tag>` instead of sharing the tag's name. A branch and a tag with identical names make `git rev-parse` and `git checkout` ambiguous, which is worth designing out of a release procedure. No `tags:` filter is added here — this workflow publishes from branches by design.

### 3. Suppress the `:latest` tag

`spider-image-build.yaml`.

`docker/metadata-action`'s `flavor.latest` defaults to `auto`, and its `procRefTag` sets `latest = true` *unconditionally* for `type=ref,event=tag` — there is no prerelease detection on that code path (that logic lives in `procSemver`, which this repository does not use). Without `flavor: "latest=false"`, the first release — a release candidate — would move `:latest` on all three images to a pre-GA build.

This is the change that must land before any release tag is pushed. GHCR has no per-tag delete: you delete a package *version*, and a version carries all of its tags. An accidental `:latest` would share a version with the release image, so it could not be removed without deleting the release image itself.

The `flavor` input is added to the `docker/metadata-action` in `merge-manifests` (the one that stamps the published tags). The instance in `build` is left alone — it only feeds `labels:`.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Ensure all workflows pass.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Updated release tag handling to use the `v*-huntsman` format.
  * Publishing now supports the `main` branch and `release/*` branches.
  * Improved cancellation behavior for non-release workflow runs.

* **Container Images**
  * Updated image builds to recognize the new release tag format.
  * Multi-architecture image metadata no longer automatically applies the `latest` tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->