### PR TITLE
chore: Bump version for 0.1.0-rc.1 release.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,7 +454,7 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "e2e"
-version = "0.1.0-dev"
+version = "0.1.0-rc.1"
 dependencies = [
  "anyhow",
  "huntsman-nn-core",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "em-runtime-tests"
-version = "0.1.0-dev"
+version = "0.1.0-rc.1"
 dependencies = [
  "anyhow",
  "spider-core",
@@ -849,7 +849,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "huntsman-complex"
-version = "0.1.0-dev"
+version = "0.1.0-rc.1"
 dependencies = [
  "huntsman-complex-types",
  "serde",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "huntsman-complex-types"
-version = "0.1.0-dev"
+version = "0.1.0-rc.1"
 dependencies = [
  "serde",
  "spider-tdl",
@@ -866,11 +866,11 @@ dependencies = [
 
 [[package]]
 name = "huntsman-nn-core"
-version = "0.1.0-dev"
+version = "0.1.0-rc.1"
 
 [[package]]
 name = "huntsman-nn-tasks"
-version = "0.1.0-dev"
+version = "0.1.0-rc.1"
 dependencies = [
  "huntsman-nn-core",
  "serde",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "integration-test-tasks"
-version = "0.1.0-dev"
+version = "0.1.0-rc.1"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -1952,7 +1952,7 @@ dependencies = [
 
 [[package]]
 name = "spider-client"
-version = "0.1.0-dev"
+version = "0.1.0-rc.1"
 dependencies = [
  "spider-core",
  "spider-proto-rust",
@@ -1964,7 +1964,7 @@ dependencies = [
 
 [[package]]
 name = "spider-core"
-version = "0.1.0-dev"
+version = "0.1.0-rc.1"
 dependencies = [
  "anyhow",
  "non-empty-string",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "spider-derive"
-version = "0.1.0-dev"
+version = "0.1.0-rc.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1995,7 +1995,7 @@ dependencies = [
 
 [[package]]
 name = "spider-execution-manager"
-version = "0.1.0-dev"
+version = "0.1.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2019,7 +2019,7 @@ dependencies = [
 
 [[package]]
 name = "spider-proto-rust"
-version = "0.1.0-dev"
+version = "0.1.0-rc.1"
 dependencies = [
  "prost",
  "spider-core",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "spider-scheduler"
-version = "0.1.0-dev"
+version = "0.1.0-rc.1"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2055,7 +2055,7 @@ dependencies = [
 
 [[package]]
 name = "spider-storage"
-version = "0.1.0-dev"
+version = "0.1.0-rc.1"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2085,7 +2085,7 @@ dependencies = [
 
 [[package]]
 name = "spider-task-executor"
-version = "0.1.0-dev"
+version = "0.1.0-rc.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2105,7 +2105,7 @@ dependencies = [
 
 [[package]]
 name = "spider-tdl"
-version = "0.1.0-dev"
+version = "0.1.0-rc.1"
 dependencies = [
  "anyhow",
  "const-str",
@@ -2118,7 +2118,7 @@ dependencies = [
 
 [[package]]
 name = "spider-tdl-derive"
-version = "0.1.0-dev"
+version = "0.1.0-rc.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2127,7 +2127,7 @@ dependencies = [
 
 [[package]]
 name = "spider-utils"
-version = "0.1.0-dev"
+version = "0.1.0-rc.1"
 dependencies = [
  "non-empty-string",
  "rand 0.9.5",
@@ -2480,7 +2480,7 @@ dependencies = [
 
 [[package]]
 name = "task-executor-tests"
-version = "0.1.0-dev"
+version = "0.1.0-rc.1"
 dependencies = [
  "integration-test-tasks",
  "rmp-serde",
@@ -2496,7 +2496,7 @@ dependencies = [
 
 [[package]]
 name = "tdl-integration"
-version = "0.1.0-dev"
+version = "0.1.0-rc.1"
 dependencies = [
  "anyhow",
  "huntsman-complex-types",
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.1.0-dev"
+version = "0.1.0-rc.1"
 dependencies = [
  "async-trait",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.1.0-dev"
+version = "0.1.0-rc.1"
 edition = "2024"
 
 [workspace.dependencies]

--- a/tools/deployment/spider-compose/.env.example
+++ b/tools/deployment/spider-compose/.env.example
@@ -1,7 +1,7 @@
 # Optionally copy this file to `.env` to override Spider's embedded defaults.
 
 # Deployment settings.
-SPIDER_IMAGE_TAG=main
+SPIDER_IMAGE_TAG=v0.1.0-rc.1-huntsman
 SPIDER_PULL_POLICY=always
 SPIDER_RESTART_POLICY=on-failure:3
 
@@ -15,7 +15,7 @@ SPIDER_STORAGE_DB_USERNAME=spider-user
 
 # Storage settings.
 # A complete storage image reference takes precedence over `SPIDER_IMAGE_TAG` when set.
-# SPIDER_STORAGE_IMAGE_REF=ghcr.io/y-scope/spider/storage:main
+# SPIDER_STORAGE_IMAGE_REF=ghcr.io/y-scope/spider/storage:v0.1.0-rc.1-huntsman
 SPIDER_STORAGE_LOG_LEVEL=INFO
 SPIDER_STORAGE_PORT=50051
 SPIDER_STORAGE_PUBLISHED_IP=127.0.0.1
@@ -32,7 +32,7 @@ SPIDER_STORAGE_TASK_INSTANCE_POOL_MESSAGE_CHANNEL_CAPACITY=128
 
 # Scheduler settings.
 # A complete scheduler image reference takes precedence over `SPIDER_IMAGE_TAG` when set.
-# SPIDER_SCHEDULER_IMAGE_REF=ghcr.io/y-scope/spider/scheduler:main
+# SPIDER_SCHEDULER_IMAGE_REF=ghcr.io/y-scope/spider/scheduler:v0.1.0-rc.1-huntsman
 SPIDER_SCHEDULER_LOG_LEVEL=INFO
 SPIDER_SCHEDULER_PORT=50052
 SPIDER_SCHEDULER_CONNECTION_POOL_SIZE=8
@@ -51,7 +51,7 @@ SPIDER_SCHEDULER_ROUND_ROBIN_TICK_INTERVAL_MS=5
 
 # Worker settings.
 # A complete worker image reference takes precedence over `SPIDER_IMAGE_TAG` when set.
-# SPIDER_WORKER_IMAGE_REF=ghcr.io/y-scope/spider/worker:main
+# SPIDER_WORKER_IMAGE_REF=ghcr.io/y-scope/spider/worker:v0.1.0-rc.1-huntsman
 SPIDER_WORKER_REPLICAS=4
 SPIDER_WORKER_LOG_LEVEL=INFO
 SPIDER_WORKER_CONNECTION_POOL_SIZE=4

--- a/tools/deployment/spider-compose/compose.yaml
+++ b/tools/deployment/spider-compose/compose.yaml
@@ -52,7 +52,7 @@ services:
   spider-storage:
     <<: *service_defaults
     image: >-
-      ${SPIDER_STORAGE_IMAGE_REF:-ghcr.io/y-scope/spider/storage:${SPIDER_IMAGE_TAG:-main}}
+      ${SPIDER_STORAGE_IMAGE_REF:-ghcr.io/y-scope/spider/storage:${SPIDER_IMAGE_TAG:-v0.1.0-rc.1-huntsman}}
     networks:
       - "default"
       - "spider-internal"
@@ -86,7 +86,7 @@ services:
   spider-scheduler:
     <<: *service_defaults
     image: >-
-      ${SPIDER_SCHEDULER_IMAGE_REF:-ghcr.io/y-scope/spider/scheduler:${SPIDER_IMAGE_TAG:-main}}
+      ${SPIDER_SCHEDULER_IMAGE_REF:-ghcr.io/y-scope/spider/scheduler:${SPIDER_IMAGE_TAG:-v0.1.0-rc.1-huntsman}}
     networks:
       - "spider-internal"
     command: [
@@ -113,7 +113,7 @@ services:
   spider-worker:
     <<: *service_defaults
     image: >-
-      ${SPIDER_WORKER_IMAGE_REF:-ghcr.io/y-scope/spider/worker:${SPIDER_IMAGE_TAG:-main}}
+      ${SPIDER_WORKER_IMAGE_REF:-ghcr.io/y-scope/spider/worker:${SPIDER_IMAGE_TAG:-v0.1.0-rc.1-huntsman}}
     networks:
       - "default"
       - "spider-internal"

--- a/tools/deployment/spider-helm/Chart.yaml
+++ b/tools/deployment/spider-helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: "v2"
 name: "spider"
 description: "A Helm chart for the Spider Huntsman deployment"
 type: "application"
-version: "0.2.0-dev.0"
-appVersion: "0.1.0-dev"
+version: "0.2.0-rc.1"
+appVersion: "0.1.0-rc.1"
 home: "https://github.com/y-scope/spider"
 sources: ["https://github.com/y-scope/spider"]
 maintainers: [{name: "y-scope", email: "dev@yscope.com", url: "https://yscope.com"}]

--- a/tools/deployment/spider-helm/values.yaml
+++ b/tools/deployment/spider-helm/values.yaml
@@ -9,15 +9,15 @@ image:
   scheduler:
     pullPolicy: "Always"
     repository: "ghcr.io/y-scope/spider/scheduler"
-    tag: "main"
+    tag: "v0.1.0-rc.1-huntsman"
   storage:
     pullPolicy: "Always"
     repository: "ghcr.io/y-scope/spider/storage"
-    tag: "main"
+    tag: "v0.1.0-rc.1-huntsman"
   worker:
     pullPolicy: "Always"
     repository: "ghcr.io/y-scope/spider/worker"
-    tag: "main"
+    tag: "v0.1.0-rc.1-huntsman"
 
 spiderConfig:
   # List of third-party services bundled (deployed) as part of the chart.


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

In preparation for v0.1.0-rc.1 release.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Ensure all workflows pass.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the workspace and Helm chart versions to the `0.1.0-rc.1` release candidate.
  - Updated default deployment images for storage, scheduler, and worker services to `v0.1.0-rc.1-huntsman`.

- **Deployment**
  - Docker Compose and Helm deployments now use the release candidate images by default.
  - Existing custom image reference overrides remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->