### PR TITLE
fix(huntsman): Enable `TCP_NODELAY` on the storage and scheduler gRPC servers' accepted sockets.

### DIFF
--- a/components/spider-scheduler/src/bin/grpc_server.rs
+++ b/components/spider-scheduler/src/bin/grpc_server.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let listener = TcpListener::bind(listen_addr).await.inspect_err(
         |error| tracing::error!(error = % error, "Failed to bind scheduler listen address."),
     )?;
-    let incoming = TcpIncoming::from(listener);
+    let incoming = TcpIncoming::from(listener).with_nodelay(Some(true));
     let mut sigterm = signal(SignalKind::terminate()).inspect_err(
         |error| tracing::error!(error = % error, "Failed to register SIGTERM handler."),
     )?;

--- a/components/spider-storage/src/bin/grpc_server.rs
+++ b/components/spider-storage/src/bin/grpc_server.rs
@@ -54,7 +54,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let listener = TcpListener::bind(listen_addr).await.inspect_err(
         |error| tracing::error!(error = % error, "Failed to bind storage listen address."),
     )?;
-    let incoming = TcpIncoming::from(listener);
+    let incoming = TcpIncoming::from(listener).with_nodelay(Some(true));
     let mut sigterm = signal(SignalKind::terminate()).inspect_err(
         |error| tracing::error!(error = % error, "Failed to register SIGTERM handler."),
     )?;


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Both gRPC server binaries build their listener with `TcpIncoming::from(listener)`, and in `tonic` 0.14.6 that constructor sets `nodelay: None` (`transport/server/incoming.rs:120`) while `set_accepted_socket_options` (`incoming.rs:144`) calls `set_nodelay` only when the option is `Some`. `Server::tcp_nodelay` defaults to `true` but is documented as ignored under `serve_with_incoming*`, so the default never reaches the socket. The result is that **Nagle's algorithm stays enabled on every socket the storage and scheduler servers accept**, and small gRPC responses are held until the peer's delayed ACK arrives. The client side was never affected — `tonic::transport::Endpoint` already defaults `tcp_nodelay: true` — so only the server→client direction stalled.

The cost is large and had been mistaken for scheduling overhead. Profiling the `nn` end-to-end test showed each execution manager spending 97.6% of its life inside a single call, `register_task_instance`, whose latency was strictly bimodal over 20,000 samples: 10,002 calls returned in 235.92 µs and 9,998 took 43,666.54 µs, with a hard floor at 40,478 µs and **not one sample in between**. That floor is this host's delayed-ACK minimum (`CONFIG_HZ=250`, so `TCP_DELACK_MIN = HZ/25` = 10 jiffies = 40 ms). A distribution with an empty middle and a fixed floor is a timer, not queueing — confirmed by latency being flat against concurrent in-flight calls (43.72 / 43.83 / 43.66 ms at 0, 1, 2 others).

This PR sets the option explicitly at both call sites. These are the only two `serve_with_incoming*` call sites in the repository.

## The change

```rust
// components/spider-storage/src/bin/grpc_server.rs
// components/spider-scheduler/src/bin/grpc_server.rs
let incoming = TcpIncoming::from(listener).with_nodelay(Some(true));
```

## Impact

Measured on a Docker Compose deployment at stock configuration (4 worker replicas, connection pool size 4, `SPIDER_CONCURRENCY=8`), with a fresh stack per run and all other knobs held identical before and after.

| | Before | After |
|---|---:|---:|
| `nn` e2e test, full workload (240,000 tasks) | ~1,343 s | **94.62 s** (14.2×) |
| Controlled 20,000-task A/B | 112.42 s | **8.14 s** (13.8×) |
| Cluster throughput | 177.9 tasks/s | 2,536 tasks/s |
| `register_task_instance` mean | 21,946.88 µs | **249.15 µs** (88.8×) |
| `register_task_instance` samples ≥ 35 ms | 9,998 of 20,000 (49.99%) | **0 of 260,000** |
| `register_task_instance` max | 48,600 µs | 6,866 µs |
| Execution-manager serial cycle | 22,377 µs | 1,542 µs |

The bimodality is gone: the empty gap between 1,457 µs and 40,478 µs is replaced by a single continuous peak with a p50 of 236–240 µs, and the post-fix maximum across 260,000 calls sits 5.9× below the old floor. Per-execution-manager means agree within 0.2%, confirming the option took effect on all sockets. `execute`, IPC and outcome-reporting timings are unchanged within noise, so the change moved exactly what it should and nothing else.

**The `nn` end-to-end test now completes in about 1 minute 35 seconds instead of roughly 22 minutes.**

## Notes

- The size of the win is host-dependent, because the stall is one delayed-ACK period and `TCP_DELACK_MIN` is `HZ/25`. This was measured on a `CONFIG_HZ=250` host, giving a 40 ms stall; a `CONFIG_HZ=1000` host would have been paying 4 ms per affected call instead. The bug is present either way — only its magnitude varies.
- Which exact HTTP/2 frame is being held (HEADERS, DATA or trailers), and why the round-robin connection pool produced a clean 50% duty cycle rather than stalling every call, were not pinned down. Neither affects the fix. A packet capture or a `SPIDER_WORKER_CONNECTION_POOL_SIZE` sweep would settle it.
- With the stall removed, the binding constraint moves to the scheduler's dispatch rate cap: `dispatch_queue_capacity` (16) over the measured tick period (5.803 ms) gives a ceiling of 2,757 tasks/s, and the run achieved 92.0% of it. The scheduler is now pinned at its per-tick cap on 92.44% of ticks while holding ~3,900 ready-but-unplaced tasks, and effective worker concurrency is 1.05 of 4 — so adding replicas buys nothing until that cap is raised. That is a separate change and is deliberately not included here, to keep this a clean A/B.
- Also worth retiring alongside this fix: the assumption that a task costs milliseconds of compute. Measured in-FFI time is 3.7–6.5 µs, and the entire 240,000-task workload is under 2 seconds of real arithmetic.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Ensure all workflows pass.
* [x] Validated on top of #454 to make sure the performance improvements are reflected in a local E2E run.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved responsiveness and reduced latency for scheduler and storage service connections.
  * Enabled more efficient handling of TCP network traffic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->