### PR TITLE
feat(spider-scheduler): Add the resource-group-aware core's inbound-poll result formatter:

### DIFF
--- a/components/spider-scheduler/src/core_impl/inbound_queue_reader.rs
+++ b/components/spider-scheduler/src/core_impl/inbound_queue_reader.rs
@@ -323,3 +323,515 @@ impl<FormatterType: InboundPollResultFormatter> InboundPollHandles<FormatterType
         }
     }
 }
+
+#[cfg(test)]
+pub(super) mod test_harness {
+    //! The shared test harness of the inbound-queue reader.
+    //!
+    //! Drives a reader against scripted poll batches instead of a storage service, so that every
+    //! core's reader tests can script the same lanes and collect the same formatted results.
+
+    use std::collections::VecDeque;
+    use std::sync::Arc;
+    use std::sync::Mutex;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::AtomicU64;
+    use std::sync::atomic::Ordering;
+    use std::time::Duration;
+
+    use anyhow::bail;
+    use async_trait::async_trait;
+    use spider_core::job::JobState;
+    use spider_core::types::id::JobId;
+    use spider_core::types::id::ResourceGroupId;
+    use spider_core::types::id::SchedulerId;
+    use spider_core::types::id::SessionId;
+    use spider_core::types::id::TaskId;
+    use tokio::sync::Semaphore;
+
+    use super::AsyncInboundQueueReader;
+    use super::InboundPollResultFormatter;
+    use super::InboundPollState;
+    use crate::error::StorageClientError;
+    use crate::storage_client::SchedulerStorageClient;
+    use crate::types::InboundEntry;
+
+    /// The session the mock storage client serves polls under unless a test scripts otherwise.
+    pub const DEFAULT_SESSION_ID: SessionId = 0;
+
+    /// The entry limit given to lanes a test wants polled.
+    pub const MAX_ENTRIES: usize = 32;
+
+    /// The poll timeout passed to the mock storage client, which never blocks on it.
+    pub const POLL_TIMEOUT: Duration = Duration::from_millis(1);
+
+    /// The formatted results of one completed inbound poll.
+    ///
+    /// # Type Parameters
+    ///
+    /// * `FormatterType` - The formatter applied to the entries drained from each inbound-queue
+    ///   lane.
+    pub struct CollectedPoll<FormatterType: InboundPollResultFormatter> {
+        /// The latest session the poll observed.
+        pub session_id: SessionId,
+
+        /// The formatted result of the regular-task lane.
+        pub ready_result: FormatterType::ReadyResult,
+
+        /// The formatted result of the commit-task lane.
+        pub commit_ready_result: FormatterType::FinalizedResult,
+
+        /// The formatted result of the cleanup-task lane.
+        pub cleanup_ready_result: FormatterType::FinalizedResult,
+    }
+
+    /// A mock [`SchedulerStorageClient`] backed by scripted poll batches.
+    ///
+    /// Each lane serves its scripted batches in FIFO order, one batch per poll; when a lane's
+    /// script is empty, polls return an empty batch under the mock's current session immediately
+    /// (the `wait` parameter is ignored to keep tests fast). The regular-task lane can be gated so
+    /// that a test can observe an in-flight poll.
+    #[derive(Clone)]
+    pub struct MockStorageClient {
+        inner: Arc<MockStorageInner>,
+    }
+
+    impl MockStorageClient {
+        /// Factory function.
+        ///
+        /// # Returns
+        ///
+        /// A new mock storage client with no scripted batches and no gated lane, reporting
+        /// [`DEFAULT_SESSION_ID`] on empty polls.
+        pub fn new() -> Self {
+            Self {
+                inner: Arc::new(MockStorageInner {
+                    session_id: AtomicU64::new(DEFAULT_SESSION_ID),
+                    ready_batches: Mutex::new(VecDeque::new()),
+                    commit_ready_batches: Mutex::new(VecDeque::new()),
+                    cleanup_ready_batches: Mutex::new(VecDeque::new()),
+                    num_ready_polls: AtomicU64::new(0),
+                    num_commit_ready_polls: AtomicU64::new(0),
+                    num_cleanup_ready_polls: AtomicU64::new(0),
+                    is_ready_lane_gated: AtomicBool::new(false),
+                    ready_lane_gate: Semaphore::new(0),
+                }),
+            }
+        }
+
+        /// Scripts a batch to be served by the next unserved [`SchedulerStorageClient::poll_ready`]
+        /// call.
+        pub fn push_ready_batch(&self, session_id: SessionId, entries: Vec<InboundEntry>) {
+            self.inner
+                .ready_batches
+                .lock()
+                .expect("ready-batch lock poisoned")
+                .push_back((session_id, entries));
+        }
+
+        /// Scripts a batch to be served by the next unserved
+        /// [`SchedulerStorageClient::poll_commit_ready`] call.
+        pub fn push_commit_ready_batch(&self, session_id: SessionId, entries: Vec<InboundEntry>) {
+            self.inner
+                .commit_ready_batches
+                .lock()
+                .expect("commit-ready-batch lock poisoned")
+                .push_back((session_id, entries));
+        }
+
+        /// Scripts a batch to be served by the next unserved
+        /// [`SchedulerStorageClient::poll_cleanup_ready`] call.
+        pub fn push_cleanup_ready_batch(&self, session_id: SessionId, entries: Vec<InboundEntry>) {
+            self.inner
+                .cleanup_ready_batches
+                .lock()
+                .expect("cleanup-ready-batch lock poisoned")
+                .push_back((session_id, entries));
+        }
+
+        /// # Returns
+        ///
+        /// A tuple containing:
+        ///
+        /// * The number of polls served by the regular-task lane.
+        /// * The number of polls served by the commit-task lane.
+        /// * The number of polls served by the cleanup-task lane.
+        pub fn num_polls(&self) -> (u64, u64, u64) {
+            (
+                self.inner.num_ready_polls.load(Ordering::Relaxed),
+                self.inner.num_commit_ready_polls.load(Ordering::Relaxed),
+                self.inner.num_cleanup_ready_polls.load(Ordering::Relaxed),
+            )
+        }
+
+        /// Holds every subsequent regular-task poll until [`Self::admit_ready_poll`] releases it.
+        pub fn gate_ready_lane(&self) {
+            self.inner
+                .is_ready_lane_gated
+                .store(true, Ordering::Relaxed);
+        }
+
+        /// Releases one held regular-task poll.
+        pub fn admit_ready_poll(&self) {
+            self.inner.ready_lane_gate.add_permits(1);
+        }
+
+        /// Serves one poll from the given lane's script.
+        ///
+        /// # Returns
+        ///
+        /// The lane's next scripted batch, or an empty batch under the current session if the
+        /// lane's script is exhausted.
+        ///
+        /// # Panics
+        ///
+        /// Panics if the scripted batch holds more entries than `max_items`.
+        fn serve_batch(
+            &self,
+            batches: &Mutex<VecDeque<(SessionId, Vec<InboundEntry>)>>,
+            max_items: usize,
+        ) -> (SessionId, Vec<InboundEntry>) {
+            let scripted_batch = batches.lock().expect("batch lock poisoned").pop_front();
+            let Some((session_id, entries)) = scripted_batch else {
+                return (self.inner.session_id.load(Ordering::Relaxed), Vec::new());
+            };
+            assert!(
+                entries.len() <= max_items,
+                "scripted batch of {} entries exceeds the poll limit of {max_items}",
+                entries.len(),
+            );
+            (session_id, entries)
+        }
+    }
+
+    #[async_trait]
+    impl SchedulerStorageClient for MockStorageClient {
+        async fn register(
+            &self,
+            _host: spider_utils::config::Host,
+            _port: u16,
+        ) -> Result<SchedulerId, StorageClientError> {
+            Ok(SchedulerId::from(0))
+        }
+
+        async fn poll_ready(
+            &self,
+            max_items: usize,
+            _wait: Duration,
+        ) -> Result<(SessionId, Vec<InboundEntry>), StorageClientError> {
+            if self.inner.is_ready_lane_gated.load(Ordering::Relaxed) {
+                self.inner
+                    .ready_lane_gate
+                    .acquire()
+                    .await
+                    .expect("the regular-task lane gate is never closed")
+                    .forget();
+            }
+            self.inner.num_ready_polls.fetch_add(1, Ordering::Relaxed);
+            Ok(self.serve_batch(&self.inner.ready_batches, max_items))
+        }
+
+        async fn poll_commit_ready(
+            &self,
+            max_items: usize,
+            _wait: Duration,
+        ) -> Result<(SessionId, Vec<InboundEntry>), StorageClientError> {
+            self.inner
+                .num_commit_ready_polls
+                .fetch_add(1, Ordering::Relaxed);
+            Ok(self.serve_batch(&self.inner.commit_ready_batches, max_items))
+        }
+
+        async fn poll_cleanup_ready(
+            &self,
+            max_items: usize,
+            _wait: Duration,
+        ) -> Result<(SessionId, Vec<InboundEntry>), StorageClientError> {
+            self.inner
+                .num_cleanup_ready_polls
+                .fetch_add(1, Ordering::Relaxed);
+            Ok(self.serve_batch(&self.inner.cleanup_ready_batches, max_items))
+        }
+
+        async fn job_state(&self, _job_id: JobId) -> Result<JobState, StorageClientError> {
+            Ok(JobState::Running)
+        }
+    }
+
+    /// # Returns
+    ///
+    /// An inbound entry for `job_id`'s `task_id`, owned by `resource_group_id`.
+    pub const fn make_entry(
+        resource_group_id: ResourceGroupId,
+        job_id: JobId,
+        task_id: TaskId,
+    ) -> InboundEntry {
+        InboundEntry {
+            resource_group_id,
+            job_id,
+            task_id,
+        }
+    }
+
+    /// Collects the result of the in-flight poll, retrying until every lane task has finished.
+    ///
+    /// # Type Parameters
+    ///
+    /// * `StorageClientType` - The storage client used to poll the inbound queue.
+    /// * `FormatterType` - The formatter applied to the entries drained from each inbound-queue
+    ///   lane.
+    ///
+    /// # Returns
+    ///
+    /// The formatted results of the completed poll on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * [`anyhow::Error`] if the poll does not complete within [`COLLECT_DEADLINE`], or if no poll
+    ///   is in flight.
+    /// * Forwards [`AsyncInboundQueueReader::try_collect_result`]'s return values on failure.
+    pub async fn collect_when_ready<
+        StorageClientType: SchedulerStorageClient + 'static,
+        FormatterType: InboundPollResultFormatter,
+    >(
+        reader: &mut AsyncInboundQueueReader<StorageClientType, FormatterType>,
+        curr_session_id: SessionId,
+    ) -> anyhow::Result<CollectedPoll<FormatterType>> {
+        let deadline = tokio::time::Instant::now() + COLLECT_DEADLINE;
+        loop {
+            match reader.try_collect_result(curr_session_id).await? {
+                InboundPollState::Ready {
+                    session_id,
+                    ready_result,
+                    commit_ready_result,
+                    cleanup_ready_result,
+                } => {
+                    return Ok(CollectedPoll {
+                        session_id,
+                        ready_result,
+                        commit_ready_result,
+                        cleanup_ready_result,
+                    });
+                }
+                InboundPollState::NotStarted => bail!("no inbound poll is in flight"),
+                InboundPollState::Pending => {
+                    if deadline <= tokio::time::Instant::now() {
+                        bail!("the inbound poll did not complete in time");
+                    }
+                    tokio::time::sleep(COLLECT_RETRY_INTERVAL).await;
+                }
+            }
+        }
+    }
+
+    /// The maximum time to wait for an in-flight poll to complete before failing a test.
+    const COLLECT_DEADLINE: Duration = Duration::from_secs(5);
+
+    /// The interval between two collection attempts while waiting for an in-flight poll.
+    const COLLECT_RETRY_INTERVAL: Duration = Duration::from_millis(1);
+
+    /// The scripted state shared by every clone of a [`MockStorageClient`].
+    struct MockStorageInner {
+        session_id: AtomicU64,
+        ready_batches: Mutex<VecDeque<(SessionId, Vec<InboundEntry>)>>,
+        commit_ready_batches: Mutex<VecDeque<(SessionId, Vec<InboundEntry>)>>,
+        cleanup_ready_batches: Mutex<VecDeque<(SessionId, Vec<InboundEntry>)>>,
+        num_ready_polls: AtomicU64,
+        num_commit_ready_polls: AtomicU64,
+        num_cleanup_ready_polls: AtomicU64,
+        is_ready_lane_gated: AtomicBool,
+        ready_lane_gate: Semaphore,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::bail;
+    use spider_core::types::id::JobId;
+    use spider_core::types::id::ResourceGroupId;
+    use spider_core::types::id::SessionId;
+    use spider_core::types::id::TaskId;
+
+    use super::test_harness::DEFAULT_SESSION_ID;
+    use super::test_harness::MAX_ENTRIES;
+    use super::test_harness::MockStorageClient;
+    use super::test_harness::POLL_TIMEOUT;
+    use super::test_harness::collect_when_ready;
+    use super::test_harness::make_entry;
+    use super::*;
+
+    /// The resource group the entries in this module belong to.
+    const RG_ID: ResourceGroupId = ResourceGroupId::from(4);
+
+    /// The first job a test polls entries for.
+    const JOB_A: JobId = JobId::from(10);
+
+    /// The second job a test polls entries for.
+    const JOB_B: JobId = JobId::from(11);
+
+    /// The third job a test polls entries for.
+    const JOB_C: JobId = JobId::from(12);
+
+    /// The reader under test, which passes the entries drained from every lane through unchanged.
+    type TestReader = AsyncInboundQueueReader<MockStorageClient>;
+
+    #[tokio::test]
+    async fn a_reader_without_a_poll_reports_not_started() -> anyhow::Result<()> {
+        let mut reader = TestReader::new(MockStorageClient::new());
+        assert!(matches!(
+            reader.try_collect_result(DEFAULT_SESSION_ID).await?,
+            InboundPollState::NotStarted
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn drained_entries_are_returned_unchanged() -> anyhow::Result<()> {
+        let ready_entries = vec![
+            make_entry(RG_ID, JOB_A, TaskId::Index(3)),
+            make_entry(RG_ID, JOB_A, TaskId::Index(1)),
+            make_entry(RG_ID, JOB_A, TaskId::Index(3)),
+            make_entry(RG_ID, JOB_B, TaskId::Commit),
+        ];
+        let commit_ready_entries = vec![make_entry(RG_ID, JOB_B, TaskId::Commit)];
+        let cleanup_ready_entries = vec![make_entry(RG_ID, JOB_C, TaskId::Cleanup)];
+
+        let storage_client = MockStorageClient::new();
+        storage_client.push_ready_batch(DEFAULT_SESSION_ID, ready_entries.clone());
+        storage_client.push_commit_ready_batch(DEFAULT_SESSION_ID, commit_ready_entries.clone());
+        storage_client.push_cleanup_ready_batch(DEFAULT_SESSION_ID, cleanup_ready_entries.clone());
+        let mut reader = TestReader::new(storage_client);
+        reader.start(POLL_TIMEOUT, MAX_ENTRIES, MAX_ENTRIES, MAX_ENTRIES)?;
+
+        let result = collect_when_ready(&mut reader, DEFAULT_SESSION_ID).await?;
+        assert_eq!(result.ready_result, ready_entries);
+        assert_eq!(result.commit_ready_result, commit_ready_entries);
+        assert_eq!(result.cleanup_ready_result, cleanup_ready_entries);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn an_unfinished_lane_keeps_the_poll_pending() -> anyhow::Result<()> {
+        let storage_client = MockStorageClient::new();
+        storage_client.gate_ready_lane();
+        storage_client.push_ready_batch(
+            DEFAULT_SESSION_ID,
+            vec![make_entry(RG_ID, JOB_A, TaskId::Index(0))],
+        );
+        let mut reader = TestReader::new(storage_client.clone());
+        reader.start(POLL_TIMEOUT, MAX_ENTRIES, MAX_ENTRIES, MAX_ENTRIES)?;
+
+        assert!(matches!(
+            reader.try_collect_result(DEFAULT_SESSION_ID).await?,
+            InboundPollState::Pending
+        ));
+        assert!(matches!(
+            reader.try_collect_result(DEFAULT_SESSION_ID).await?,
+            InboundPollState::Pending
+        ));
+
+        storage_client.admit_ready_poll();
+        let result = collect_when_ready(&mut reader, DEFAULT_SESSION_ID).await?;
+        assert_eq!(
+            result.ready_result.as_slice(),
+            &[make_entry(RG_ID, JOB_A, TaskId::Index(0))]
+        );
+
+        assert!(matches!(
+            reader.try_collect_result(DEFAULT_SESSION_ID).await?,
+            InboundPollState::NotStarted
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn a_stale_lane_result_is_dropped() -> anyhow::Result<()> {
+        const STALE_SESSION_ID: SessionId = 1;
+        const LATEST_SESSION_ID: SessionId = 2;
+
+        let storage_client = MockStorageClient::new();
+        storage_client.push_ready_batch(
+            STALE_SESSION_ID,
+            vec![make_entry(RG_ID, JOB_A, TaskId::Index(0))],
+        );
+        storage_client.push_commit_ready_batch(
+            LATEST_SESSION_ID,
+            vec![make_entry(RG_ID, JOB_B, TaskId::Commit)],
+        );
+        storage_client.push_cleanup_ready_batch(
+            STALE_SESSION_ID,
+            vec![make_entry(RG_ID, JOB_C, TaskId::Cleanup)],
+        );
+        let mut reader = TestReader::new(storage_client);
+        reader.start(POLL_TIMEOUT, MAX_ENTRIES, MAX_ENTRIES, MAX_ENTRIES)?;
+
+        let result = collect_when_ready(&mut reader, STALE_SESSION_ID).await?;
+        assert_eq!(result.session_id, LATEST_SESSION_ID);
+        assert_eq!(result.ready_result.as_slice(), &[]);
+        assert_eq!(result.cleanup_ready_result.as_slice(), &[]);
+        assert_eq!(
+            result.commit_ready_result.as_slice(),
+            &[make_entry(RG_ID, JOB_B, TaskId::Commit)]
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn starting_a_poll_while_one_is_in_flight_fails() -> anyhow::Result<()> {
+        let storage_client = MockStorageClient::new();
+        storage_client.gate_ready_lane();
+        let mut reader = TestReader::new(storage_client.clone());
+        reader.start(POLL_TIMEOUT, MAX_ENTRIES, MAX_ENTRIES, MAX_ENTRIES)?;
+
+        let Err(SchedulerError::Internal(message)) =
+            reader.start(POLL_TIMEOUT, MAX_ENTRIES, MAX_ENTRIES, MAX_ENTRIES)
+        else {
+            bail!("starting a second poll should be rejected");
+        };
+        assert_eq!(message, "inbound poll handle already exists");
+
+        storage_client.admit_ready_poll();
+        collect_when_ready(&mut reader, DEFAULT_SESSION_ID).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn zero_limits_start_no_poll() -> anyhow::Result<()> {
+        let storage_client = MockStorageClient::new();
+        let mut reader = TestReader::new(storage_client.clone());
+        reader.start(POLL_TIMEOUT, 0, 0, 0)?;
+
+        assert!(matches!(
+            reader.try_collect_result(DEFAULT_SESSION_ID).await?,
+            InboundPollState::NotStarted
+        ));
+        assert_eq!(storage_client.num_polls(), (0, 0, 0));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn a_lane_with_a_zero_limit_is_not_polled() -> anyhow::Result<()> {
+        let storage_client = MockStorageClient::new();
+        storage_client.push_ready_batch(
+            DEFAULT_SESSION_ID,
+            vec![make_entry(RG_ID, JOB_A, TaskId::Index(0))],
+        );
+        storage_client.push_commit_ready_batch(
+            DEFAULT_SESSION_ID,
+            vec![make_entry(RG_ID, JOB_B, TaskId::Commit)],
+        );
+        let mut reader = TestReader::new(storage_client.clone());
+        reader.start(POLL_TIMEOUT, 0, MAX_ENTRIES, MAX_ENTRIES)?;
+
+        let result = collect_when_ready(&mut reader, DEFAULT_SESSION_ID).await?;
+        assert_eq!(storage_client.num_polls(), (0, 1, 1));
+        assert_eq!(result.ready_result.as_slice(), &[]);
+        assert_eq!(
+            result.commit_ready_result.as_slice(),
+            &[make_entry(RG_ID, JOB_B, TaskId::Commit)]
+        );
+        Ok(())
+    }
+}

--- a/components/spider-scheduler/src/core_impl/inbound_queue_reader.rs
+++ b/components/spider-scheduler/src/core_impl/inbound_queue_reader.rs
@@ -9,15 +9,69 @@ use crate::error::StorageClientError;
 use crate::storage_client::SchedulerStorageClient;
 use crate::types::InboundEntry;
 
+/// The reshaping a core applies to the entries drained from each inbound-queue lane.
+///
+/// The formatting runs inside the lane's background polling task, so it is kept off the core's
+/// critical path.
+pub(super) trait InboundPollResultFormatter: Send + 'static {
+    /// The formatted result of the regular-task lane.
+    type ReadyResult: Default + Send + 'static;
+
+    /// The formatted result of a finalization lane.
+    type FinalizedResult: Default + Send + 'static;
+
+    /// Formats the entries drained from the regular-task lane.
+    ///
+    /// # Parameters
+    ///
+    /// * `entries` - The entries drained from the lane.
+    ///
+    /// # Returns
+    ///
+    /// The formatted lane result.
+    fn format_ready(entries: Vec<InboundEntry>) -> Self::ReadyResult;
+
+    /// Formats the entries drained from a finalization lane.
+    ///
+    /// # Parameters
+    ///
+    /// * `entries` - The entries drained from the lane.
+    ///
+    /// # Returns
+    ///
+    /// The formatted lane result.
+    fn format_finalized(entries: Vec<InboundEntry>) -> Self::FinalizedResult;
+}
+
+/// The formatter of a core that consumes the drained entries as they are.
+pub(super) struct RawInboundEntries;
+
+impl InboundPollResultFormatter for RawInboundEntries {
+    type ReadyResult = Vec<InboundEntry>;
+    type FinalizedResult = Vec<InboundEntry>;
+
+    fn format_ready(entries: Vec<InboundEntry>) -> Self::ReadyResult {
+        entries
+    }
+
+    fn format_finalized(entries: Vec<InboundEntry>) -> Self::FinalizedResult {
+        entries
+    }
+}
+
 /// The state of an asynchronous inbound-queue poll.
-pub(super) enum InboundPollState {
-    /// The poll has completed, carrying the polled session and the entries drained from each
+///
+/// # Type Parameters
+///
+/// * `FormatterType` - The formatter applied to the entries drained from each inbound-queue lane.
+pub(super) enum InboundPollState<FormatterType: InboundPollResultFormatter = RawInboundEntries> {
+    /// The poll has completed, carrying the polled session and the formatted result of each
     /// inbound-queue lane.
     Ready {
         session_id: SessionId,
-        ready_entries: Vec<InboundEntry>,
-        commit_ready_entries: Vec<InboundEntry>,
-        cleanup_ready_entries: Vec<InboundEntry>,
+        ready_result: FormatterType::ReadyResult,
+        commit_ready_result: FormatterType::FinalizedResult,
+        cleanup_ready_result: FormatterType::FinalizedResult,
     },
 
     /// The poll is still in flight.
@@ -33,13 +87,19 @@ pub(super) enum InboundPollState {
 /// # Type Parameters
 ///
 /// * `StorageClientType` - The storage client used to poll the inbound queue.
-pub(super) struct AsyncInboundQueueReader<StorageClientType: SchedulerStorageClient + 'static> {
+/// * `FormatterType` - The formatter applied to the entries drained from each inbound-queue lane.
+pub(super) struct AsyncInboundQueueReader<
+    StorageClientType: SchedulerStorageClient + 'static,
+    FormatterType: InboundPollResultFormatter = RawInboundEntries,
+> {
     storage_client: StorageClientType,
-    handle: Option<InboundPollHandles>,
+    handle: Option<InboundPollHandles<FormatterType>>,
 }
 
-impl<StorageClientType: SchedulerStorageClient + 'static>
-    AsyncInboundQueueReader<StorageClientType>
+impl<
+    StorageClientType: SchedulerStorageClient + 'static,
+    FormatterType: InboundPollResultFormatter,
+> AsyncInboundQueueReader<StorageClientType, FormatterType>
 {
     /// Factory function.
     ///
@@ -71,7 +131,7 @@ impl<StorageClientType: SchedulerStorageClient + 'static>
     pub(super) async fn try_collect_result(
         &mut self,
         curr_session_id: SessionId,
-    ) -> Result<InboundPollState, SchedulerError> {
+    ) -> Result<InboundPollState<FormatterType>, SchedulerError> {
         match &mut self.handle {
             None => Ok(InboundPollState::NotStarted),
             Some(handle) => {
@@ -84,7 +144,8 @@ impl<StorageClientType: SchedulerStorageClient + 'static>
         }
     }
 
-    /// Starts a new inbound poll, polling each inbound-queue lane as a background task.
+    /// Starts a new inbound poll, polling and formatting each inbound-queue lane as a background
+    /// task.
     ///
     /// Lanes whose entry limit is 0 are not polled; if all limits are 0, no poll is started.
     ///
@@ -115,31 +176,34 @@ impl<StorageClientType: SchedulerStorageClient + 'static>
         let ready_storage_client = self.storage_client.clone();
         let ready_handle = tokio::task::spawn(async move {
             if max_ready_entries == 0 {
-                return Ok((0, Vec::new()));
+                return Ok((0, Default::default()));
             }
-            ready_storage_client
+            let (session_id, entries) = ready_storage_client
                 .poll_ready(max_ready_entries, storage_poll_timeout)
-                .await
+                .await?;
+            Ok((session_id, FormatterType::format_ready(entries)))
         });
 
         let commit_ready_storage_client = self.storage_client.clone();
         let commit_ready_handle = tokio::task::spawn(async move {
             if max_commit_ready_entries == 0 {
-                return Ok((0, Vec::new()));
+                return Ok((0, Default::default()));
             }
-            commit_ready_storage_client
+            let (session_id, entries) = commit_ready_storage_client
                 .poll_commit_ready(max_commit_ready_entries, storage_poll_timeout)
-                .await
+                .await?;
+            Ok((session_id, FormatterType::format_finalized(entries)))
         });
 
         let cleanup_ready_storage_client = self.storage_client.clone();
         let cleanup_ready_handle = tokio::task::spawn(async move {
             if max_cleanup_ready_entries == 0 {
-                return Ok((0, Vec::new()));
+                return Ok((0, Default::default()));
             }
-            cleanup_ready_storage_client
+            let (session_id, entries) = cleanup_ready_storage_client
                 .poll_cleanup_ready(max_cleanup_ready_entries, storage_poll_timeout)
-                .await
+                .await?;
+            Ok((session_id, FormatterType::format_finalized(entries)))
         });
 
         self.handle = Some(InboundPollHandles {
@@ -160,20 +224,27 @@ impl<StorageClientType: SchedulerStorageClient + 'static>
 }
 
 /// The join handles of one in-flight inbound poll, one per inbound-queue lane.
+///
+/// # Type Parameters
+///
+/// * `FormatterType` - The formatter applied to the entries drained from each inbound-queue lane.
 #[allow(clippy::struct_field_names)]
-struct InboundPollHandles {
-    ready_handle:
-        tokio::task::JoinHandle<Result<(SessionId, Vec<InboundEntry>), StorageClientError>>,
-    commit_ready_handle:
-        tokio::task::JoinHandle<Result<(SessionId, Vec<InboundEntry>), StorageClientError>>,
-    cleanup_ready_handle:
-        tokio::task::JoinHandle<Result<(SessionId, Vec<InboundEntry>), StorageClientError>>,
+struct InboundPollHandles<FormatterType: InboundPollResultFormatter> {
+    ready_handle: tokio::task::JoinHandle<
+        Result<(SessionId, FormatterType::ReadyResult), StorageClientError>,
+    >,
+    commit_ready_handle: tokio::task::JoinHandle<
+        Result<(SessionId, FormatterType::FinalizedResult), StorageClientError>,
+    >,
+    cleanup_ready_handle: tokio::task::JoinHandle<
+        Result<(SessionId, FormatterType::FinalizedResult), StorageClientError>,
+    >,
 }
 
-impl InboundPollHandles {
+impl<FormatterType: InboundPollResultFormatter> InboundPollHandles<FormatterType> {
     /// Tries to collect the results of all lane polls without blocking.
     ///
-    /// Entries from lanes that report an older session than the latest observed session are
+    /// Results from lanes that report an older session than the latest observed session are
     /// dropped.
     ///
     /// # Returns
@@ -181,7 +252,7 @@ impl InboundPollHandles {
     /// On success:
     ///
     /// * [`InboundPollState::Pending`] if any lane poll is still in flight.
-    /// * [`InboundPollState::Ready`] with the latest observed session and its entries otherwise.
+    /// * [`InboundPollState::Ready`] with the latest observed session and its results otherwise.
     ///
     /// # Errors
     ///
@@ -194,7 +265,7 @@ impl InboundPollHandles {
     async fn try_collect_result(
         &mut self,
         curr_session_id: SessionId,
-    ) -> Result<InboundPollState, SchedulerError> {
+    ) -> Result<InboundPollState<FormatterType>, SchedulerError> {
         if !self.ready_handle.is_finished()
             || !self.commit_ready_handle.is_finished()
             || !self.cleanup_ready_handle.is_finished()
@@ -202,16 +273,15 @@ impl InboundPollHandles {
             return Ok(InboundPollState::Pending);
         }
 
-        let (ready_session_id, ready_entries) = (&mut self.ready_handle)
+        let (ready_session_id, ready_result) = (&mut self.ready_handle)
             .await
             .map_err(|e| SchedulerError::Internal(e.to_string()))??;
-        let (commit_session_id, commit_ready_entries) = (&mut self.commit_ready_handle)
+        let (commit_session_id, commit_ready_result) = (&mut self.commit_ready_handle)
             .await
             .map_err(|e| SchedulerError::Internal(e.to_string()))??;
-        let (cleanup_session_id, cleanup_ready_entries) =
-            (&mut self.cleanup_ready_handle)
-                .await
-                .map_err(|e| SchedulerError::Internal(e.to_string()))??;
+        let (cleanup_session_id, cleanup_ready_result) = (&mut self.cleanup_ready_handle)
+            .await
+            .map_err(|e| SchedulerError::Internal(e.to_string()))??;
 
         let latest_session_id = curr_session_id
             .max(ready_session_id)
@@ -220,32 +290,37 @@ impl InboundPollHandles {
 
         Ok(InboundPollState::Ready {
             session_id: latest_session_id,
-            ready_entries: Self::drop_if_stale(ready_session_id, latest_session_id, ready_entries),
-            commit_ready_entries: Self::drop_if_stale(
+            ready_result: Self::drop_if_stale(ready_session_id, latest_session_id, ready_result),
+            commit_ready_result: Self::drop_if_stale(
                 commit_session_id,
                 latest_session_id,
-                commit_ready_entries,
+                commit_ready_result,
             ),
-            cleanup_ready_entries: Self::drop_if_stale(
+            cleanup_ready_result: Self::drop_if_stale(
                 cleanup_session_id,
                 latest_session_id,
-                cleanup_ready_entries,
+                cleanup_ready_result,
             ),
         })
     }
 
+    /// # Type Parameters
+    ///
+    /// * `LaneResultType` - The formatted result of a single inbound-queue lane.
+    ///
     /// # Returns
     ///
-    /// `entries` if `session_id` matches `latest_session_id`, or an empty vector otherwise.
-    fn drop_if_stale(
+    /// `lane_result` if `session_id` matches `latest_session_id`, or a default-constructed result
+    /// otherwise.
+    fn drop_if_stale<LaneResultType: Default>(
         session_id: SessionId,
         latest_session_id: SessionId,
-        entries: Vec<InboundEntry>,
-    ) -> Vec<InboundEntry> {
+        lane_result: LaneResultType,
+    ) -> LaneResultType {
         if session_id == latest_session_id {
-            entries
+            lane_result
         } else {
-            Vec::new()
+            LaneResultType::default()
         }
     }
 }

--- a/components/spider-scheduler/src/core_impl/inbound_queue_reader.rs
+++ b/components/spider-scheduler/src/core_impl/inbound_queue_reader.rs
@@ -47,8 +47,8 @@ pub(super) trait InboundPollResultFormatter: Send + 'static {
 pub(super) struct RawInboundEntries;
 
 impl InboundPollResultFormatter for RawInboundEntries {
-    type ReadyResult = Vec<InboundEntry>;
     type FinalizedResult = Vec<InboundEntry>;
+    type ReadyResult = Vec<InboundEntry>;
 
     fn format_ready(entries: Vec<InboundEntry>) -> Self::ReadyResult {
         entries
@@ -96,10 +96,8 @@ pub(super) struct AsyncInboundQueueReader<
     handle: Option<InboundPollHandles<FormatterType>>,
 }
 
-impl<
-    StorageClientType: SchedulerStorageClient + 'static,
-    FormatterType: InboundPollResultFormatter,
-> AsyncInboundQueueReader<StorageClientType, FormatterType>
+impl<StorageClientType: SchedulerStorageClient + 'static, FormatterType: InboundPollResultFormatter>
+    AsyncInboundQueueReader<StorageClientType, FormatterType>
 {
     /// Factory function.
     ///
@@ -279,9 +277,10 @@ impl<FormatterType: InboundPollResultFormatter> InboundPollHandles<FormatterType
         let (commit_session_id, commit_ready_result) = (&mut self.commit_ready_handle)
             .await
             .map_err(|e| SchedulerError::Internal(e.to_string()))??;
-        let (cleanup_session_id, cleanup_ready_result) = (&mut self.cleanup_ready_handle)
-            .await
-            .map_err(|e| SchedulerError::Internal(e.to_string()))??;
+        let (cleanup_session_id, cleanup_ready_result) =
+            (&mut self.cleanup_ready_handle)
+                .await
+                .map_err(|e| SchedulerError::Internal(e.to_string()))??;
 
         let latest_session_id = curr_session_id
             .max(ready_session_id)

--- a/components/spider-scheduler/src/core_impl/resource_group_round_robin/inbound_queue_reader.rs
+++ b/components/spider-scheduler/src/core_impl/resource_group_round_robin/inbound_queue_reader.rs
@@ -1,0 +1,671 @@
+//! The inbound-poll result formatter of the resource-group-aware round-robin scheduler.
+//!
+//! The core schedules a resource group's jobs one batch at a time, so the entries drained from the
+//! inbound queue are grouped by job before they reach it. The grouping is driven through
+//! [`crate::core_impl::inbound_queue_reader::AsyncInboundQueueReader`], which applies it inside
+//! each lane's background polling task.
+
+use std::collections::HashMap;
+
+use spider_core::task::TaskIndex;
+use spider_core::types::id::JobId;
+use spider_core::types::id::ResourceGroupId;
+use spider_core::types::id::TaskId;
+
+use crate::core_impl::inbound_queue_reader::InboundPollResultFormatter;
+use crate::types::InboundEntry;
+
+/// The regular tasks a single poll drained for one job.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct ReadyJobBatch {
+    /// The resource group that owns the job.
+    pub(super) resource_group_id: ResourceGroupId,
+
+    /// The job the tasks belong to.
+    pub(super) job_id: JobId,
+
+    /// The ready tasks, sorted and deduplicated.
+    pub(super) task_indices: Vec<TaskIndex>,
+}
+
+/// A job that has reached one of its terminal states.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct FinalizedJob {
+    /// The resource group that owns the job.
+    pub(super) resource_group_id: ResourceGroupId,
+
+    /// The finalized job.
+    pub(super) job_id: JobId,
+}
+
+/// The formatter of the resource-group-aware core, which consumes the drained entries grouped by
+/// job.
+pub(super) struct GroupedJobs;
+
+impl InboundPollResultFormatter for GroupedJobs {
+    type FinalizedResult = Vec<FinalizedJob>;
+    type ReadyResult = Vec<ReadyJobBatch>;
+
+    fn format_ready(entries: Vec<InboundEntry>) -> Self::ReadyResult {
+        format_ready_job_batches(entries)
+    }
+
+    fn format_finalized(entries: Vec<InboundEntry>) -> Self::FinalizedResult {
+        format_finalized_jobs(entries)
+    }
+}
+
+/// Groups the entries drained from the regular-task lane by job, discarding every entry that does
+/// not carry a task index.
+///
+/// # Returns
+///
+/// One batch per job, in an unspecified order.
+fn format_ready_job_batches(entries: Vec<InboundEntry>) -> Vec<ReadyJobBatch> {
+    let mut batches: HashMap<JobId, (ResourceGroupId, Vec<TaskIndex>)> = HashMap::new();
+    for entry in entries {
+        let TaskId::Index(task_index) = entry.task_id else {
+            continue;
+        };
+        batches
+            .entry(entry.job_id)
+            .or_insert_with(|| (entry.resource_group_id, Vec::new()))
+            .1
+            .push(task_index);
+    }
+
+    batches
+        .into_iter()
+        .map(|(job_id, (resource_group_id, mut task_indices))| {
+            task_indices.sort_unstable();
+            task_indices.dedup();
+            ReadyJobBatch {
+                resource_group_id,
+                job_id,
+                task_indices,
+            }
+        })
+        .collect()
+}
+
+/// # Returns
+///
+/// One finalized job per entry drained from a finalization lane, in the order they were drained.
+fn format_finalized_jobs(entries: Vec<InboundEntry>) -> Vec<FinalizedJob> {
+    entries
+        .into_iter()
+        .map(|entry| FinalizedJob {
+            resource_group_id: entry.resource_group_id,
+            job_id: entry.job_id,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::sync::Arc;
+    use std::sync::Mutex;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::AtomicU64;
+    use std::sync::atomic::Ordering;
+    use std::time::Duration;
+
+    use anyhow::anyhow;
+    use anyhow::bail;
+    use async_trait::async_trait;
+    use spider_core::job::JobState;
+    use spider_core::types::id::SchedulerId;
+    use spider_core::types::id::SessionId;
+    use tokio::sync::Semaphore;
+
+    use super::*;
+    use crate::core_impl::inbound_queue_reader::AsyncInboundQueueReader;
+    use crate::core_impl::inbound_queue_reader::InboundPollState;
+    use crate::error::SchedulerError;
+    use crate::error::StorageClientError;
+    use crate::storage_client::SchedulerStorageClient;
+
+    /// The reader under test, which formats every lane's entries with [`GroupedJobs`].
+    type TestReader = AsyncInboundQueueReader<MockStorageClient, GroupedJobs>;
+
+    /// The session the mock storage client serves polls under unless a test scripts otherwise.
+    const DEFAULT_SESSION_ID: SessionId = 0;
+
+    /// The resource group most entries in this module belong to.
+    const RG_ID: ResourceGroupId = ResourceGroupId::from(4);
+
+    /// The resource group used where a test needs a second group.
+    const OTHER_RG_ID: ResourceGroupId = ResourceGroupId::from(5);
+
+    /// The first job a test polls entries for.
+    const JOB_A: JobId = JobId::from(10);
+
+    /// The second job a test polls entries for.
+    const JOB_B: JobId = JobId::from(11);
+
+    /// The third job a test polls entries for.
+    const JOB_C: JobId = JobId::from(12);
+
+    /// The entry limit given to lanes a test wants polled.
+    const MAX_ENTRIES: usize = 32;
+
+    /// The poll timeout passed to the mock storage client, which never blocks on it.
+    const POLL_TIMEOUT: Duration = Duration::from_millis(1);
+
+    /// The maximum time to wait for an in-flight poll to complete before failing a test.
+    const COLLECT_DEADLINE: Duration = Duration::from_secs(5);
+
+    /// The interval between two collection attempts while waiting for an in-flight poll.
+    const COLLECT_RETRY_INTERVAL: Duration = Duration::from_millis(1);
+
+    struct MockStorageInner {
+        session_id: AtomicU64,
+        ready_batches: Mutex<VecDeque<(SessionId, Vec<InboundEntry>)>>,
+        commit_ready_batches: Mutex<VecDeque<(SessionId, Vec<InboundEntry>)>>,
+        cleanup_ready_batches: Mutex<VecDeque<(SessionId, Vec<InboundEntry>)>>,
+        num_ready_polls: AtomicU64,
+        num_commit_ready_polls: AtomicU64,
+        num_cleanup_ready_polls: AtomicU64,
+        is_ready_lane_gated: AtomicBool,
+        ready_lane_gate: Semaphore,
+    }
+
+    /// A mock [`SchedulerStorageClient`] backed by scripted poll batches.
+    ///
+    /// Each lane serves its scripted batches in FIFO order, one batch per poll; when a lane's
+    /// script is empty, polls return an empty batch under the mock's current session immediately
+    /// (the `wait` parameter is ignored to keep tests fast). The regular-task lane can be gated so
+    /// that a test can observe an in-flight poll.
+    #[derive(Clone)]
+    struct MockStorageClient {
+        inner: Arc<MockStorageInner>,
+    }
+
+    impl MockStorageClient {
+        /// Factory function.
+        ///
+        /// # Returns
+        ///
+        /// A new mock storage client with no scripted batches and no gated lane, reporting
+        /// [`DEFAULT_SESSION_ID`] on empty polls.
+        fn new() -> Self {
+            Self {
+                inner: Arc::new(MockStorageInner {
+                    session_id: AtomicU64::new(DEFAULT_SESSION_ID),
+                    ready_batches: Mutex::new(VecDeque::new()),
+                    commit_ready_batches: Mutex::new(VecDeque::new()),
+                    cleanup_ready_batches: Mutex::new(VecDeque::new()),
+                    num_ready_polls: AtomicU64::new(0),
+                    num_commit_ready_polls: AtomicU64::new(0),
+                    num_cleanup_ready_polls: AtomicU64::new(0),
+                    is_ready_lane_gated: AtomicBool::new(false),
+                    ready_lane_gate: Semaphore::new(0),
+                }),
+            }
+        }
+
+        /// Scripts a batch to be served by the next unserved
+        /// [`SchedulerStorageClient::poll_ready`] call.
+        fn push_ready_batch(&self, session_id: SessionId, entries: Vec<InboundEntry>) {
+            self.inner
+                .ready_batches
+                .lock()
+                .expect("ready-batch lock poisoned")
+                .push_back((session_id, entries));
+        }
+
+        /// Scripts a batch to be served by the next unserved
+        /// [`SchedulerStorageClient::poll_commit_ready`] call.
+        fn push_commit_ready_batch(&self, session_id: SessionId, entries: Vec<InboundEntry>) {
+            self.inner
+                .commit_ready_batches
+                .lock()
+                .expect("commit-ready-batch lock poisoned")
+                .push_back((session_id, entries));
+        }
+
+        /// Scripts a batch to be served by the next unserved
+        /// [`SchedulerStorageClient::poll_cleanup_ready`] call.
+        fn push_cleanup_ready_batch(&self, session_id: SessionId, entries: Vec<InboundEntry>) {
+            self.inner
+                .cleanup_ready_batches
+                .lock()
+                .expect("cleanup-ready-batch lock poisoned")
+                .push_back((session_id, entries));
+        }
+
+        /// # Returns
+        ///
+        /// A tuple containing the number of polls served by the regular-task, commit-task, and
+        /// cleanup-task lanes respectively.
+        fn num_polls(&self) -> (u64, u64, u64) {
+            (
+                self.inner.num_ready_polls.load(Ordering::Relaxed),
+                self.inner.num_commit_ready_polls.load(Ordering::Relaxed),
+                self.inner.num_cleanup_ready_polls.load(Ordering::Relaxed),
+            )
+        }
+
+        /// Holds every subsequent regular-task poll until [`Self::admit_ready_poll`] releases it.
+        fn gate_ready_lane(&self) {
+            self.inner
+                .is_ready_lane_gated
+                .store(true, Ordering::Relaxed);
+        }
+
+        /// Releases one held regular-task poll.
+        fn admit_ready_poll(&self) {
+            self.inner.ready_lane_gate.add_permits(1);
+        }
+
+        /// Serves one poll from the given lane's script.
+        ///
+        /// # Returns
+        ///
+        /// The lane's next scripted batch, or an empty batch under the current session if the
+        /// lane's script is exhausted.
+        ///
+        /// # Panics
+        ///
+        /// Panics if the scripted batch holds more entries than `max_items`.
+        fn serve_batch(
+            &self,
+            batches: &Mutex<VecDeque<(SessionId, Vec<InboundEntry>)>>,
+            max_items: usize,
+        ) -> (SessionId, Vec<InboundEntry>) {
+            let scripted_batch = batches.lock().expect("batch lock poisoned").pop_front();
+            let Some((session_id, entries)) = scripted_batch else {
+                return (self.inner.session_id.load(Ordering::Relaxed), Vec::new());
+            };
+            assert!(
+                entries.len() <= max_items,
+                "scripted batch of {} entries exceeds the poll limit of {max_items}",
+                entries.len(),
+            );
+            (session_id, entries)
+        }
+    }
+
+    #[async_trait]
+    impl SchedulerStorageClient for MockStorageClient {
+        async fn register(
+            &self,
+            _host: spider_utils::config::Host,
+            _port: u16,
+        ) -> Result<SchedulerId, StorageClientError> {
+            Ok(SchedulerId::from(0))
+        }
+
+        async fn poll_ready(
+            &self,
+            max_items: usize,
+            _wait: Duration,
+        ) -> Result<(SessionId, Vec<InboundEntry>), StorageClientError> {
+            if self.inner.is_ready_lane_gated.load(Ordering::Relaxed) {
+                self.inner
+                    .ready_lane_gate
+                    .acquire()
+                    .await
+                    .expect("the regular-task lane gate is never closed")
+                    .forget();
+            }
+            self.inner.num_ready_polls.fetch_add(1, Ordering::Relaxed);
+            Ok(self.serve_batch(&self.inner.ready_batches, max_items))
+        }
+
+        async fn poll_commit_ready(
+            &self,
+            max_items: usize,
+            _wait: Duration,
+        ) -> Result<(SessionId, Vec<InboundEntry>), StorageClientError> {
+            self.inner
+                .num_commit_ready_polls
+                .fetch_add(1, Ordering::Relaxed);
+            Ok(self.serve_batch(&self.inner.commit_ready_batches, max_items))
+        }
+
+        async fn poll_cleanup_ready(
+            &self,
+            max_items: usize,
+            _wait: Duration,
+        ) -> Result<(SessionId, Vec<InboundEntry>), StorageClientError> {
+            self.inner
+                .num_cleanup_ready_polls
+                .fetch_add(1, Ordering::Relaxed);
+            Ok(self.serve_batch(&self.inner.cleanup_ready_batches, max_items))
+        }
+
+        async fn job_state(&self, _job_id: JobId) -> Result<JobState, StorageClientError> {
+            Ok(JobState::Running)
+        }
+    }
+
+    /// The formatted results of one completed poll.
+    struct PollResult {
+        session_id: SessionId,
+        ready_jobs: Vec<ReadyJobBatch>,
+        commit_ready_jobs: Vec<FinalizedJob>,
+        cleanup_ready_jobs: Vec<FinalizedJob>,
+    }
+
+    impl PollResult {
+        /// # Returns
+        ///
+        /// The batch [`ReadyJobBatch::job_id`] of which is `job_id`.
+        ///
+        /// # Errors
+        ///
+        /// Returns an error if:
+        ///
+        /// * [`anyhow::Error`] if no batch was polled for `job_id`.
+        fn ready_batch(&self, job_id: JobId) -> anyhow::Result<&ReadyJobBatch> {
+            self.ready_jobs
+                .iter()
+                .find(|batch| batch.job_id == job_id)
+                .ok_or_else(|| anyhow!("no ready batch was polled for job {job_id}"))
+        }
+    }
+
+    /// # Returns
+    ///
+    /// An inbound entry for `job_id`'s `task_id`, owned by `resource_group_id`.
+    const fn make_entry(
+        resource_group_id: ResourceGroupId,
+        job_id: JobId,
+        task_id: TaskId,
+    ) -> InboundEntry {
+        InboundEntry {
+            resource_group_id,
+            job_id,
+            task_id,
+        }
+    }
+
+    /// Collects the result of the in-flight poll, retrying until every lane task has finished.
+    ///
+    /// # Returns
+    ///
+    /// The formatted results of the completed poll on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * [`anyhow::Error`] if the poll does not complete within [`COLLECT_DEADLINE`], or if no poll
+    ///   is in flight.
+    /// * Forwards [`AsyncInboundQueueReader::try_collect_result`]'s return values on failure.
+    async fn collect_when_ready(
+        reader: &mut TestReader,
+        curr_session_id: SessionId,
+    ) -> anyhow::Result<PollResult> {
+        let deadline = tokio::time::Instant::now() + COLLECT_DEADLINE;
+        loop {
+            match reader.try_collect_result(curr_session_id).await? {
+                InboundPollState::Ready {
+                    session_id,
+                    ready_result: ready_jobs,
+                    commit_ready_result: commit_ready_jobs,
+                    cleanup_ready_result: cleanup_ready_jobs,
+                } => {
+                    return Ok(PollResult {
+                        session_id,
+                        ready_jobs,
+                        commit_ready_jobs,
+                        cleanup_ready_jobs,
+                    });
+                }
+                InboundPollState::NotStarted => bail!("no inbound poll is in flight"),
+                InboundPollState::Pending => {
+                    if deadline <= tokio::time::Instant::now() {
+                        bail!("the inbound poll did not complete in time");
+                    }
+                    tokio::time::sleep(COLLECT_RETRY_INTERVAL).await;
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn a_reader_without_a_poll_reports_not_started() -> anyhow::Result<()> {
+        let mut reader = TestReader::new(MockStorageClient::new());
+        assert!(matches!(
+            reader.try_collect_result(DEFAULT_SESSION_ID).await?,
+            InboundPollState::NotStarted
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn an_unfinished_lane_keeps_the_poll_pending() -> anyhow::Result<()> {
+        let storage_client = MockStorageClient::new();
+        storage_client.gate_ready_lane();
+        storage_client.push_ready_batch(
+            DEFAULT_SESSION_ID,
+            vec![make_entry(RG_ID, JOB_A, TaskId::Index(0))],
+        );
+        let mut reader = TestReader::new(storage_client.clone());
+        reader.start(POLL_TIMEOUT, MAX_ENTRIES, MAX_ENTRIES, MAX_ENTRIES)?;
+
+        assert!(matches!(
+            reader.try_collect_result(DEFAULT_SESSION_ID).await?,
+            InboundPollState::Pending
+        ));
+        assert!(matches!(
+            reader.try_collect_result(DEFAULT_SESSION_ID).await?,
+            InboundPollState::Pending
+        ));
+
+        storage_client.admit_ready_poll();
+        let result = collect_when_ready(&mut reader, DEFAULT_SESSION_ID).await?;
+        assert_eq!(result.ready_batch(JOB_A)?.task_indices, vec![0]);
+
+        assert!(matches!(
+            reader.try_collect_result(DEFAULT_SESSION_ID).await?,
+            InboundPollState::NotStarted
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn ready_entries_are_grouped_by_job() -> anyhow::Result<()> {
+        let storage_client = MockStorageClient::new();
+        storage_client.push_ready_batch(
+            DEFAULT_SESSION_ID,
+            vec![
+                make_entry(RG_ID, JOB_A, TaskId::Index(3)),
+                make_entry(OTHER_RG_ID, JOB_B, TaskId::Index(7)),
+                make_entry(RG_ID, JOB_A, TaskId::Index(1)),
+                make_entry(RG_ID, JOB_A, TaskId::Index(3)),
+                make_entry(RG_ID, JOB_A, TaskId::Index(2)),
+            ],
+        );
+        let mut reader = TestReader::new(storage_client);
+        reader.start(POLL_TIMEOUT, MAX_ENTRIES, MAX_ENTRIES, MAX_ENTRIES)?;
+
+        let result = collect_when_ready(&mut reader, DEFAULT_SESSION_ID).await?;
+        assert_eq!(result.ready_jobs.len(), 2);
+        assert_eq!(
+            result.ready_batch(JOB_A)?,
+            &ReadyJobBatch {
+                resource_group_id: RG_ID,
+                job_id: JOB_A,
+                task_indices: vec![1, 2, 3],
+            }
+        );
+        assert_eq!(
+            result.ready_batch(JOB_B)?,
+            &ReadyJobBatch {
+                resource_group_id: OTHER_RG_ID,
+                job_id: JOB_B,
+                task_indices: vec![7],
+            }
+        );
+        assert_eq!(result.commit_ready_jobs.as_slice(), &[]);
+        assert_eq!(result.cleanup_ready_jobs.as_slice(), &[]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn a_ready_entry_without_a_task_index_is_skipped() -> anyhow::Result<()> {
+        let storage_client = MockStorageClient::new();
+        storage_client.push_ready_batch(
+            DEFAULT_SESSION_ID,
+            vec![
+                make_entry(RG_ID, JOB_A, TaskId::Commit),
+                make_entry(RG_ID, JOB_B, TaskId::Cleanup),
+                make_entry(RG_ID, JOB_C, TaskId::Index(0)),
+            ],
+        );
+        let mut reader = TestReader::new(storage_client);
+        reader.start(POLL_TIMEOUT, MAX_ENTRIES, MAX_ENTRIES, MAX_ENTRIES)?;
+
+        let result = collect_when_ready(&mut reader, DEFAULT_SESSION_ID).await?;
+        assert_eq!(
+            result.ready_jobs.as_slice(),
+            &[ReadyJobBatch {
+                resource_group_id: RG_ID,
+                job_id: JOB_C,
+                task_indices: vec![0],
+            }]
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn finalization_entries_are_mapped_to_finalized_jobs() -> anyhow::Result<()> {
+        let storage_client = MockStorageClient::new();
+        storage_client.push_commit_ready_batch(
+            DEFAULT_SESSION_ID,
+            vec![
+                make_entry(RG_ID, JOB_A, TaskId::Commit),
+                make_entry(OTHER_RG_ID, JOB_B, TaskId::Commit),
+            ],
+        );
+        storage_client.push_cleanup_ready_batch(
+            DEFAULT_SESSION_ID,
+            vec![make_entry(RG_ID, JOB_C, TaskId::Cleanup)],
+        );
+        let mut reader = TestReader::new(storage_client);
+        reader.start(POLL_TIMEOUT, MAX_ENTRIES, MAX_ENTRIES, MAX_ENTRIES)?;
+
+        let result = collect_when_ready(&mut reader, DEFAULT_SESSION_ID).await?;
+        assert_eq!(
+            result.commit_ready_jobs.as_slice(),
+            &[
+                FinalizedJob {
+                    resource_group_id: RG_ID,
+                    job_id: JOB_A,
+                },
+                FinalizedJob {
+                    resource_group_id: OTHER_RG_ID,
+                    job_id: JOB_B,
+                }
+            ]
+        );
+        assert_eq!(
+            result.cleanup_ready_jobs.as_slice(),
+            &[FinalizedJob {
+                resource_group_id: RG_ID,
+                job_id: JOB_C,
+            }]
+        );
+        assert_eq!(result.ready_jobs.as_slice(), &[]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn a_stale_lane_result_is_dropped() -> anyhow::Result<()> {
+        const STALE_SESSION_ID: SessionId = 1;
+        const LATEST_SESSION_ID: SessionId = 2;
+
+        let storage_client = MockStorageClient::new();
+        storage_client.push_ready_batch(
+            STALE_SESSION_ID,
+            vec![make_entry(RG_ID, JOB_A, TaskId::Index(0))],
+        );
+        storage_client.push_commit_ready_batch(
+            LATEST_SESSION_ID,
+            vec![make_entry(RG_ID, JOB_B, TaskId::Commit)],
+        );
+        storage_client.push_cleanup_ready_batch(
+            STALE_SESSION_ID,
+            vec![make_entry(RG_ID, JOB_C, TaskId::Cleanup)],
+        );
+        let mut reader = TestReader::new(storage_client);
+        reader.start(POLL_TIMEOUT, MAX_ENTRIES, MAX_ENTRIES, MAX_ENTRIES)?;
+
+        let result = collect_when_ready(&mut reader, STALE_SESSION_ID).await?;
+        assert_eq!(result.session_id, LATEST_SESSION_ID);
+        assert_eq!(result.ready_jobs.as_slice(), &[]);
+        assert_eq!(result.cleanup_ready_jobs.as_slice(), &[]);
+        assert_eq!(
+            result.commit_ready_jobs.as_slice(),
+            &[FinalizedJob {
+                resource_group_id: RG_ID,
+                job_id: JOB_B,
+            }]
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn starting_a_poll_while_one_is_in_flight_fails() -> anyhow::Result<()> {
+        let storage_client = MockStorageClient::new();
+        storage_client.gate_ready_lane();
+        let mut reader = TestReader::new(storage_client.clone());
+        reader.start(POLL_TIMEOUT, MAX_ENTRIES, MAX_ENTRIES, MAX_ENTRIES)?;
+
+        let Err(SchedulerError::Internal(message)) =
+            reader.start(POLL_TIMEOUT, MAX_ENTRIES, MAX_ENTRIES, MAX_ENTRIES)
+        else {
+            bail!("starting a second poll should be rejected");
+        };
+        assert_eq!(message, "inbound poll handle already exists");
+
+        storage_client.admit_ready_poll();
+        collect_when_ready(&mut reader, DEFAULT_SESSION_ID).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn zero_limits_start_no_poll() -> anyhow::Result<()> {
+        let storage_client = MockStorageClient::new();
+        let mut reader = TestReader::new(storage_client.clone());
+        reader.start(POLL_TIMEOUT, 0, 0, 0)?;
+
+        assert!(matches!(
+            reader.try_collect_result(DEFAULT_SESSION_ID).await?,
+            InboundPollState::NotStarted
+        ));
+        assert_eq!(storage_client.num_polls(), (0, 0, 0));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn a_lane_with_a_zero_limit_is_not_polled() -> anyhow::Result<()> {
+        let storage_client = MockStorageClient::new();
+        storage_client.push_ready_batch(
+            DEFAULT_SESSION_ID,
+            vec![make_entry(RG_ID, JOB_A, TaskId::Index(0))],
+        );
+        storage_client.push_commit_ready_batch(
+            DEFAULT_SESSION_ID,
+            vec![make_entry(RG_ID, JOB_B, TaskId::Commit)],
+        );
+        let mut reader = TestReader::new(storage_client.clone());
+        reader.start(POLL_TIMEOUT, 0, MAX_ENTRIES, MAX_ENTRIES)?;
+
+        let result = collect_when_ready(&mut reader, DEFAULT_SESSION_ID).await?;
+        assert_eq!(storage_client.num_polls(), (0, 1, 1));
+        assert_eq!(result.ready_jobs.as_slice(), &[]);
+        assert_eq!(
+            result.commit_ready_jobs.as_slice(),
+            &[FinalizedJob {
+                resource_group_id: RG_ID,
+                job_id: JOB_B,
+            }]
+        );
+        Ok(())
+    }
+}

--- a/components/spider-scheduler/src/core_impl/resource_group_round_robin/inbound_queue_reader.rs
+++ b/components/spider-scheduler/src/core_impl/resource_group_round_robin/inbound_queue_reader.rs
@@ -1,8 +1,4 @@
 //! The inbound-poll result formatter of the resource-group-aware round-robin scheduler.
-//!
-//! The core schedules a resource group's jobs one batch at a time, so the entries drained from the
-//! inbound queue are grouped by job before they reach it. [`RgInboundQueueReader`] applies the
-//! grouping inside each lane's background polling task.
 
 use std::collections::HashMap;
 
@@ -18,7 +14,7 @@ use crate::types::InboundEntry;
 
 /// The regular tasks a single poll drained for one job.
 #[derive(Debug, PartialEq, Eq)]
-pub(super) struct ReadyJobBatch {
+pub(super) struct ReadyBatch {
     /// The resource group that owns the job.
     pub(super) resource_group_id: ResourceGroupId,
 
@@ -41,11 +37,11 @@ pub(super) struct FinalizedJob {
 
 /// The formatter of the resource-group-aware core, which consumes the drained entries grouped by
 /// job.
-pub(super) struct GroupedJobs;
+pub(super) struct RgInboundPollResultFormatter;
 
-impl InboundPollResultFormatter for GroupedJobs {
+impl InboundPollResultFormatter for RgInboundPollResultFormatter {
     type FinalizedResult = Vec<FinalizedJob>;
-    type ReadyResult = Vec<ReadyJobBatch>;
+    type ReadyResult = Vec<ReadyBatch>;
 
     fn format_ready(entries: Vec<InboundEntry>) -> Self::ReadyResult {
         format_ready_job_batches(entries)
@@ -57,24 +53,24 @@ impl InboundPollResultFormatter for GroupedJobs {
 }
 
 /// The inbound-queue reader of the resource-group-aware core, which formats the entries drained
-/// from every lane with [`GroupedJobs`].
+/// from every lane with [`RgInboundPollResultFormatter`].
 ///
 /// # Type Parameters
 ///
 /// * `StorageClientType` - The storage client used to poll the inbound queue.
 pub(super) type RgInboundQueueReader<StorageClientType> =
-    AsyncInboundQueueReader<StorageClientType, GroupedJobs>;
+    AsyncInboundQueueReader<StorageClientType, RgInboundPollResultFormatter>;
 
 /// The state of an inbound-queue poll started by the resource-group-aware core.
-pub(super) type RgInboundPollState = InboundPollState<GroupedJobs>;
+pub(super) type RgInboundPollState = InboundPollState<RgInboundPollResultFormatter>;
 
 /// Groups the entries drained from the regular-task lane by job, discarding every entry that does
 /// not carry a task index.
 ///
 /// # Returns
 ///
-/// One batch per job, in an unspecified order.
-fn format_ready_job_batches(entries: Vec<InboundEntry>) -> Vec<ReadyJobBatch> {
+/// One batch per job, where jobs are in an unspecified order.
+fn format_ready_job_batches(entries: Vec<InboundEntry>) -> Vec<ReadyBatch> {
     let mut batches: HashMap<JobId, (ResourceGroupId, Vec<TaskIndex>)> = HashMap::new();
     for entry in entries {
         let TaskId::Index(task_index) = entry.task_id else {
@@ -92,7 +88,7 @@ fn format_ready_job_batches(entries: Vec<InboundEntry>) -> Vec<ReadyJobBatch> {
         .map(|(job_id, (resource_group_id, mut task_indices))| {
             task_indices.sort_unstable();
             task_indices.dedup();
-            ReadyJobBatch {
+            ReadyBatch {
                 resource_group_id,
                 job_id,
                 task_indices,
@@ -116,32 +112,17 @@ fn format_finalized_jobs(entries: Vec<InboundEntry>) -> Vec<FinalizedJob> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::VecDeque;
-    use std::sync::Arc;
-    use std::sync::Mutex;
-    use std::sync::atomic::AtomicBool;
-    use std::sync::atomic::AtomicU64;
-    use std::sync::atomic::Ordering;
-    use std::time::Duration;
-
-    use anyhow::anyhow;
-    use anyhow::bail;
-    use async_trait::async_trait;
-    use spider_core::job::JobState;
-    use spider_core::types::id::SchedulerId;
-    use spider_core::types::id::SessionId;
-    use tokio::sync::Semaphore;
-
     use super::*;
-    use crate::error::SchedulerError;
-    use crate::error::StorageClientError;
-    use crate::storage_client::SchedulerStorageClient;
+    use crate::core_impl::inbound_queue_reader::test_harness::DEFAULT_SESSION_ID;
+    use crate::core_impl::inbound_queue_reader::test_harness::MAX_ENTRIES;
+    use crate::core_impl::inbound_queue_reader::test_harness::MockStorageClient;
+    use crate::core_impl::inbound_queue_reader::test_harness::POLL_TIMEOUT;
+    use crate::core_impl::inbound_queue_reader::test_harness::collect_when_ready;
+    use crate::core_impl::inbound_queue_reader::test_harness::make_entry;
 
-    /// The reader under test, which formats every lane's entries with [`GroupedJobs`].
+    /// The reader under test, which formats every lane's entries with
+    /// [`RgInboundPollResultFormatter`].
     type TestReader = RgInboundQueueReader<MockStorageClient>;
-
-    /// The session the mock storage client serves polls under unless a test scripts otherwise.
-    const DEFAULT_SESSION_ID: SessionId = 0;
 
     /// The resource group most entries in this module belong to.
     const RG_ID: ResourceGroupId = ResourceGroupId::from(4);
@@ -158,324 +139,20 @@ mod tests {
     /// The third job a test polls entries for.
     const JOB_C: JobId = JobId::from(12);
 
-    /// The entry limit given to lanes a test wants polled.
-    const MAX_ENTRIES: usize = 32;
-
-    /// The poll timeout passed to the mock storage client, which never blocks on it.
-    const POLL_TIMEOUT: Duration = Duration::from_millis(1);
-
-    /// The maximum time to wait for an in-flight poll to complete before failing a test.
-    const COLLECT_DEADLINE: Duration = Duration::from_secs(5);
-
-    /// The interval between two collection attempts while waiting for an in-flight poll.
-    const COLLECT_RETRY_INTERVAL: Duration = Duration::from_millis(1);
-
-    struct MockStorageInner {
-        session_id: AtomicU64,
-        ready_batches: Mutex<VecDeque<(SessionId, Vec<InboundEntry>)>>,
-        commit_ready_batches: Mutex<VecDeque<(SessionId, Vec<InboundEntry>)>>,
-        cleanup_ready_batches: Mutex<VecDeque<(SessionId, Vec<InboundEntry>)>>,
-        num_ready_polls: AtomicU64,
-        num_commit_ready_polls: AtomicU64,
-        num_cleanup_ready_polls: AtomicU64,
-        is_ready_lane_gated: AtomicBool,
-        ready_lane_gate: Semaphore,
-    }
-
-    /// A mock [`SchedulerStorageClient`] backed by scripted poll batches.
-    ///
-    /// Each lane serves its scripted batches in FIFO order, one batch per poll; when a lane's
-    /// script is empty, polls return an empty batch under the mock's current session immediately
-    /// (the `wait` parameter is ignored to keep tests fast). The regular-task lane can be gated so
-    /// that a test can observe an in-flight poll.
-    #[derive(Clone)]
-    struct MockStorageClient {
-        inner: Arc<MockStorageInner>,
-    }
-
-    impl MockStorageClient {
-        /// Factory function.
-        ///
-        /// # Returns
-        ///
-        /// A new mock storage client with no scripted batches and no gated lane, reporting
-        /// [`DEFAULT_SESSION_ID`] on empty polls.
-        fn new() -> Self {
-            Self {
-                inner: Arc::new(MockStorageInner {
-                    session_id: AtomicU64::new(DEFAULT_SESSION_ID),
-                    ready_batches: Mutex::new(VecDeque::new()),
-                    commit_ready_batches: Mutex::new(VecDeque::new()),
-                    cleanup_ready_batches: Mutex::new(VecDeque::new()),
-                    num_ready_polls: AtomicU64::new(0),
-                    num_commit_ready_polls: AtomicU64::new(0),
-                    num_cleanup_ready_polls: AtomicU64::new(0),
-                    is_ready_lane_gated: AtomicBool::new(false),
-                    ready_lane_gate: Semaphore::new(0),
-                }),
-            }
-        }
-
-        /// Scripts a batch to be served by the next unserved
-        /// [`SchedulerStorageClient::poll_ready`] call.
-        fn push_ready_batch(&self, session_id: SessionId, entries: Vec<InboundEntry>) {
-            self.inner
-                .ready_batches
-                .lock()
-                .expect("ready-batch lock poisoned")
-                .push_back((session_id, entries));
-        }
-
-        /// Scripts a batch to be served by the next unserved
-        /// [`SchedulerStorageClient::poll_commit_ready`] call.
-        fn push_commit_ready_batch(&self, session_id: SessionId, entries: Vec<InboundEntry>) {
-            self.inner
-                .commit_ready_batches
-                .lock()
-                .expect("commit-ready-batch lock poisoned")
-                .push_back((session_id, entries));
-        }
-
-        /// Scripts a batch to be served by the next unserved
-        /// [`SchedulerStorageClient::poll_cleanup_ready`] call.
-        fn push_cleanup_ready_batch(&self, session_id: SessionId, entries: Vec<InboundEntry>) {
-            self.inner
-                .cleanup_ready_batches
-                .lock()
-                .expect("cleanup-ready-batch lock poisoned")
-                .push_back((session_id, entries));
-        }
-
-        /// # Returns
-        ///
-        /// A tuple containing the number of polls served by the regular-task, commit-task, and
-        /// cleanup-task lanes respectively.
-        fn num_polls(&self) -> (u64, u64, u64) {
-            (
-                self.inner.num_ready_polls.load(Ordering::Relaxed),
-                self.inner.num_commit_ready_polls.load(Ordering::Relaxed),
-                self.inner.num_cleanup_ready_polls.load(Ordering::Relaxed),
-            )
-        }
-
-        /// Holds every subsequent regular-task poll until [`Self::admit_ready_poll`] releases it.
-        fn gate_ready_lane(&self) {
-            self.inner
-                .is_ready_lane_gated
-                .store(true, Ordering::Relaxed);
-        }
-
-        /// Releases one held regular-task poll.
-        fn admit_ready_poll(&self) {
-            self.inner.ready_lane_gate.add_permits(1);
-        }
-
-        /// Serves one poll from the given lane's script.
-        ///
-        /// # Returns
-        ///
-        /// The lane's next scripted batch, or an empty batch under the current session if the
-        /// lane's script is exhausted.
-        ///
-        /// # Panics
-        ///
-        /// Panics if the scripted batch holds more entries than `max_items`.
-        fn serve_batch(
-            &self,
-            batches: &Mutex<VecDeque<(SessionId, Vec<InboundEntry>)>>,
-            max_items: usize,
-        ) -> (SessionId, Vec<InboundEntry>) {
-            let scripted_batch = batches.lock().expect("batch lock poisoned").pop_front();
-            let Some((session_id, entries)) = scripted_batch else {
-                return (self.inner.session_id.load(Ordering::Relaxed), Vec::new());
-            };
-            assert!(
-                entries.len() <= max_items,
-                "scripted batch of {} entries exceeds the poll limit of {max_items}",
-                entries.len(),
-            );
-            (session_id, entries)
-        }
-    }
-
-    #[async_trait]
-    impl SchedulerStorageClient for MockStorageClient {
-        async fn register(
-            &self,
-            _host: spider_utils::config::Host,
-            _port: u16,
-        ) -> Result<SchedulerId, StorageClientError> {
-            Ok(SchedulerId::from(0))
-        }
-
-        async fn poll_ready(
-            &self,
-            max_items: usize,
-            _wait: Duration,
-        ) -> Result<(SessionId, Vec<InboundEntry>), StorageClientError> {
-            if self.inner.is_ready_lane_gated.load(Ordering::Relaxed) {
-                self.inner
-                    .ready_lane_gate
-                    .acquire()
-                    .await
-                    .expect("the regular-task lane gate is never closed")
-                    .forget();
-            }
-            self.inner.num_ready_polls.fetch_add(1, Ordering::Relaxed);
-            Ok(self.serve_batch(&self.inner.ready_batches, max_items))
-        }
-
-        async fn poll_commit_ready(
-            &self,
-            max_items: usize,
-            _wait: Duration,
-        ) -> Result<(SessionId, Vec<InboundEntry>), StorageClientError> {
-            self.inner
-                .num_commit_ready_polls
-                .fetch_add(1, Ordering::Relaxed);
-            Ok(self.serve_batch(&self.inner.commit_ready_batches, max_items))
-        }
-
-        async fn poll_cleanup_ready(
-            &self,
-            max_items: usize,
-            _wait: Duration,
-        ) -> Result<(SessionId, Vec<InboundEntry>), StorageClientError> {
-            self.inner
-                .num_cleanup_ready_polls
-                .fetch_add(1, Ordering::Relaxed);
-            Ok(self.serve_batch(&self.inner.cleanup_ready_batches, max_items))
-        }
-
-        async fn job_state(&self, _job_id: JobId) -> Result<JobState, StorageClientError> {
-            Ok(JobState::Running)
-        }
-    }
-
-    /// The formatted results of one completed poll.
-    struct PollResult {
-        session_id: SessionId,
-        ready_jobs: Vec<ReadyJobBatch>,
-        commit_ready_jobs: Vec<FinalizedJob>,
-        cleanup_ready_jobs: Vec<FinalizedJob>,
-    }
-
-    impl PollResult {
-        /// # Returns
-        ///
-        /// The batch [`ReadyJobBatch::job_id`] of which is `job_id`.
-        ///
-        /// # Errors
-        ///
-        /// Returns an error if:
-        ///
-        /// * [`anyhow::Error`] if no batch was polled for `job_id`.
-        fn ready_batch(&self, job_id: JobId) -> anyhow::Result<&ReadyJobBatch> {
-            self.ready_jobs
-                .iter()
-                .find(|batch| batch.job_id == job_id)
-                .ok_or_else(|| anyhow!("no ready batch was polled for job {job_id}"))
-        }
-    }
-
     /// # Returns
     ///
-    /// An inbound entry for `job_id`'s `task_id`, owned by `resource_group_id`.
-    const fn make_entry(
-        resource_group_id: ResourceGroupId,
-        job_id: JobId,
-        task_id: TaskId,
-    ) -> InboundEntry {
-        InboundEntry {
-            resource_group_id,
-            job_id,
-            task_id,
-        }
-    }
-
-    /// Collects the result of the in-flight poll, retrying until every lane task has finished.
-    ///
-    /// # Returns
-    ///
-    /// The formatted results of the completed poll on success.
+    /// The batch in `batches` whose [`ReadyBatch::job_id`] is `job_id`.
     ///
     /// # Errors
     ///
     /// Returns an error if:
     ///
-    /// * [`anyhow::Error`] if the poll does not complete within [`COLLECT_DEADLINE`], or if no poll
-    ///   is in flight.
-    /// * Forwards [`AsyncInboundQueueReader::try_collect_result`]'s return values on failure.
-    async fn collect_when_ready(
-        reader: &mut TestReader,
-        curr_session_id: SessionId,
-    ) -> anyhow::Result<PollResult> {
-        let deadline = tokio::time::Instant::now() + COLLECT_DEADLINE;
-        loop {
-            match reader.try_collect_result(curr_session_id).await? {
-                RgInboundPollState::Ready {
-                    session_id,
-                    ready_result: ready_jobs,
-                    commit_ready_result: commit_ready_jobs,
-                    cleanup_ready_result: cleanup_ready_jobs,
-                } => {
-                    return Ok(PollResult {
-                        session_id,
-                        ready_jobs,
-                        commit_ready_jobs,
-                        cleanup_ready_jobs,
-                    });
-                }
-                RgInboundPollState::NotStarted => bail!("no inbound poll is in flight"),
-                RgInboundPollState::Pending => {
-                    if deadline <= tokio::time::Instant::now() {
-                        bail!("the inbound poll did not complete in time");
-                    }
-                    tokio::time::sleep(COLLECT_RETRY_INTERVAL).await;
-                }
-            }
-        }
-    }
-
-    #[tokio::test]
-    async fn a_reader_without_a_poll_reports_not_started() -> anyhow::Result<()> {
-        let mut reader = TestReader::new(MockStorageClient::new());
-        assert!(matches!(
-            reader.try_collect_result(DEFAULT_SESSION_ID).await?,
-            RgInboundPollState::NotStarted
-        ));
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn an_unfinished_lane_keeps_the_poll_pending() -> anyhow::Result<()> {
-        let storage_client = MockStorageClient::new();
-        storage_client.gate_ready_lane();
-        storage_client.push_ready_batch(
-            DEFAULT_SESSION_ID,
-            vec![make_entry(RG_ID, JOB_A, TaskId::Index(0))],
-        );
-        let mut reader = TestReader::new(storage_client.clone());
-        reader.start(POLL_TIMEOUT, MAX_ENTRIES, MAX_ENTRIES, MAX_ENTRIES)?;
-
-        assert!(matches!(
-            reader.try_collect_result(DEFAULT_SESSION_ID).await?,
-            RgInboundPollState::Pending
-        ));
-        assert!(matches!(
-            reader.try_collect_result(DEFAULT_SESSION_ID).await?,
-            RgInboundPollState::Pending
-        ));
-
-        storage_client.admit_ready_poll();
-        let result = collect_when_ready(&mut reader, DEFAULT_SESSION_ID).await?;
-        assert_eq!(result.ready_batch(JOB_A)?.task_indices, vec![0]);
-
-        assert!(matches!(
-            reader.try_collect_result(DEFAULT_SESSION_ID).await?,
-            RgInboundPollState::NotStarted
-        ));
-        Ok(())
+    /// * [`anyhow::Error`] if no batch was polled for `job_id`.
+    fn find_batch(batches: &[ReadyBatch], job_id: JobId) -> anyhow::Result<&ReadyBatch> {
+        batches
+            .iter()
+            .find(|batch| batch.job_id == job_id)
+            .ok_or_else(|| anyhow::anyhow!("no ready batch was polled for job {job_id}"))
     }
 
     #[tokio::test]
@@ -495,51 +172,25 @@ mod tests {
         reader.start(POLL_TIMEOUT, MAX_ENTRIES, MAX_ENTRIES, MAX_ENTRIES)?;
 
         let result = collect_when_ready(&mut reader, DEFAULT_SESSION_ID).await?;
-        assert_eq!(result.ready_jobs.len(), 2);
+        assert_eq!(result.ready_result.len(), 2);
         assert_eq!(
-            result.ready_batch(JOB_A)?,
-            &ReadyJobBatch {
+            find_batch(&result.ready_result, JOB_A)?,
+            &ReadyBatch {
                 resource_group_id: RG_ID,
                 job_id: JOB_A,
                 task_indices: vec![1, 2, 3],
             }
         );
         assert_eq!(
-            result.ready_batch(JOB_B)?,
-            &ReadyJobBatch {
+            find_batch(&result.ready_result, JOB_B)?,
+            &ReadyBatch {
                 resource_group_id: OTHER_RG_ID,
                 job_id: JOB_B,
                 task_indices: vec![7],
             }
         );
-        assert_eq!(result.commit_ready_jobs.as_slice(), &[]);
-        assert_eq!(result.cleanup_ready_jobs.as_slice(), &[]);
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn a_ready_entry_without_a_task_index_is_skipped() -> anyhow::Result<()> {
-        let storage_client = MockStorageClient::new();
-        storage_client.push_ready_batch(
-            DEFAULT_SESSION_ID,
-            vec![
-                make_entry(RG_ID, JOB_A, TaskId::Commit),
-                make_entry(RG_ID, JOB_B, TaskId::Cleanup),
-                make_entry(RG_ID, JOB_C, TaskId::Index(0)),
-            ],
-        );
-        let mut reader = TestReader::new(storage_client);
-        reader.start(POLL_TIMEOUT, MAX_ENTRIES, MAX_ENTRIES, MAX_ENTRIES)?;
-
-        let result = collect_when_ready(&mut reader, DEFAULT_SESSION_ID).await?;
-        assert_eq!(
-            result.ready_jobs.as_slice(),
-            &[ReadyJobBatch {
-                resource_group_id: RG_ID,
-                job_id: JOB_C,
-                task_indices: vec![0],
-            }]
-        );
+        assert_eq!(result.commit_ready_result.as_slice(), &[]);
+        assert_eq!(result.cleanup_ready_result.as_slice(), &[]);
         Ok(())
     }
 
@@ -562,7 +213,7 @@ mod tests {
 
         let result = collect_when_ready(&mut reader, DEFAULT_SESSION_ID).await?;
         assert_eq!(
-            result.commit_ready_jobs.as_slice(),
+            result.commit_ready_result.as_slice(),
             &[
                 FinalizedJob {
                     resource_group_id: RG_ID,
@@ -575,108 +226,13 @@ mod tests {
             ]
         );
         assert_eq!(
-            result.cleanup_ready_jobs.as_slice(),
+            result.cleanup_ready_result.as_slice(),
             &[FinalizedJob {
                 resource_group_id: RG_ID,
                 job_id: JOB_C,
             }]
         );
-        assert_eq!(result.ready_jobs.as_slice(), &[]);
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn a_stale_lane_result_is_dropped() -> anyhow::Result<()> {
-        const STALE_SESSION_ID: SessionId = 1;
-        const LATEST_SESSION_ID: SessionId = 2;
-
-        let storage_client = MockStorageClient::new();
-        storage_client.push_ready_batch(
-            STALE_SESSION_ID,
-            vec![make_entry(RG_ID, JOB_A, TaskId::Index(0))],
-        );
-        storage_client.push_commit_ready_batch(
-            LATEST_SESSION_ID,
-            vec![make_entry(RG_ID, JOB_B, TaskId::Commit)],
-        );
-        storage_client.push_cleanup_ready_batch(
-            STALE_SESSION_ID,
-            vec![make_entry(RG_ID, JOB_C, TaskId::Cleanup)],
-        );
-        let mut reader = TestReader::new(storage_client);
-        reader.start(POLL_TIMEOUT, MAX_ENTRIES, MAX_ENTRIES, MAX_ENTRIES)?;
-
-        let result = collect_when_ready(&mut reader, STALE_SESSION_ID).await?;
-        assert_eq!(result.session_id, LATEST_SESSION_ID);
-        assert_eq!(result.ready_jobs.as_slice(), &[]);
-        assert_eq!(result.cleanup_ready_jobs.as_slice(), &[]);
-        assert_eq!(
-            result.commit_ready_jobs.as_slice(),
-            &[FinalizedJob {
-                resource_group_id: RG_ID,
-                job_id: JOB_B,
-            }]
-        );
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn starting_a_poll_while_one_is_in_flight_fails() -> anyhow::Result<()> {
-        let storage_client = MockStorageClient::new();
-        storage_client.gate_ready_lane();
-        let mut reader = TestReader::new(storage_client.clone());
-        reader.start(POLL_TIMEOUT, MAX_ENTRIES, MAX_ENTRIES, MAX_ENTRIES)?;
-
-        let Err(SchedulerError::Internal(message)) =
-            reader.start(POLL_TIMEOUT, MAX_ENTRIES, MAX_ENTRIES, MAX_ENTRIES)
-        else {
-            bail!("starting a second poll should be rejected");
-        };
-        assert_eq!(message, "inbound poll handle already exists");
-
-        storage_client.admit_ready_poll();
-        collect_when_ready(&mut reader, DEFAULT_SESSION_ID).await?;
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn zero_limits_start_no_poll() -> anyhow::Result<()> {
-        let storage_client = MockStorageClient::new();
-        let mut reader = TestReader::new(storage_client.clone());
-        reader.start(POLL_TIMEOUT, 0, 0, 0)?;
-
-        assert!(matches!(
-            reader.try_collect_result(DEFAULT_SESSION_ID).await?,
-            RgInboundPollState::NotStarted
-        ));
-        assert_eq!(storage_client.num_polls(), (0, 0, 0));
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn a_lane_with_a_zero_limit_is_not_polled() -> anyhow::Result<()> {
-        let storage_client = MockStorageClient::new();
-        storage_client.push_ready_batch(
-            DEFAULT_SESSION_ID,
-            vec![make_entry(RG_ID, JOB_A, TaskId::Index(0))],
-        );
-        storage_client.push_commit_ready_batch(
-            DEFAULT_SESSION_ID,
-            vec![make_entry(RG_ID, JOB_B, TaskId::Commit)],
-        );
-        let mut reader = TestReader::new(storage_client.clone());
-        reader.start(POLL_TIMEOUT, 0, MAX_ENTRIES, MAX_ENTRIES)?;
-
-        let result = collect_when_ready(&mut reader, DEFAULT_SESSION_ID).await?;
-        assert_eq!(storage_client.num_polls(), (0, 1, 1));
-        assert_eq!(result.ready_jobs.as_slice(), &[]);
-        assert_eq!(
-            result.commit_ready_jobs.as_slice(),
-            &[FinalizedJob {
-                resource_group_id: RG_ID,
-                job_id: JOB_B,
-            }]
-        );
+        assert_eq!(result.ready_result.as_slice(), &[]);
         Ok(())
     }
 }

--- a/components/spider-scheduler/src/core_impl/resource_group_round_robin/inbound_queue_reader.rs
+++ b/components/spider-scheduler/src/core_impl/resource_group_round_robin/inbound_queue_reader.rs
@@ -1,9 +1,8 @@
 //! The inbound-poll result formatter of the resource-group-aware round-robin scheduler.
 //!
 //! The core schedules a resource group's jobs one batch at a time, so the entries drained from the
-//! inbound queue are grouped by job before they reach it. The grouping is driven through
-//! [`crate::core_impl::inbound_queue_reader::AsyncInboundQueueReader`], which applies it inside
-//! each lane's background polling task.
+//! inbound queue are grouped by job before they reach it. [`RgInboundQueueReader`] applies the
+//! grouping inside each lane's background polling task.
 
 use std::collections::HashMap;
 
@@ -12,7 +11,9 @@ use spider_core::types::id::JobId;
 use spider_core::types::id::ResourceGroupId;
 use spider_core::types::id::TaskId;
 
+use crate::core_impl::inbound_queue_reader::AsyncInboundQueueReader;
 use crate::core_impl::inbound_queue_reader::InboundPollResultFormatter;
+use crate::core_impl::inbound_queue_reader::InboundPollState;
 use crate::types::InboundEntry;
 
 /// The regular tasks a single poll drained for one job.
@@ -54,6 +55,18 @@ impl InboundPollResultFormatter for GroupedJobs {
         format_finalized_jobs(entries)
     }
 }
+
+/// The inbound-queue reader of the resource-group-aware core, which formats the entries drained
+/// from every lane with [`GroupedJobs`].
+///
+/// # Type Parameters
+///
+/// * `StorageClientType` - The storage client used to poll the inbound queue.
+pub(super) type RgInboundQueueReader<StorageClientType> =
+    AsyncInboundQueueReader<StorageClientType, GroupedJobs>;
+
+/// The state of an inbound-queue poll started by the resource-group-aware core.
+pub(super) type RgInboundPollState = InboundPollState<GroupedJobs>;
 
 /// Groups the entries drained from the regular-task lane by job, discarding every entry that does
 /// not carry a task index.
@@ -120,14 +133,12 @@ mod tests {
     use tokio::sync::Semaphore;
 
     use super::*;
-    use crate::core_impl::inbound_queue_reader::AsyncInboundQueueReader;
-    use crate::core_impl::inbound_queue_reader::InboundPollState;
     use crate::error::SchedulerError;
     use crate::error::StorageClientError;
     use crate::storage_client::SchedulerStorageClient;
 
     /// The reader under test, which formats every lane's entries with [`GroupedJobs`].
-    type TestReader = AsyncInboundQueueReader<MockStorageClient, GroupedJobs>;
+    type TestReader = RgInboundQueueReader<MockStorageClient>;
 
     /// The session the mock storage client serves polls under unless a test scripts otherwise.
     const DEFAULT_SESSION_ID: SessionId = 0;
@@ -402,7 +413,7 @@ mod tests {
         let deadline = tokio::time::Instant::now() + COLLECT_DEADLINE;
         loop {
             match reader.try_collect_result(curr_session_id).await? {
-                InboundPollState::Ready {
+                RgInboundPollState::Ready {
                     session_id,
                     ready_result: ready_jobs,
                     commit_ready_result: commit_ready_jobs,
@@ -415,8 +426,8 @@ mod tests {
                         cleanup_ready_jobs,
                     });
                 }
-                InboundPollState::NotStarted => bail!("no inbound poll is in flight"),
-                InboundPollState::Pending => {
+                RgInboundPollState::NotStarted => bail!("no inbound poll is in flight"),
+                RgInboundPollState::Pending => {
                     if deadline <= tokio::time::Instant::now() {
                         bail!("the inbound poll did not complete in time");
                     }
@@ -431,7 +442,7 @@ mod tests {
         let mut reader = TestReader::new(MockStorageClient::new());
         assert!(matches!(
             reader.try_collect_result(DEFAULT_SESSION_ID).await?,
-            InboundPollState::NotStarted
+            RgInboundPollState::NotStarted
         ));
         Ok(())
     }
@@ -449,11 +460,11 @@ mod tests {
 
         assert!(matches!(
             reader.try_collect_result(DEFAULT_SESSION_ID).await?,
-            InboundPollState::Pending
+            RgInboundPollState::Pending
         ));
         assert!(matches!(
             reader.try_collect_result(DEFAULT_SESSION_ID).await?,
-            InboundPollState::Pending
+            RgInboundPollState::Pending
         ));
 
         storage_client.admit_ready_poll();
@@ -462,7 +473,7 @@ mod tests {
 
         assert!(matches!(
             reader.try_collect_result(DEFAULT_SESSION_ID).await?,
-            InboundPollState::NotStarted
+            RgInboundPollState::NotStarted
         ));
         Ok(())
     }
@@ -636,7 +647,7 @@ mod tests {
 
         assert!(matches!(
             reader.try_collect_result(DEFAULT_SESSION_ID).await?,
-            InboundPollState::NotStarted
+            RgInboundPollState::NotStarted
         ));
         assert_eq!(storage_client.num_polls(), (0, 0, 0));
         Ok(())

--- a/components/spider-scheduler/src/core_impl/resource_group_round_robin/mod.rs
+++ b/components/spider-scheduler/src/core_impl/resource_group_round_robin/mod.rs
@@ -16,6 +16,18 @@
 )]
 mod dispatch_queue;
 
+// The formatter has no consumer outside its own tests until the rest of the core lands, so every
+// item it exposes reads as dead. `expect` rather than `allow`: once `implementation.rs` polls with
+// the formatter, this attribute becomes unfulfilled and the compiler flags it for removal.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "the core that polls with the inbound-poll result formatter has not landed yet"
+    )
+)]
+mod inbound_queue_reader;
+
 // The registry has no consumer outside tests until the rest of the core lands, so every item it
 // exposes reads as dead. `expect` rather than `allow`: once `implementation.rs` uses the registry,
 // this attribute becomes unfulfilled and the compiler flags it for removal.

--- a/components/spider-scheduler/src/core_impl/resource_group_round_robin/mod.rs
+++ b/components/spider-scheduler/src/core_impl/resource_group_round_robin/mod.rs
@@ -16,15 +16,12 @@
 )]
 mod dispatch_queue;
 
-// The formatter has no consumer outside its own tests until the rest of the core lands, so every
-// item it exposes reads as dead. `expect` rather than `allow`: once `implementation.rs` polls with
-// the formatter, this attribute becomes unfulfilled and the compiler flags it for removal.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "the core that polls with the inbound-poll result formatter has not landed yet"
-    )
+// The formatter has no consumer until the rest of the core lands, so every item it exposes reads as
+// dead. `expect` rather than `allow`: once `implementation.rs` polls with the formatter, this
+// attribute becomes unfulfilled and the compiler flags it for removal.
+#[expect(
+    dead_code,
+    reason = "the core that polls with the inbound-poll result formatter has not landed yet"
 )]
 mod inbound_queue_reader;
 

--- a/components/spider-scheduler/src/core_impl/round_robin/implementation.rs
+++ b/components/spider-scheduler/src/core_impl/round_robin/implementation.rs
@@ -746,9 +746,9 @@ impl<SchedulerStorageClientType: SchedulerStorageClient + 'static>
         match inbound_poll_state {
             InboundPollState::Ready {
                 session_id: storage_session_id,
-                ready_entries,
-                commit_ready_entries,
-                cleanup_ready_entries,
+                ready_result: ready_entries,
+                commit_ready_result: commit_ready_entries,
+                cleanup_ready_result: cleanup_ready_entries,
             } => {
                 tracing::info!("Inbound poll completed.");
                 self.ingest_inbound_entries(


### PR DESCRIPTION
* Add `RgInboundPollResultFormatter` for grouping each lane's drained entries into the form the core consumes.
* Add unit tests for the shared inbound-queue reader.
* Add a test harness shared by formatter tests.

<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

The resource-group-aware core polls the same three inbound-queue lanes as the round-robin core, but consumes them in a different shape: it schedules a resource group's jobs one batch at a time, so it needs the regular-task lane grouped by job and both finalization lanes reduced to the jobs they name. This PR supplies that formatter, together with the tests and the harness they share.

The formatter is the last piece the core needs from the inbound queue. The core that polls with it is still to come, so nothing is wired up and no behaviour changes.

## What the formatter produces

`RgInboundPollResultFormatter` turns the regular-task lane into one `ReadyBatch` per job, with each job's task indices sorted and deduplicated, and both finalization lanes into `FinalizedJob`s. The shared reader applies it inside each lane's background polling task, so the grouping runs in parallel with the core's ticks rather than on its critical path.

`RgInboundQueueReader` and `RgInboundPollState` name the reader and poll state the core will hold, so it does not spell the shared reader's formatter parameter at every use site.

## Where the tests live

The reader's general behaviour — the at-most-one-poll-in-flight rule, the per-lane entry limits, and the dropping of a lane that reports a stale session — belongs to the shared reader, not to either core, so those seven tests now live with it and run against the identity formatter. Only the two tests that assert on grouping stay in the resource-group module.

Both draw on one `test_harness`, a test-only module beside the shared reader that scripts poll batches in place of a storage service. Keeping it there rather than in either core is what lets the next core's reader tests script the same lanes without a second mock.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [x] Ensure all workflows pass.
* [x] Add unit tests to assert the shared reader's behavior.
* [x] Add unit tests to assert the batching behavior of the resource-group-round-robin reader's formatter.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resource-group-aware inbound queue processing.
  * Ready jobs are grouped by job, with task indices sorted and duplicates removed.
  * Finalized jobs are mapped in processing order.

* **Tests**
  * Added coverage for queue state handling, stale results, concurrent polls, zero-limit lanes, job grouping, task ordering, and finalization mapping.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->