### PR TITLE
feat(spider-proto): Add optional resource-group fields to the scheduler's next-task request and the storage's execution manager registration.

### DIFF
--- a/components/spider-execution-manager/src/client/grpc/liveness.rs
+++ b/components/spider-execution-manager/src/client/grpc/liveness.rs
@@ -55,7 +55,7 @@ impl LivenessClient for GrpcLivenessClient {
     async fn register(&self, ip: IpAddr) -> Result<RegistrationResponse, LivenessResponseError> {
         let request = storage::RegisterExecutionManagerRequest {
             ip_address: ip.to_string(),
-            external_resource_group_id: None,
+            resource_group_credentials: None,
         };
         let response = self
             .connection_pool

--- a/components/spider-execution-manager/src/client/grpc/liveness.rs
+++ b/components/spider-execution-manager/src/client/grpc/liveness.rs
@@ -55,6 +55,7 @@ impl LivenessClient for GrpcLivenessClient {
     async fn register(&self, ip: IpAddr) -> Result<RegistrationResponse, LivenessResponseError> {
         let request = storage::RegisterExecutionManagerRequest {
             ip_address: ip.to_string(),
+            external_resource_group_id: None,
         };
         let response = self
             .connection_pool
@@ -156,6 +157,7 @@ mod tests {
             registration: Some(storage::ExecutionManagerRegistration {
                 execution_manager_id: EM_ID.get(),
                 session_id: SESSION_ID,
+                resource_group_id: None,
             }),
         };
 
@@ -187,6 +189,7 @@ mod tests {
             registration: Some(storage::ExecutionManagerRegistration {
                 execution_manager_id: 5,
                 session_id: 0,
+                resource_group_id: None,
             }),
         };
 

--- a/components/spider-execution-manager/src/client/grpc/scheduler.rs
+++ b/components/spider-execution-manager/src/client/grpc/scheduler.rs
@@ -67,6 +67,7 @@ impl SchedulerClient for GrpcSchedulerClient {
                     execution_manager_id: em_id.get(),
                     prev_assignment: prev_assignment.take().map(Into::into),
                     wait_time_ms,
+                    resource_group_id: None,
                 })
                 .await
                 .map_err(|status| status_to_error(&status))?

--- a/components/spider-proto-rust/src/generated/scheduler.rs
+++ b/components/spider-proto-rust/src/generated/scheduler.rs
@@ -7,6 +7,8 @@ pub struct NextTaskRequest {
     pub prev_assignment: ::core::option::Option<TaskAssignmentRecord>,
     #[prost(uint64, tag = "3")]
     pub wait_time_ms: u64,
+    #[prost(uint64, optional, tag = "4")]
+    pub resource_group_id: ::core::option::Option<u64>,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct NextTaskResponse {

--- a/components/spider-proto-rust/src/generated/storage.rs
+++ b/components/spider-proto-rust/src/generated/storage.rs
@@ -152,12 +152,19 @@ pub struct VerifyResourceGroupRequest {
     pub password: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ExternalResourceGroupCredentials {
+    #[prost(string, tag = "1")]
+    pub external_resource_group_id: ::prost::alloc::string::String,
+    #[prost(bytes = "vec", tag = "2")]
+    pub password: ::prost::alloc::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RegisterExecutionManagerRequest {
     #[prost(string, tag = "1")]
     pub ip_address: ::prost::alloc::string::String,
-    #[prost(string, optional, tag = "2")]
-    pub external_resource_group_id: ::core::option::Option<
-        ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "2")]
+    pub resource_group_credentials: ::core::option::Option<
+        ExternalResourceGroupCredentials,
     >,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]

--- a/components/spider-proto-rust/src/generated/storage.rs
+++ b/components/spider-proto-rust/src/generated/storage.rs
@@ -155,6 +155,10 @@ pub struct VerifyResourceGroupRequest {
 pub struct RegisterExecutionManagerRequest {
     #[prost(string, tag = "1")]
     pub ip_address: ::prost::alloc::string::String,
+    #[prost(string, optional, tag = "2")]
+    pub external_resource_group_id: ::core::option::Option<
+        ::prost::alloc::string::String,
+    >,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ExecutionManagerIdRequest {
@@ -167,6 +171,8 @@ pub struct ExecutionManagerRegistration {
     pub execution_manager_id: u64,
     #[prost(uint64, tag = "2")]
     pub session_id: u64,
+    #[prost(uint64, optional, tag = "3")]
+    pub resource_group_id: ::core::option::Option<u64>,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RegisterExecutionManagerResponse {

--- a/components/spider-proto-rust/src/unpack/scheduler.rs
+++ b/components/spider-proto-rust/src/unpack/scheduler.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use spider_core::types::id::ExecutionManagerId;
 use spider_core::types::scheduler::TaskAssignmentRecord;
+use tonic::Code;
 
 use crate::scheduler::HeartbeatRequest;
 use crate::scheduler::NextTaskRequest;
@@ -21,6 +22,12 @@ impl RequestUnpack for NextTaskRequest {
     type Unpacked = (ExecutionManagerId, Option<TaskAssignmentRecord>, Duration);
 
     fn unpack(self) -> Result<Self::Unpacked, UnpackError> {
+        if self.resource_group_id.is_some() {
+            return Err(UnpackError {
+                code: Code::Unimplemented,
+                message: "`resource_group_id` is not supported yet".to_owned(),
+            });
+        }
         Ok((
             ExecutionManagerId::from(self.execution_manager_id),
             self.prev_assignment.map(ProtoTaskAssignmentRecord::into),

--- a/components/spider-proto-rust/src/unpack/storage.rs
+++ b/components/spider-proto-rust/src/unpack/storage.rs
@@ -166,20 +166,22 @@ impl RequestUnpack for VerifyResourceGroupRequest {
     }
 }
 
-/// Unpacks [`RegisterExecutionManagerRequest`] into the execution manager's IP address.
+/// Unpacks [`RegisterExecutionManagerRequest`] into a tuple containing:
+///
+/// * The execution manager's IP address.
+/// * The external resource group credentials, if present.
 impl RequestUnpack for RegisterExecutionManagerRequest {
-    type Unpacked = IpAddr;
+    type Unpacked = (IpAddr, Option<(String, Vec<u8>)>);
 
     fn unpack(self) -> Result<Self::Unpacked, UnpackError> {
-        if self.external_resource_group_id.is_some() {
-            return Err(UnpackError {
-                code: Code::Unimplemented,
-                message: "`external_resource_group_id` is not supported yet".to_owned(),
-            });
-        }
-        self.ip_address
+        let ip_address = self
+            .ip_address
             .parse::<IpAddr>()
-            .map_err(|error| invalid_argument(format!("invalid IP address: {error}")))
+            .map_err(|error| invalid_argument(format!("invalid IP address: {error}")))?;
+        let resource_group_credentials = self
+            .resource_group_credentials
+            .map(|credentials| (credentials.external_resource_group_id, credentials.password));
+        Ok((ip_address, resource_group_credentials))
     }
 }
 

--- a/components/spider-proto-rust/src/unpack/storage.rs
+++ b/components/spider-proto-rust/src/unpack/storage.rs
@@ -171,6 +171,12 @@ impl RequestUnpack for RegisterExecutionManagerRequest {
     type Unpacked = IpAddr;
 
     fn unpack(self) -> Result<Self::Unpacked, UnpackError> {
+        if self.external_resource_group_id.is_some() {
+            return Err(UnpackError {
+                code: Code::Unimplemented,
+                message: "`external_resource_group_id` is not supported yet".to_owned(),
+            });
+        }
         self.ip_address
             .parse::<IpAddr>()
             .map_err(|error| invalid_argument(format!("invalid IP address: {error}")))

--- a/components/spider-proto/scheduler/scheduler.proto
+++ b/components/spider-proto/scheduler/scheduler.proto
@@ -14,6 +14,7 @@ message NextTaskRequest {
   uint64 execution_manager_id = 1;
   TaskAssignmentRecord prev_assignment = 2;
   uint64 wait_time_ms = 3;
+  optional uint64 resource_group_id = 4;
 }
 
 message NextTaskResponse {

--- a/components/spider-proto/storage/storage.proto
+++ b/components/spider-proto/storage/storage.proto
@@ -152,9 +152,14 @@ message VerifyResourceGroupRequest {
   bytes password = 2;
 }
 
+message ExternalResourceGroupCredentials {
+  string external_resource_group_id = 1;
+  bytes password = 2;
+}
+
 message RegisterExecutionManagerRequest {
   string ip_address = 1;
-  optional string external_resource_group_id = 2;
+  ExternalResourceGroupCredentials resource_group_credentials = 2;
 }
 
 message ExecutionManagerIdRequest {

--- a/components/spider-proto/storage/storage.proto
+++ b/components/spider-proto/storage/storage.proto
@@ -154,6 +154,7 @@ message VerifyResourceGroupRequest {
 
 message RegisterExecutionManagerRequest {
   string ip_address = 1;
+  optional string external_resource_group_id = 2;
 }
 
 message ExecutionManagerIdRequest {
@@ -163,6 +164,7 @@ message ExecutionManagerIdRequest {
 message ExecutionManagerRegistration {
   uint64 execution_manager_id = 1;
   uint64 session_id = 2;
+  optional uint64 resource_group_id = 3;
 }
 
 message RegisterExecutionManagerResponse {

--- a/components/spider-storage/src/grpc.rs
+++ b/components/spider-storage/src/grpc.rs
@@ -817,6 +817,7 @@ impl<
             registration: Some(storage::ExecutionManagerRegistration {
                 execution_manager_id: em_id.get(),
                 session_id: self.inner.session_id(),
+                resource_group_id: None,
             }),
         }))
     }

--- a/components/spider-storage/src/grpc.rs
+++ b/components/spider-storage/src/grpc.rs
@@ -801,7 +801,12 @@ impl<
         &self,
         request: Request<storage::RegisterExecutionManagerRequest>,
     ) -> Result<Response<storage::RegisterExecutionManagerResponse>, Status> {
-        let ip_address = request.into_inner().unpack()?;
+        let (ip_address, resource_group_credentials) = request.into_inner().unpack()?;
+        if resource_group_credentials.is_some() {
+            return Err(Status::unimplemented(
+                "`resource_group_credentials` is not supported yet",
+            ));
+        }
         tracing::info!(% ip_address, "Execution manager registration request received.");
         let em_id = self
             .inner


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR adds an optional execution manager in several gRPC protocols:
- Execution manager to scheduler's task request.
- Execution manager's register request includes an optional external resource group id, and the reply includes an optional resource group id. 


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
- [x] GitHub workflows pass.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional resource-group information to task scheduling requests.
  * Added secure external resource-group credentials to execution-manager registration.
  * Registration responses can include an associated resource-group identifier.
  * Existing workflows continue to operate when no resource group is specified.

* **Bug Fixes**
  * Registration requests with external resource-group credentials are now handled correctly.
  * Unsupported resource-group scheduling requests return a clear response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->